### PR TITLE
Support for plain groups in other structures.

### DIFF
--- a/cddl_test/supported.cddl
+++ b/cddl_test/supported.cddl
@@ -33,7 +33,7 @@ keyhash = hash
 scripthash = hash
 
 address =
- [  0, keyhash, keyhash       ; base address
+ (  0, keyhash, keyhash       ; base address
  // 1, keyhash, scripthash    ; base address
  // 2, scripthash, keyhash    ; base address
  // 3, scripthash, scripthash ; base address
@@ -42,12 +42,12 @@ address =
  // 6, keyhash                ; enterprise address (null staking reference)
  // 7, scripthash             ; enterprise address (null staking reference)
  // 8, keyhash                ; bootstrap address
- ]
+ )
 
 transaction_input = [transaction_id : hash, index : uint]
 
 ; replace address with address type
-transaction_output = [address : tstr, amount : uint]
+transaction_output = [address, amount : uint]
 
 transaction_body =
   { 0 : #6.258([* transaction_input])


### PR DESCRIPTION
Use case: `address` in `shelley.cddl`

For groups are not defined in terms of array or map representation yet
we can still use them inside of other structures. If they are array then
their elements are inserted into the wrapping array ie:
x = (1, 2) y = [3, x, x, 4] should be [3, 1, 2, 1, 2, 4]
not [3, [1, 2], [1, 2], 4]