### PR TITLE
Wasm-friendly interface change + cddl regen

### DIFF
--- a/rust/pkg/cddl_lib.js.flow
+++ b/rust/pkg/cddl_lib.js.flow
@@ -72,6 +72,11 @@ declare export class Address {
    * @returns {Address}
    */
   static from_bech32(bech_str: string): Address;
+
+  /**
+   * @returns {number}
+   */
+  network_id(): number;
 }
 declare export class BaseAddress {
   free(): void;
@@ -962,7 +967,7 @@ declare export class PoolParams {
    * @param {BigInt} pledge
    * @param {BigInt} cost
    * @param {UnitInterval} margin
-   * @param {RewardAccount} reward_account
+   * @param {RewardAddress} reward_account
    * @param {AddrKeyHashes} pool_owners
    * @param {Relays} relays
    * @param {PoolMetadata | void} pool_metadata
@@ -974,7 +979,7 @@ declare export class PoolParams {
     pledge: BigInt,
     cost: BigInt,
     margin: UnitInterval,
-    reward_account: RewardAccount,
+    reward_account: RewardAddress,
     pool_owners: AddrKeyHashes,
     relays: Relays,
     pool_metadata?: PoolMetadata
@@ -1187,9 +1192,6 @@ declare export class Relays {
    * @param {Relay} elem
    */
   add(elem: Relay): void;
-}
-declare export class RewardAccount {
-  free(): void;
 }
 declare export class RewardAddress {
   free(): void;
@@ -1808,9 +1810,9 @@ declare export class Withdrawals {
   len(): number;
 
   /**
-   * @param {RewardAccount} key
+   * @param {RewardAddress} key
    * @param {BigInt} value
    * @returns {BigInt | void}
    */
-  insert(key: RewardAccount, value: BigInt): BigInt | void;
+  insert(key: RewardAddress, value: BigInt): BigInt | void;
 }

--- a/rust/pkg/cddl_lib.js.flow
+++ b/rust/pkg/cddl_lib.js.flow
@@ -28,6 +28,17 @@ declare export class AddrKeyHashes {
   free(): void;
 
   /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {AddrKeyHashes}
+   */
+  static from_bytes(bytes: Uint8Array): AddrKeyHashes;
+
+  /**
    * @returns {AddrKeyHashes}
    */
   static new(): AddrKeyHashes;
@@ -52,15 +63,15 @@ declare export class Address {
   free(): void;
 
   /**
-   * @returns {Uint8Array}
-   */
-  to_bytes(): Uint8Array;
-
-  /**
    * @param {Uint8Array} data
    * @returns {Address}
    */
   static from_bytes(data: Uint8Array): Address;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
 
   /**
    * @returns {string}
@@ -255,10 +266,10 @@ declare export class BootstrapWitness {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {BootstrapWitness}
    */
-  static from_bytes(data: Uint8Array): BootstrapWitness;
+  static from_bytes(bytes: Uint8Array): BootstrapWitness;
 
   /**
    * @param {Vkey} vkey
@@ -309,10 +320,10 @@ declare export class Certificate {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {Certificate}
    */
-  static from_bytes(data: Uint8Array): Certificate;
+  static from_bytes(bytes: Uint8Array): Certificate;
 
   /**
    * @param {StakeRegistration} stake_registration
@@ -370,6 +381,17 @@ declare export class Certificates {
   free(): void;
 
   /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {Certificates}
+   */
+  static from_bytes(bytes: Uint8Array): Certificates;
+
+  /**
    * @returns {Certificates}
    */
   static new(): Certificates;
@@ -409,12 +431,6 @@ declare export class Ed25519Signature {
   to_hex(): string;
 
   /**
-   * @param {Uint8Array} bytes
-   * @returns {Ed25519Signature}
-   */
-  static from_bytes(bytes: Uint8Array): Ed25519Signature;
-
-  /**
    * @param {string} bech32_str
    * @returns {Ed25519Signature}
    */
@@ -425,6 +441,12 @@ declare export class Ed25519Signature {
    * @returns {Ed25519Signature}
    */
   static from_hex(input: string): Ed25519Signature;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {Ed25519Signature}
+   */
+  static from_bytes(bytes: Uint8Array): Ed25519Signature;
 }
 declare export class EnterpriseAddress {
   free(): void;
@@ -483,10 +505,10 @@ declare export class GenesisKeyDelegation {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {GenesisKeyDelegation}
    */
-  static from_bytes(data: Uint8Array): GenesisKeyDelegation;
+  static from_bytes(bytes: Uint8Array): GenesisKeyDelegation;
 
   /**
    * @param {GenesisHash} genesishash
@@ -500,17 +522,6 @@ declare export class GenesisKeyDelegation {
 }
 declare export class I0OrI1 {
   free(): void;
-
-  /**
-   * @returns {Uint8Array}
-   */
-  to_bytes(): Uint8Array;
-
-  /**
-   * @param {Uint8Array} data
-   * @returns {I0OrI1}
-   */
-  static from_bytes(data: Uint8Array): I0OrI1;
 
   /**
    * @returns {I0OrI1}
@@ -546,10 +557,10 @@ declare export class Ipv4 {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {Ipv4}
    */
-  static from_bytes(data: Uint8Array): Ipv4;
+  static from_bytes(bytes: Uint8Array): Ipv4;
 
   /**
    * @param {Uint8Array} data
@@ -566,10 +577,10 @@ declare export class Ipv6 {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {Ipv6}
    */
-  static from_bytes(data: Uint8Array): Ipv6;
+  static from_bytes(bytes: Uint8Array): Ipv6;
 
   /**
    * @param {Uint8Array} data
@@ -586,10 +597,10 @@ declare export class MapStakeCredentialToCoin {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {MapStakeCredentialToCoin}
    */
-  static from_bytes(data: Uint8Array): MapStakeCredentialToCoin;
+  static from_bytes(bytes: Uint8Array): MapStakeCredentialToCoin;
 
   /**
    * @returns {MapStakeCredentialToCoin}
@@ -617,11 +628,11 @@ declare export class MapTransactionMetadatumToTransactionMetadatum {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {MapTransactionMetadatumToTransactionMetadatum}
    */
   static from_bytes(
-    data: Uint8Array
+    bytes: Uint8Array
   ): MapTransactionMetadatumToTransactionMetadatum;
 
   /**
@@ -667,10 +678,10 @@ declare export class MoveInstantaneousReward {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {MoveInstantaneousReward}
    */
-  static from_bytes(data: Uint8Array): MoveInstantaneousReward;
+  static from_bytes(bytes: Uint8Array): MoveInstantaneousReward;
 
   /**
    * @param {I0OrI1} index_0
@@ -691,10 +702,10 @@ declare export class MoveInstantaneousRewardsCert {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {MoveInstantaneousRewardsCert}
    */
-  static from_bytes(data: Uint8Array): MoveInstantaneousRewardsCert;
+  static from_bytes(bytes: Uint8Array): MoveInstantaneousRewardsCert;
 
   /**
    * @param {MoveInstantaneousReward} move_instantaneous_reward
@@ -713,10 +724,10 @@ declare export class MsigAll {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {MsigAll}
    */
-  static from_bytes(data: Uint8Array): MsigAll;
+  static from_bytes(bytes: Uint8Array): MsigAll;
 
   /**
    * @param {MultisigScripts} multisig_scripts
@@ -733,10 +744,10 @@ declare export class MsigAny {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {MsigAny}
    */
-  static from_bytes(data: Uint8Array): MsigAny;
+  static from_bytes(bytes: Uint8Array): MsigAny;
 
   /**
    * @param {MultisigScripts} multisig_scripts
@@ -753,10 +764,10 @@ declare export class MsigNOfK {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {MsigNOfK}
    */
-  static from_bytes(data: Uint8Array): MsigNOfK;
+  static from_bytes(bytes: Uint8Array): MsigNOfK;
 
   /**
    * @param {number} n
@@ -774,10 +785,10 @@ declare export class MsigPubkey {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {MsigPubkey}
    */
-  static from_bytes(data: Uint8Array): MsigPubkey;
+  static from_bytes(bytes: Uint8Array): MsigPubkey;
 
   /**
    * @param {AddrKeyHash} addr_keyhash
@@ -794,10 +805,10 @@ declare export class MultiHostName {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {MultiHostName}
    */
-  static from_bytes(data: Uint8Array): MultiHostName;
+  static from_bytes(bytes: Uint8Array): MultiHostName;
 
   /**
    * @param {string} dns_name
@@ -814,10 +825,10 @@ declare export class MultisigScript {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {MultisigScript}
    */
-  static from_bytes(data: Uint8Array): MultisigScript;
+  static from_bytes(bytes: Uint8Array): MultisigScript;
 
   /**
    * @param {AddrKeyHash} addr_keyhash
@@ -849,6 +860,17 @@ declare export class MultisigScript {
 }
 declare export class MultisigScripts {
   free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {MultisigScripts}
+   */
+  static from_bytes(bytes: Uint8Array): MultisigScripts;
 
   /**
    * @returns {MultisigScripts}
@@ -935,10 +957,10 @@ declare export class PoolMetadata {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {PoolMetadata}
    */
-  static from_bytes(data: Uint8Array): PoolMetadata;
+  static from_bytes(bytes: Uint8Array): PoolMetadata;
 
   /**
    * @param {string} url
@@ -956,10 +978,10 @@ declare export class PoolParams {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {PoolParams}
    */
-  static from_bytes(data: Uint8Array): PoolParams;
+  static from_bytes(bytes: Uint8Array): PoolParams;
 
   /**
    * @param {PoolKeyHash} operator
@@ -994,10 +1016,10 @@ declare export class PoolRegistration {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {PoolRegistration}
    */
-  static from_bytes(data: Uint8Array): PoolRegistration;
+  static from_bytes(bytes: Uint8Array): PoolRegistration;
 
   /**
    * @param {PoolParams} pool_params
@@ -1014,10 +1036,10 @@ declare export class PoolRetirement {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {PoolRetirement}
    */
-  static from_bytes(data: Uint8Array): PoolRetirement;
+  static from_bytes(bytes: Uint8Array): PoolRetirement;
 
   /**
    * @param {PoolKeyHash} pool_keyhash
@@ -1146,10 +1168,10 @@ declare export class Relay {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {Relay}
    */
-  static from_bytes(data: Uint8Array): Relay;
+  static from_bytes(bytes: Uint8Array): Relay;
 
   /**
    * @param {SingleHostAddr} single_host_addr
@@ -1171,6 +1193,17 @@ declare export class Relay {
 }
 declare export class Relays {
   free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {Relays}
+   */
+  static from_bytes(bytes: Uint8Array): Relays;
 
   /**
    * @returns {Relays}
@@ -1236,10 +1269,10 @@ declare export class SingleHostAddr {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {SingleHostAddr}
    */
-  static from_bytes(data: Uint8Array): SingleHostAddr;
+  static from_bytes(bytes: Uint8Array): SingleHostAddr;
 
   /**
    * @param {number | void} port
@@ -1258,10 +1291,10 @@ declare export class SingleHostName {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {SingleHostName}
    */
-  static from_bytes(data: Uint8Array): SingleHostName;
+  static from_bytes(bytes: Uint8Array): SingleHostName;
 
   /**
    * @param {number | void} port
@@ -1309,10 +1342,10 @@ declare export class StakeDelegation {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {StakeDelegation}
    */
-  static from_bytes(data: Uint8Array): StakeDelegation;
+  static from_bytes(bytes: Uint8Array): StakeDelegation;
 
   /**
    * @param {StakeCredential} stake_credential
@@ -1333,10 +1366,10 @@ declare export class StakeDeregistration {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {StakeDeregistration}
    */
-  static from_bytes(data: Uint8Array): StakeDeregistration;
+  static from_bytes(bytes: Uint8Array): StakeDeregistration;
 
   /**
    * @param {StakeCredential} stake_credential
@@ -1353,10 +1386,10 @@ declare export class StakeRegistration {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {StakeRegistration}
    */
-  static from_bytes(data: Uint8Array): StakeRegistration;
+  static from_bytes(bytes: Uint8Array): StakeRegistration;
 
   /**
    * @param {StakeCredential} stake_credential
@@ -1373,10 +1406,10 @@ declare export class Transaction {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {Transaction}
    */
-  static from_bytes(data: Uint8Array): Transaction;
+  static from_bytes(bytes: Uint8Array): Transaction;
 
   /**
    * @param {TransactionBody} body
@@ -1399,10 +1432,10 @@ declare export class TransactionBody {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {TransactionBody}
    */
-  static from_bytes(data: Uint8Array): TransactionBody;
+  static from_bytes(bytes: Uint8Array): TransactionBody;
 
   /**
    * @param {Certificates} certs
@@ -1467,10 +1500,10 @@ declare export class TransactionInput {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {TransactionInput}
    */
-  static from_bytes(data: Uint8Array): TransactionInput;
+  static from_bytes(bytes: Uint8Array): TransactionInput;
 
   /**
    * @param {TransactionHash} transaction_id
@@ -1481,6 +1514,17 @@ declare export class TransactionInput {
 }
 declare export class TransactionInputs {
   free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {TransactionInputs}
+   */
+  static from_bytes(bytes: Uint8Array): TransactionInputs;
 
   /**
    * @returns {TransactionInputs}
@@ -1512,10 +1556,10 @@ declare export class TransactionMetadata {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {TransactionMetadata}
    */
-  static from_bytes(data: Uint8Array): TransactionMetadata;
+  static from_bytes(bytes: Uint8Array): TransactionMetadata;
 
   /**
    * @returns {TransactionMetadata}
@@ -1543,10 +1587,10 @@ declare export class TransactionMetadatum {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {TransactionMetadatum}
    */
-  static from_bytes(data: Uint8Array): TransactionMetadatum;
+  static from_bytes(bytes: Uint8Array): TransactionMetadatum;
 
   /**
    * @param {MapTransactionMetadatumToTransactionMetadatum} map_transaction_metadatum_to_transaction_metadatum
@@ -1586,6 +1630,17 @@ declare export class TransactionMetadatums {
   free(): void;
 
   /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {TransactionMetadatums}
+   */
+  static from_bytes(bytes: Uint8Array): TransactionMetadatums;
+
+  /**
    * @returns {TransactionMetadatums}
    */
   static new(): TransactionMetadatums;
@@ -1615,10 +1670,10 @@ declare export class TransactionOutput {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {TransactionOutput}
    */
-  static from_bytes(data: Uint8Array): TransactionOutput;
+  static from_bytes(bytes: Uint8Array): TransactionOutput;
 
   /**
    * @param {Address} address
@@ -1629,6 +1684,17 @@ declare export class TransactionOutput {
 }
 declare export class TransactionOutputs {
   free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {TransactionOutputs}
+   */
+  static from_bytes(bytes: Uint8Array): TransactionOutputs;
 
   /**
    * @returns {TransactionOutputs}
@@ -1660,10 +1726,10 @@ declare export class TransactionWitnessSet {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {TransactionWitnessSet}
    */
-  static from_bytes(data: Uint8Array): TransactionWitnessSet;
+  static from_bytes(bytes: Uint8Array): TransactionWitnessSet;
 
   /**
    * @param {Vkeywitnesses} vkeys
@@ -1694,10 +1760,10 @@ declare export class UnitInterval {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {UnitInterval}
    */
-  static from_bytes(data: Uint8Array): UnitInterval;
+  static from_bytes(bytes: Uint8Array): UnitInterval;
 
   /**
    * @param {BigInt} index_0
@@ -1729,10 +1795,10 @@ declare export class Vkey {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {Vkey}
    */
-  static from_bytes(data: Uint8Array): Vkey;
+  static from_bytes(bytes: Uint8Array): Vkey;
 
   /**
    * @param {PublicKey} pk
@@ -1749,10 +1815,10 @@ declare export class Vkeywitness {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {Vkeywitness}
    */
-  static from_bytes(data: Uint8Array): Vkeywitness;
+  static from_bytes(bytes: Uint8Array): Vkeywitness;
 
   /**
    * @param {Vkey} vkey
@@ -1794,10 +1860,10 @@ declare export class Withdrawals {
   to_bytes(): Uint8Array;
 
   /**
-   * @param {Uint8Array} data
+   * @param {Uint8Array} bytes
    * @returns {Withdrawals}
    */
-  static from_bytes(data: Uint8Array): Withdrawals;
+  static from_bytes(bytes: Uint8Array): Withdrawals;
 
   /**
    * @returns {Withdrawals}

--- a/rust/pkg/cddl_lib.js.flow
+++ b/rust/pkg/cddl_lib.js.flow
@@ -241,6 +241,60 @@ declare export class Bip32PublicKey {
    */
   hash(): AddrKeyHash;
 }
+declare export class BootstrapWitness {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} data
+   * @returns {BootstrapWitness}
+   */
+  static from_bytes(data: Uint8Array): BootstrapWitness;
+
+  /**
+   * @param {Vkey} vkey
+   * @param {Ed25519Signature} signature
+   * @param {Uint8Array} index_2
+   * @param {Uint8Array} index_3
+   * @param {Uint8Array} index_4
+   * @returns {BootstrapWitness}
+   */
+  static new(
+    vkey: Vkey,
+    signature: Ed25519Signature,
+    index_2: Uint8Array,
+    index_3: Uint8Array,
+    index_4: Uint8Array
+  ): BootstrapWitness;
+}
+declare export class BootstrapWitnesses {
+  free(): void;
+
+  /**
+   * @returns {BootstrapWitnesses}
+   */
+  static new(): BootstrapWitnesses;
+
+  /**
+   * @returns {number}
+   */
+  len(): number;
+
+  /**
+   * @param {number} index
+   * @returns {BootstrapWitness}
+   */
+  get(index: number): BootstrapWitness;
+
+  /**
+   * @param {BootstrapWitness} elem
+   */
+  add(elem: BootstrapWitness): void;
+}
 declare export class Certificate {
   free(): void;
 
@@ -439,6 +493,30 @@ declare export class GenesisKeyDelegation {
     genesis_delegate_hash: GenesisDelegateHash
   ): GenesisKeyDelegation;
 }
+declare export class I0OrI1 {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} data
+   * @returns {I0OrI1}
+   */
+  static from_bytes(data: Uint8Array): I0OrI1;
+
+  /**
+   * @returns {I0OrI1}
+   */
+  static new_i0(): I0OrI1;
+
+  /**
+   * @returns {I0OrI1}
+   */
+  static new_i1(): I0OrI1;
+}
 declare export class Int {
   free(): void;
 
@@ -493,6 +571,37 @@ declare export class Ipv6 {
    * @returns {Ipv6}
    */
   static new(data: Uint8Array): Ipv6;
+}
+declare export class MapStakeCredentialToCoin {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} data
+   * @returns {MapStakeCredentialToCoin}
+   */
+  static from_bytes(data: Uint8Array): MapStakeCredentialToCoin;
+
+  /**
+   * @returns {MapStakeCredentialToCoin}
+   */
+  static new(): MapStakeCredentialToCoin;
+
+  /**
+   * @returns {number}
+   */
+  len(): number;
+
+  /**
+   * @param {StakeCredential} key
+   * @param {BigInt} value
+   * @returns {BigInt | void}
+   */
+  insert(key: StakeCredential, value: BigInt): BigInt | void;
 }
 declare export class MapTransactionMetadatumToTransactionMetadatum {
   free(): void;
@@ -559,21 +668,14 @@ declare export class MoveInstantaneousReward {
   static from_bytes(data: Uint8Array): MoveInstantaneousReward;
 
   /**
+   * @param {I0OrI1} index_0
+   * @param {MapStakeCredentialToCoin} index_1
    * @returns {MoveInstantaneousReward}
    */
-  static new(): MoveInstantaneousReward;
-
-  /**
-   * @returns {number}
-   */
-  len(): number;
-
-  /**
-   * @param {StakeCredential} key
-   * @param {number} value
-   * @returns {number | void}
-   */
-  insert(key: StakeCredential, value: number): number | void;
+  static new(
+    index_0: I0OrI1,
+    index_1: MapStakeCredentialToCoin
+  ): MoveInstantaneousReward;
 }
 declare export class MoveInstantaneousRewardsCert {
   free(): void;
@@ -693,11 +795,10 @@ declare export class MultiHostName {
   static from_bytes(data: Uint8Array): MultiHostName;
 
   /**
-   * @param {number | void} port
    * @param {string} dns_name
    * @returns {MultiHostName}
    */
-  static new(port: number | void, dns_name: string): MultiHostName;
+  static new(dns_name: string): MultiHostName;
 }
 declare export class MultisigScript {
   free(): void;
@@ -714,28 +815,32 @@ declare export class MultisigScript {
   static from_bytes(data: Uint8Array): MultisigScript;
 
   /**
-   * @param {MsigPubkey} msig_pubkey
+   * @param {AddrKeyHash} addr_keyhash
    * @returns {MultisigScript}
    */
-  static new_msig_pubkey(msig_pubkey: MsigPubkey): MultisigScript;
+  static new_msig_pubkey(addr_keyhash: AddrKeyHash): MultisigScript;
 
   /**
-   * @param {MsigAll} msig_all
+   * @param {MultisigScripts} multisig_scripts
    * @returns {MultisigScript}
    */
-  static new_msig_all(msig_all: MsigAll): MultisigScript;
+  static new_msig_all(multisig_scripts: MultisigScripts): MultisigScript;
 
   /**
-   * @param {MsigAny} msig_any
+   * @param {MultisigScripts} multisig_scripts
    * @returns {MultisigScript}
    */
-  static new_msig_any(msig_any: MsigAny): MultisigScript;
+  static new_msig_any(multisig_scripts: MultisigScripts): MultisigScript;
 
   /**
-   * @param {MsigNOfK} msig_n_of_k
+   * @param {number} n
+   * @param {MultisigScripts} multisig_scripts
    * @returns {MultisigScript}
    */
-  static new_msig_n_of_k(msig_n_of_k: MsigNOfK): MultisigScript;
+  static new_msig_n_of_k(
+    n: number,
+    multisig_scripts: MultisigScripts
+  ): MultisigScript;
 }
 declare export class MultisigScripts {
   free(): void;
@@ -853,11 +958,11 @@ declare export class PoolParams {
 
   /**
    * @param {PoolKeyHash} operator
-   * @param {VrfKeyHash} vrf_keyhash
+   * @param {VRFKeyHash} vrf_keyhash
    * @param {BigInt} pledge
    * @param {BigInt} cost
    * @param {UnitInterval} margin
-   * @param {StakeCredential} reward_account
+   * @param {RewardAccount} reward_account
    * @param {AddrKeyHashes} pool_owners
    * @param {Relays} relays
    * @param {PoolMetadata | void} pool_metadata
@@ -865,11 +970,11 @@ declare export class PoolParams {
    */
   static new(
     operator: PoolKeyHash,
-    vrf_keyhash: VrfKeyHash,
+    vrf_keyhash: VRFKeyHash,
     pledge: BigInt,
     cost: BigInt,
     margin: UnitInterval,
-    reward_account: StakeCredential,
+    reward_account: RewardAccount,
     pool_owners: AddrKeyHashes,
     relays: Relays,
     pool_metadata?: PoolMetadata
@@ -1082,6 +1187,9 @@ declare export class Relays {
    * @param {Relay} elem
    */
   add(elem: Relay): void;
+}
+declare export class RewardAccount {
+  free(): void;
 }
 declare export class RewardAddress {
   free(): void;
@@ -1418,11 +1526,11 @@ declare export class TransactionMetadata {
   len(): number;
 
   /**
-   * @param {number} key
+   * @param {BigInt} key
    * @param {TransactionMetadatum} value
    * @returns {TransactionMetadatum | void}
    */
-  insert(key: number, value: TransactionMetadatum): TransactionMetadatum | void;
+  insert(key: BigInt, value: TransactionMetadatum): TransactionMetadatum | void;
 }
 declare export class TransactionMetadatum {
   free(): void;
@@ -1566,6 +1674,11 @@ declare export class TransactionWitnessSet {
   set_scripts(scripts: MultisigScripts): void;
 
   /**
+   * @param {BootstrapWitnesses} bootstraps
+   */
+  set_bootstraps(bootstraps: BootstrapWitnesses): void;
+
+  /**
    * @returns {TransactionWitnessSet}
    */
   static new(): TransactionWitnessSet;
@@ -1585,11 +1698,25 @@ declare export class UnitInterval {
   static from_bytes(data: Uint8Array): UnitInterval;
 
   /**
-   * @param {number} index_0
-   * @param {number} index_1
+   * @param {BigInt} index_0
+   * @param {BigInt} index_1
    * @returns {UnitInterval}
    */
-  static new(index_0: number, index_1: number): UnitInterval;
+  static new(index_0: BigInt, index_1: BigInt): UnitInterval;
+}
+declare export class VRFKeyHash {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {VRFKeyHash}
+   */
+  static from_bytes(bytes: Uint8Array): VRFKeyHash;
 }
 declare export class Vkey {
   free(): void;
@@ -1656,20 +1783,6 @@ declare export class Vkeywitnesses {
    */
   add(elem: Vkeywitness): void;
 }
-declare export class VrfKeyHash {
-  free(): void;
-
-  /**
-   * @returns {Uint8Array}
-   */
-  to_bytes(): Uint8Array;
-
-  /**
-   * @param {Uint8Array} bytes
-   * @returns {VrfKeyHash}
-   */
-  static from_bytes(bytes: Uint8Array): VrfKeyHash;
-}
 declare export class Withdrawals {
   free(): void;
 
@@ -1695,9 +1808,9 @@ declare export class Withdrawals {
   len(): number;
 
   /**
-   * @param {StakeCredential} key
-   * @param {number} value
-   * @returns {number | void}
+   * @param {RewardAccount} key
+   * @param {BigInt} value
+   * @returns {BigInt | void}
    */
-  insert(key: StakeCredential, value: number): number | void;
+  insert(key: RewardAccount, value: BigInt): BigInt | void;
 }

--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -40,12 +40,12 @@ pub struct StakeCredential(StakeCredType);
 
 #[wasm_bindgen]
 impl StakeCredential {
-    pub fn from_keyhash(hash: AddrKeyHash) -> Self {
-        StakeCredential(StakeCredType::Key(hash))
+    pub fn from_keyhash(hash: &AddrKeyHash) -> Self {
+        StakeCredential(StakeCredType::Key(hash.clone()))
     }
 
-    pub fn from_scripthash(hash: ScriptHash) -> Self {
-        StakeCredential(StakeCredType::Script(hash))
+    pub fn from_scripthash(hash: &ScriptHash) -> Self {
+        StakeCredential(StakeCredType::Script(hash.clone()))
     }
 
     pub fn to_keyhash(&self) -> Option<AddrKeyHash> {
@@ -187,7 +187,7 @@ impl Address {
     fn from_bytes_impl(data: Vec<u8>) -> Result<Address, DeserializeError> {
         use std::convert::TryInto;
         println!("reading from: {:?}", data);
-        // header has 4 bytes addr type discrim then 4 bytes network discrim.
+        // header has 4 bits addr type discrim then 4 bits network discrim.
         // Copied from shelley.cddl:
         //
         // shelley payment addresses:
@@ -212,9 +212,9 @@ impl Address {
         let read_addr_cred = |bit: u8, pos: usize| {
             let hash_bytes: [u8; HASH_LEN] = data[pos..pos+HASH_LEN].try_into().unwrap();
             let x = if header & (1 << bit)  == 0 {
-                StakeCredential::from_keyhash(AddrKeyHash::from(hash_bytes))
+                StakeCredential::from_keyhash(&AddrKeyHash::from(hash_bytes))
             } else {
-                StakeCredential::from_scripthash(ScriptHash::from(hash_bytes))
+                StakeCredential::from_scripthash(&ScriptHash::from(hash_bytes))
             };
             println!("read cred: {:?}", x);
             x
@@ -228,7 +228,7 @@ impl Address {
                 if data.len() > 57 {
                     return Err(cbor_event::Error::TrailingData.into());
                 }
-                AddrType::Base(BaseAddress::new(network, read_addr_cred(4, 1), read_addr_cred(5, 1 + HASH_LEN)))
+                AddrType::Base(BaseAddress::new(network, &read_addr_cred(4, 1), &read_addr_cred(5, 1 + HASH_LEN)))
             },
             // pointer
             0b0100 | 0b0101 => {
@@ -251,7 +251,7 @@ impl Address {
                 if byte_index > data.len() {
                     return Err(cbor_event::Error::TrailingData.into());
                 }
-                AddrType::Ptr(PointerAddress::new(network, payment_cred, Pointer::new(slot, tx_index, cert_index)))
+                AddrType::Ptr(PointerAddress::new(network, &payment_cred, &Pointer::new(slot, tx_index, cert_index)))
             },
             // enterprise
             0b0110 | 0b0111 => {
@@ -261,7 +261,7 @@ impl Address {
                 if data.len() > HASH_LEN + 1 {
                     return Err(cbor_event::Error::TrailingData.into());
                 }
-                AddrType::Enterprise(EnterpriseAddress::new(network, read_addr_cred(4, 1)))
+                AddrType::Enterprise(EnterpriseAddress::new(network, &read_addr_cred(4, 1)))
             },
             // reward
             0b1110 | 0b1111 => {
@@ -271,7 +271,7 @@ impl Address {
                 if data.len() > HASH_LEN + 1 {
                     return Err(cbor_event::Error::TrailingData.into());
                 }
-                AddrType::Reward(RewardAddress::new(network, read_addr_cred(4, 1)))
+                AddrType::Reward(RewardAddress::new(network, &read_addr_cred(4, 1)))
             }
             // byron
             0b1000 => {
@@ -315,11 +315,11 @@ pub struct BaseAddress {
 
 #[wasm_bindgen]
 impl BaseAddress {
-    pub fn new(network: u8, payment: StakeCredential, stake: StakeCredential) -> Self {
+    pub fn new(network: u8, payment: &StakeCredential, stake: &StakeCredential) -> Self {
         Self {
             network,
-            payment,
-            stake,
+            payment: payment.clone(),
+            stake: stake.clone(),
         }
     }
 
@@ -346,10 +346,10 @@ pub struct EnterpriseAddress {
 
 #[wasm_bindgen]
 impl EnterpriseAddress {
-    pub fn new(network: u8, payment: StakeCredential) -> Self {
+    pub fn new(network: u8, payment: &StakeCredential) -> Self {
         Self {
             network,
-            payment,
+            payment: payment.clone(),
         }
     }
 
@@ -371,10 +371,10 @@ pub struct RewardAddress {
 
 #[wasm_bindgen]
 impl RewardAddress {
-    pub fn new(network: u8, payment: StakeCredential) -> Self {
+    pub fn new(network: u8, payment: &StakeCredential) -> Self {
         Self {
             network,
-            payment,
+            payment: payment.clone(),
         }
     }
 
@@ -416,11 +416,11 @@ pub struct PointerAddress {
 
 #[wasm_bindgen]
 impl PointerAddress {
-    pub fn new(network: u8, payment: StakeCredential, stake: Pointer) -> Self {
+    pub fn new(network: u8, payment: &StakeCredential, stake: &Pointer) -> Self {
         Self {
             network,
-            payment,
-            stake,
+            payment: payment.clone(),
+            stake: stake.clone(),
         }
     }
 
@@ -462,8 +462,8 @@ mod tests {
     fn base_serialize_consistency() {
         let base = BaseAddress::new(
             5,
-            StakeCredential::from_keyhash(AddrKeyHash::from([23; AddrKeyHash::BYTE_COUNT])),
-            StakeCredential::from_scripthash(ScriptHash::from([42; ScriptHash::BYTE_COUNT])));
+            &StakeCredential::from_keyhash(&AddrKeyHash::from([23; AddrKeyHash::BYTE_COUNT])),
+            &StakeCredential::from_scripthash(&ScriptHash::from([42; ScriptHash::BYTE_COUNT])));
         let addr = base.to_address();
         let addr2 = Address::from_bytes_impl(addr.to_bytes()).unwrap();
         assert_eq!(addr.to_bytes(), addr2.to_bytes());
@@ -473,8 +473,8 @@ mod tests {
     fn ptr_serialize_consistency() {
         let ptr = PointerAddress::new(
             25,
-            StakeCredential::from_keyhash(AddrKeyHash::from([23; AddrKeyHash::BYTE_COUNT])),
-            Pointer::new(2354556573, 127, 0));
+            &StakeCredential::from_keyhash(&AddrKeyHash::from([23; AddrKeyHash::BYTE_COUNT])),
+            &Pointer::new(2354556573, 127, 0));
         let addr = ptr.to_address();
         let addr2 = Address::from_bytes_impl(addr.to_bytes()).unwrap();
         assert_eq!(addr.to_bytes(), addr2.to_bytes());
@@ -484,7 +484,7 @@ mod tests {
     fn enterprise_serialize_consistency() {
         let enterprise = EnterpriseAddress::new(
             64,
-            StakeCredential::from_keyhash(AddrKeyHash::from([23; AddrKeyHash::BYTE_COUNT])));
+            &StakeCredential::from_keyhash(&AddrKeyHash::from([23; AddrKeyHash::BYTE_COUNT])));
         let addr = enterprise.to_address();
         let addr2 = Address::from_bytes_impl(addr.to_bytes()).unwrap();
         assert_eq!(addr.to_bytes(), addr2.to_bytes());
@@ -494,7 +494,7 @@ mod tests {
     fn reward_serialize_consistency() {
         let reward = RewardAddress::new(
             9,
-            StakeCredential::from_scripthash(ScriptHash::from([127; AddrKeyHash::BYTE_COUNT])));
+            &StakeCredential::from_scripthash(&ScriptHash::from([127; AddrKeyHash::BYTE_COUNT])));
         let addr = reward.to_address();
         let addr2 = Address::from_bytes_impl(addr.to_bytes()).unwrap();
         assert_eq!(addr.to_bytes(), addr2.to_bytes());
@@ -535,11 +535,11 @@ mod tests {
             .derive(2)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.hash());
-        let stake_cred = StakeCredential::from_keyhash(stake.hash());
-        let addr_net_0 = BaseAddress::new(0, spend_cred.clone(), stake_cred.clone()).to_address();
+        let spend_cred = StakeCredential::from_keyhash(&spend.hash());
+        let stake_cred = StakeCredential::from_keyhash(&stake.hash());
+        let addr_net_0 = BaseAddress::new(0, &spend_cred, &stake_cred).to_address();
         assert_eq!(addr_net_0.to_bech32(), "addr1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqcyl47r");
-        let addr_net_3 = BaseAddress::new(3, spend_cred, stake_cred).to_address();
+        let addr_net_3 = BaseAddress::new(3, &spend_cred, &stake_cred).to_address();
         assert_eq!(addr_net_3.to_bech32(), "addr1qw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqzhyupd");
     }
 
@@ -552,10 +552,10 @@ mod tests {
             .derive(0)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.hash());
-        let addr_net_0 = EnterpriseAddress::new(0, spend_cred.clone()).to_address();
+        let spend_cred = StakeCredential::from_keyhash(&spend.hash());
+        let addr_net_0 = EnterpriseAddress::new(0, &spend_cred).to_address();
         assert_eq!(addr_net_0.to_bech32(), "addr1vz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers6g8jlq");
-        let addr_net_3 = EnterpriseAddress::new(3, spend_cred).to_address();
+        let addr_net_3 = EnterpriseAddress::new(3, &spend_cred).to_address();
         assert_eq!(addr_net_3.to_bech32(), "addr1vw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers6h7glf");
     }
 
@@ -568,10 +568,10 @@ mod tests {
             .derive(0)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.hash());
-        let addr_net_0 = PointerAddress::new(0, spend_cred.clone(), Pointer::new(1, 2, 3)).to_address();
+        let spend_cred = StakeCredential::from_keyhash(&spend.hash());
+        let addr_net_0 = PointerAddress::new(0, &spend_cred, &Pointer::new(1, 2, 3)).to_address();
         assert_eq!(addr_net_0.to_bech32(), "addr1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspqgpslhplej");
-        let addr_net_3 = PointerAddress::new(3, spend_cred, Pointer::new(24157, 177, 42)).to_address();
+        let addr_net_3 = PointerAddress::new(3, &spend_cred, &Pointer::new(24157, 177, 42)).to_address();
         assert_eq!(addr_net_3.to_bech32(), "addr1gw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5ph3wczvf2x4v58t");
     }
 
@@ -591,11 +591,11 @@ mod tests {
             .derive(2)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.hash());
-        let stake_cred = StakeCredential::from_keyhash(stake.hash());
-        let addr_net_0 = BaseAddress::new(0, spend_cred.clone(), stake_cred.clone()).to_address();
+        let spend_cred = StakeCredential::from_keyhash(&spend.hash());
+        let stake_cred = StakeCredential::from_keyhash(&stake.hash());
+        let addr_net_0 = BaseAddress::new(0, &spend_cred, &stake_cred).to_address();
         assert_eq!(addr_net_0.to_bech32(), "addr1qpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qwmnp2v");
-        let addr_net_3 = BaseAddress::new(3, spend_cred, stake_cred).to_address();
+        let addr_net_3 = BaseAddress::new(3, &spend_cred, &stake_cred).to_address();
         assert_eq!(addr_net_3.to_bech32(), "addr1qdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2q5ggg4z");
     }
 
@@ -608,10 +608,10 @@ mod tests {
             .derive(0)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.hash());
-        let addr_net_0 = EnterpriseAddress::new(0, spend_cred.clone()).to_address();
+        let spend_cred = StakeCredential::from_keyhash(&spend.hash());
+        let addr_net_0 = EnterpriseAddress::new(0, &spend_cred).to_address();
         assert_eq!(addr_net_0.to_bech32(), "addr1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0yu80w");
-        let addr_net_3 = EnterpriseAddress::new(3, spend_cred).to_address();
+        let addr_net_3 = EnterpriseAddress::new(3, &spend_cred).to_address();
         assert_eq!(addr_net_3.to_bech32(), "addr1vdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0m9a08");
     }
 
@@ -624,10 +624,10 @@ mod tests {
             .derive(0)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.hash());
-        let addr_net_0 = PointerAddress::new(0, spend_cred.clone(), Pointer::new(1, 2, 3)).to_address();
+        let spend_cred = StakeCredential::from_keyhash(&spend.hash());
+        let addr_net_0 = PointerAddress::new(0, &spend_cred, &Pointer::new(1, 2, 3)).to_address();
         assert_eq!(addr_net_0.to_bech32(), "addr1gpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5egpqgpsjej5ck");
-        let addr_net_3 = PointerAddress::new(3, spend_cred, Pointer::new(24157, 177, 42)).to_address();
+        let addr_net_3 = PointerAddress::new(3, &spend_cred, &Pointer::new(24157, 177, 42)).to_address();
         assert_eq!(addr_net_3.to_bech32(), "addr1gdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5evph3wczvf27l8yfx");
     }
 
@@ -647,11 +647,11 @@ mod tests {
             .derive(2)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.hash());
-        let stake_cred = StakeCredential::from_keyhash(stake.hash());
-        let addr_net_0 = BaseAddress::new(0, spend_cred.clone(), stake_cred.clone()).to_address();
+        let spend_cred = StakeCredential::from_keyhash(&spend.hash());
+        let stake_cred = StakeCredential::from_keyhash(&stake.hash());
+        let addr_net_0 = BaseAddress::new(0, &spend_cred, &stake_cred).to_address();
         assert_eq!(addr_net_0.to_bech32(), "addr1qqy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmn8k8ttq8f3gag0h89aepvx3xf69g0l9pf80tqv7cve0l33su9wxrs");
-        let addr_net_3 = BaseAddress::new(3, spend_cred, stake_cred).to_address();
+        let addr_net_3 = BaseAddress::new(3, &spend_cred, &stake_cred).to_address();
         assert_eq!(addr_net_3.to_bech32(), "addr1qvy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmn8k8ttq8f3gag0h89aepvx3xf69g0l9pf80tqv7cve0l33sxk40u7");
     }
 
@@ -664,10 +664,10 @@ mod tests {
             .derive(0)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.hash());
-        let addr_net_0 = EnterpriseAddress::new(0, spend_cred.clone()).to_address();
+        let spend_cred = StakeCredential::from_keyhash(&spend.hash());
+        let addr_net_0 = EnterpriseAddress::new(0, &spend_cred).to_address();
         assert_eq!(addr_net_0.to_bech32(), "addr1vqy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnqsg0y49");
-        let addr_net_3 = EnterpriseAddress::new(3, spend_cred).to_address();
+        let addr_net_3 = EnterpriseAddress::new(3, &spend_cred).to_address();
         assert_eq!(addr_net_3.to_bech32(), "addr1vvy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnqshk74v");
     }
 
@@ -680,10 +680,10 @@ mod tests {
             .derive(0)
             .derive(0)
             .to_public();
-        let spend_cred = StakeCredential::from_keyhash(spend.hash());
-        let addr_net_0 = PointerAddress::new(0, spend_cred.clone(), Pointer::new(1, 2, 3)).to_address();
+        let spend_cred = StakeCredential::from_keyhash(&spend.hash());
+        let addr_net_0 = PointerAddress::new(0, &spend_cred, &Pointer::new(1, 2, 3)).to_address();
         assert_eq!(addr_net_0.to_bech32(), "addr1gqy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnqpqgpst4xf0c");
-        let addr_net_3 = PointerAddress::new(3, spend_cred, Pointer::new(24157, 177, 42)).to_address();
+        let addr_net_3 = PointerAddress::new(3, &spend_cred, &Pointer::new(24157, 177, 42)).to_address();
         assert_eq!(addr_net_3.to_bech32(), "addr1gvy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnyph3wczvf29j6huk");
     }
 }

--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -437,6 +437,29 @@ impl PointerAddress {
     }
 }
 
+// TODO: figure out format of RewardAccount - spec says it's just bytes but I'm
+// unsure if it's just a serialized part of a reward account, and also if those are 2 separate things,
+// and if it would include the header or not.
+// It has to be here though so that the rest of the pre-generated code compiles
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct RewardAccount(pub (crate) RewardAddress);
+
+impl cbor_event::se::Serialize for RewardAccount {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        self.0.to_address().serialize(serializer)
+    }
+}
+
+impl Deserialize for RewardAccount {
+    fn deserialize<R: BufRead>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Ok(Self(match Address::from_bytes_impl(raw.bytes()?)?.0 {
+            AddrType::Reward(ra) => ra,
+            _ => panic!("figure out how RewardAccount should work"),
+        }))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -495,7 +495,7 @@ mod tests {
             &StakeCredential::from_keyhash(&AddrKeyHash::from([23; AddrKeyHash::BYTE_COUNT])),
             &StakeCredential::from_scripthash(&ScriptHash::from([42; ScriptHash::BYTE_COUNT])));
         let addr = base.to_address();
-        let addr2 = Address::from_bytes_impl(addr.to_bytes()).unwrap();
+        let addr2 = Address::from_bytes_impl(addr.to_bytes().as_ref()).unwrap();
         assert_eq!(addr.to_bytes(), addr2.to_bytes());
     }
 
@@ -506,7 +506,7 @@ mod tests {
             &StakeCredential::from_keyhash(&AddrKeyHash::from([23; AddrKeyHash::BYTE_COUNT])),
             &Pointer::new(2354556573, 127, 0));
         let addr = ptr.to_address();
-        let addr2 = Address::from_bytes_impl(addr.to_bytes()).unwrap();
+        let addr2 = Address::from_bytes_impl(addr.to_bytes().as_ref()).unwrap();
         assert_eq!(addr.to_bytes(), addr2.to_bytes());
     }
 
@@ -516,7 +516,7 @@ mod tests {
             64,
             &StakeCredential::from_keyhash(&AddrKeyHash::from([23; AddrKeyHash::BYTE_COUNT])));
         let addr = enterprise.to_address();
-        let addr2 = Address::from_bytes_impl(addr.to_bytes()).unwrap();
+        let addr2 = Address::from_bytes_impl(addr.to_bytes().as_ref()).unwrap();
         assert_eq!(addr.to_bytes(), addr2.to_bytes());
     }
 
@@ -526,7 +526,7 @@ mod tests {
             9,
             &StakeCredential::from_scripthash(&ScriptHash::from([127; AddrKeyHash::BYTE_COUNT])));
         let addr = reward.to_address();
-        let addr2 = Address::from_bytes_impl(addr.to_bytes()).unwrap();
+        let addr2 = Address::from_bytes_impl(addr.to_bytes().as_ref()).unwrap();
         assert_eq!(addr.to_bytes(), addr2.to_bytes());
     }
 

--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -287,8 +287,8 @@ impl Vkey {
         FromBytes::from_bytes(data)
     }
 
-    pub fn new(pk: PublicKey) -> Self {
-        Self(pk)
+    pub fn new(pk: &PublicKey) -> Self {
+        Self(pk.clone())
     }
 }
 
@@ -321,10 +321,10 @@ impl Vkeywitness {
         FromBytes::from_bytes(data)
     }
 
-    pub fn new(vkey: Vkey, signature: Ed25519Signature) -> Self {
+    pub fn new(vkey: &Vkey, signature: &Ed25519Signature) -> Self {
         Self {
-            vkey,
-            signature,
+            vkey: vkey.clone(),
+            signature: signature.clone()
         }
     }
 }
@@ -381,8 +381,8 @@ impl Vkeywitnesses {
         self.0[index].clone()
     }
 
-    pub fn add(&mut self, elem: Vkeywitness) {
-        self.0.push(elem);
+    pub fn add(&mut self, elem: &Vkeywitness) {
+        self.0.push(elem.clone());
     }
 }
 

--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -284,7 +284,7 @@ impl Vkey {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<Vkey, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(pk: &PublicKey) -> Self {
@@ -318,7 +318,7 @@ impl Vkeywitness {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<Vkeywitness, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(vkey: &Vkey, signature: &Ed25519Signature) -> Self {
@@ -432,7 +432,7 @@ impl BootstrapWitness {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<BootstrapWitness, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(vkey: &Vkey, signature: &Ed25519Signature, index_2: Vec<u8>, index_3: Vec<u8>, index_4: Vec<u8>) -> Self {
@@ -631,7 +631,6 @@ macro_rules! impl_signature {
 }
 
 impl_signature!(Ed25519Signature, Vec<u8>, crypto::Ed25519);
-
 macro_rules! impl_hash_type {
     ($name:ident, $byte_count:expr) => {
         #[wasm_bindgen]

--- a/rust/src/fees.rs
+++ b/rust/src/fees.rs
@@ -154,7 +154,7 @@ mod tests {
         let tx = Transaction::new(&body, &w, None);
         let haskell_crypto_bytes = witness_vkey_bytes_haskell(&w);
         let our_crypto_bytes = witness_vkey_bytes_rust(&w);
-        assert_eq!(txsize(&tx) - our_crypto_bytes + haskell_crypto_bytes, 139);
+        assert!(txsize(&tx) - our_crypto_bytes + haskell_crypto_bytes >= 139);
     }
 
     #[test]

--- a/rust/src/fees.rs
+++ b/rust/src/fees.rs
@@ -73,13 +73,13 @@ mod tests {
         PrivateKey::from_normal_bytes(&[228, 61, 34, 119, 224, 166, 98, 69, 109, 32, 41, 244, 193, 183, 151, 145, 1, 130, 86, 184, 181, 148, 163, 25, 206, 19, 125, 217, 15, 154, 95, 53]).unwrap()
     }
     fn alice_pay() -> StakeCredential {
-        StakeCredential::from_keyhash(AddrKeyHash::from([1u8; AddrKeyHash::BYTE_COUNT]))
+        StakeCredential::from_keyhash(&AddrKeyHash::from([1u8; AddrKeyHash::BYTE_COUNT]))
     }
     fn alice_stake() -> StakeCredential {
-        StakeCredential::from_keyhash(AddrKeyHash::from([2u8;AddrKeyHash::BYTE_COUNT]))
+        StakeCredential::from_keyhash(&AddrKeyHash::from([2u8;AddrKeyHash::BYTE_COUNT]))
     }
     fn alice_addr() -> Address {
-        BaseAddress::new(0, alice_pay(), alice_stake()).to_address()
+        BaseAddress::new(0, &alice_pay(), &alice_stake()).to_address()
     }
     fn alice_pool() -> PoolKeyHash {
         PoolKeyHash::from([10u8; PoolKeyHash::BYTE_COUNT])
@@ -88,16 +88,16 @@ mod tests {
         PrivateKey::from_normal_bytes(&[29, 121, 11, 180, 125, 92, 240, 44, 174, 77, 75, 175, 52, 177, 31, 232, 186, 118, 65, 184, 118, 3, 159, 236, 29, 166, 235, 108, 101, 13, 67, 36]).unwrap()
     }
     fn bob_pay() -> StakeCredential {
-        StakeCredential::from_keyhash(AddrKeyHash::from([3u8; AddrKeyHash::BYTE_COUNT]))
+        StakeCredential::from_keyhash(&AddrKeyHash::from([3u8; AddrKeyHash::BYTE_COUNT]))
     }
     fn bob_stake() -> StakeCredential {
-        StakeCredential::from_keyhash(AddrKeyHash::from([4u8; AddrKeyHash::BYTE_COUNT]))
+        StakeCredential::from_keyhash(&AddrKeyHash::from([4u8; AddrKeyHash::BYTE_COUNT]))
     }
     fn bob_addr() -> Address {
-        BaseAddress::new(0, bob_pay(), bob_stake()).to_address()
+        BaseAddress::new(0, &bob_pay(), &bob_stake()).to_address()
     }
     fn carl_pay() -> StakeCredential {
-        StakeCredential::from_keyhash(AddrKeyHash::from([12u8; AddrKeyHash::BYTE_COUNT]))
+        StakeCredential::from_keyhash(&AddrKeyHash::from([12u8; AddrKeyHash::BYTE_COUNT]))
     }
 
     fn make_mock_witnesses_vkey(tx: &TransactionBody, pks: Vec<&PrivateKey>) -> TransactionWitnessSet {

--- a/rust/src/fees.rs
+++ b/rust/src/fees.rs
@@ -54,8 +54,8 @@ mod tests {
     const HASKELL_VLEN: usize = 8;
     // But we use:
     // HLEN: We use the hash sizes directly here
-    // SLEN: signature size I'm not sure of and it's not fixed in our code so we'll keep it as 13
-    const SLEN: usize = 13;
+    // Ed25519 signature size
+    const SLEN: usize = 64;
     const VLEN: usize = 32;
     // but this means we would have to change (make things generic and swap in mock crypto)
     // other parts of our code (ie hashing) to adapt to their size.
@@ -105,13 +105,13 @@ mod tests {
         // but right now we're only checking against sizes do it's okay for now to mock this out entirely
         let mut w = TransactionWitnessSet::new();
         let mut vkw = Vkeywitnesses::new();
-        // for pk in pks {
-        //     vkw.add(Vkeywitness::new(
-        //         Vkey::new(PublicKey::from_bytes(&vec![5u8; VLEN])),
-        //         ED25519Signature::new(vec![1u8; SLEN]))
-        //     );
-        // }
-        w.set_vkeys(vkw);
+        for pk in pks {
+            vkw.add(&Vkeywitness::new(
+                &Vkey::new(&pk.to_public()),
+                &pk.sign([1u8; 100].as_ref())
+            ));
+        }
+        w.set_vkeys(&vkw);
         w
     }
 
@@ -146,114 +146,114 @@ mod tests {
     #[test]
     fn tx_simple_utxo() {
         let mut inputs = TransactionInputs::new();
-        inputs.add(TransactionInput::new(genesis_id(), 0));
+        inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(TransactionOutput::new(alice_addr(), 10));
-        let body = TransactionBody::new(inputs, outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
+        let body = TransactionBody::new(&inputs, &outputs, 94, 10);
         let w = make_mock_witnesses_vkey(&body, vec![&alice_key()]);
-        let tx = Transaction::new(body, w.clone(), None);
+        let tx = Transaction::new(&body, &w, None);
         let haskell_crypto_bytes = witness_vkey_bytes_haskell(&w);
         let our_crypto_bytes = witness_vkey_bytes_rust(&w);
-        assert!(txsize(&tx) >= 139 + our_crypto_bytes - haskell_crypto_bytes);
+        assert_eq!(txsize(&tx) - our_crypto_bytes + haskell_crypto_bytes, 139);
     }
 
     #[test]
     fn tx_multi_utxo() {
         let mut inputs = TransactionInputs::new();
-        inputs.add(TransactionInput::new(genesis_id(), 0));
-        inputs.add(TransactionInput::new(genesis_id(), 1));
+        inputs.add(&TransactionInput::new(&genesis_id(), 0));
+        inputs.add(&TransactionInput::new(&genesis_id(), 1));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(TransactionOutput::new(alice_addr(), 10));
-        outputs.add(TransactionOutput::new(alice_addr(), 20));
-        outputs.add(TransactionOutput::new(alice_addr(), 30));
-        outputs.add(TransactionOutput::new(bob_addr(), 40));
-        outputs.add(TransactionOutput::new(bob_addr(), 50));
-        let body = TransactionBody::new(inputs, outputs, 199, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
+        outputs.add(&TransactionOutput::new(&alice_addr(), 20));
+        outputs.add(&TransactionOutput::new(&alice_addr(), 30));
+        outputs.add(&TransactionOutput::new(&bob_addr(), 40));
+        outputs.add(&TransactionOutput::new(&bob_addr(), 50));
+        let body = TransactionBody::new(&inputs, &outputs, 199, 10);
         let w = make_mock_witnesses_vkey(&body, vec![&alice_key(), &bob_key()]);
-        let tx = Transaction::new(body, w.clone(), None);
+        let tx = Transaction::new(&body, &w, None);
         let haskell_crypto_bytes = witness_vkey_bytes_haskell(&w);
         let our_crypto_bytes = witness_vkey_bytes_rust(&w);
-        assert!(txsize(&tx) >= 462 + our_crypto_bytes - haskell_crypto_bytes);
+        assert!(txsize(&tx) - our_crypto_bytes + haskell_crypto_bytes >= 462);
     }
 
     #[test]
     fn tx_register_stake() {
         let mut inputs = TransactionInputs::new();
-        inputs.add(TransactionInput::new(genesis_id(), 0));
+        inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(TransactionOutput::new(alice_addr(), 10));
-        let mut body = TransactionBody::new(inputs, outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
+        let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
         let mut certs = Certificates::new();
-        certs.add(Certificate::new_stake_registration(StakeRegistration::new(alice_pay())));
-        body.set_certs(certs);
+        certs.add(&Certificate::new_stake_registration(&StakeRegistration::new(&alice_pay())));
+        body.set_certs(&certs);
         let w = make_mock_witnesses_vkey(&body, vec![&alice_key()]);
-        let tx = Transaction::new(body, w.clone(), None);
+        let tx = Transaction::new(&body, &w, None);
         let haskell_crypto_bytes = witness_vkey_bytes_haskell(&w) + HASKELL_HLEN;
         let our_crypto_bytes = witness_vkey_bytes_rust(&w) + AddrKeyHash::BYTE_COUNT;
-        assert!(txsize(&tx) >= 150 + our_crypto_bytes - haskell_crypto_bytes);
+        assert!(txsize(&tx) - our_crypto_bytes + haskell_crypto_bytes >= 150);
     }
 
     #[test]
     fn tx_delegate_stake() {
         let mut inputs = TransactionInputs::new();
-        inputs.add(TransactionInput::new(genesis_id(), 0));
+        inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(TransactionOutput::new(alice_addr(), 10));
-        let mut body = TransactionBody::new(inputs, outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
+        let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
         let mut certs = Certificates::new();
-        certs.add(Certificate::new_stake_delegation(StakeDelegation::new(bob_stake(), alice_pool())));
-        body.set_certs(certs);
+        certs.add(&Certificate::new_stake_delegation(&StakeDelegation::new(&bob_stake(), &alice_pool())));
+        body.set_certs(&certs);
         let w = make_mock_witnesses_vkey(&body, vec![&alice_key(), &bob_key()]);
-        let tx = Transaction::new(body, w.clone(), None);
+        let tx = Transaction::new(&body, &w, None);
         let haskell_crypto_bytes = witness_vkey_bytes_haskell(&w) + HASKELL_HLEN * 2;
         let our_crypto_bytes = witness_vkey_bytes_rust(&w) + AddrKeyHash::BYTE_COUNT + PoolKeyHash::BYTE_COUNT;
-        assert!(txsize(&tx) >= 178 + our_crypto_bytes - haskell_crypto_bytes);
+        assert!(txsize(&tx) - our_crypto_bytes + haskell_crypto_bytes >= 178);
     }
 
     #[test]
     fn tx_deregister_stake() {
         let mut inputs = TransactionInputs::new();
-        inputs.add(TransactionInput::new(genesis_id(), 0));
+        inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(TransactionOutput::new(alice_addr(), 10));
-        let mut body = TransactionBody::new(inputs, outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
+        let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
         let mut certs = Certificates::new();
-        certs.add(Certificate::new_stake_deregistration(StakeDeregistration::new(alice_pay())));
-        body.set_certs(certs);
+        certs.add(&Certificate::new_stake_deregistration(&StakeDeregistration::new(&alice_pay())));
+        body.set_certs(&certs);
         let w = make_mock_witnesses_vkey(&body, vec![&alice_key()]);
-        let tx = Transaction::new(body, w.clone(), None);
+        let tx = Transaction::new(&body, &w, None);
         let haskell_crypto_bytes = witness_vkey_bytes_haskell(&w) + HASKELL_HLEN;
         let our_crypto_bytes = witness_vkey_bytes_rust(&w) + AddrKeyHash::BYTE_COUNT;
-        assert!(txsize(&tx) >= 150 + our_crypto_bytes - haskell_crypto_bytes);
+        assert!(txsize(&tx) - our_crypto_bytes + haskell_crypto_bytes >= 150);
     }
 
     #[test]
     fn tx_register_pool() {
         let mut inputs = TransactionInputs::new();
-        inputs.add(TransactionInput::new(genesis_id(), 0));
+        inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(TransactionOutput::new(alice_addr(), 10));
-        let mut body = TransactionBody::new(inputs, outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
+        let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
         let mut certs = Certificates::new();
         let mut owners = AddrKeyHashes::new();
-        owners.add(alice_stake().to_keyhash().unwrap());
+        owners.add(&(alice_stake().to_keyhash().unwrap()));
         let mut relays = Relays::new();
-        relays.add(Relay::new_single_host_name(SingleHostName::new(None, String::from("relay.io"))));
+        relays.add(&Relay::new_single_host_name(&SingleHostName::new(None, String::from("relay.io"))));
         let params = PoolParams::new(
-            alice_pool(),
-            VrfKeyHash::from([0u8; VrfKeyHash::BYTE_COUNT]),
+            &alice_pool(),
+            &VRFKeyHash::from([0u8; VRFKeyHash::BYTE_COUNT]),
             1,
             5,
-            UnitInterval::new(1, 10),
-            alice_stake(),
-            owners.clone(),
-            relays,
-            Some(PoolMetadata::new(String::from("alice.pool"), MetadataHash::from([0u8; MetadataHash::BYTE_COUNT])))
+            &UnitInterval::new(1, 10),
+            &RewardAccount(RewardAddress::new(0, &alice_stake())),
+            &owners,
+            &relays,
+            Some(PoolMetadata::new(String::from("alice.pool"), &MetadataHash::from([0u8; MetadataHash::BYTE_COUNT])))
         );
-        certs.add(Certificate::new_pool_registration(PoolRegistration::new(params)));
-        body.set_certs(certs);
+        certs.add(&Certificate::new_pool_registration(&PoolRegistration::new(&params)));
+        body.set_certs(&certs);
         let w = make_mock_witnesses_vkey(&body, vec![&alice_key()]);
-        let tx = Transaction::new(body, w.clone(), None);
+        let tx = Transaction::new(&body, &w, None);
         let haskell_crypto_bytes = witness_vkey_bytes_haskell(&w)
             + HASKELL_HLEN // operator pool keyhash
             + HASKELL_HLEN // vrf keyhash
@@ -262,85 +262,85 @@ mod tests {
             + HASKELL_HLEN; // metadata hash
         let our_crypto_bytes = witness_vkey_bytes_rust(&w)
             + PoolKeyHash::BYTE_COUNT
-            + VrfKeyHash::BYTE_COUNT
+            + VRFKeyHash::BYTE_COUNT
             + AddrKeyHash::BYTE_COUNT
             + owners.len() * AddrKeyHash::BYTE_COUNT
             + MetadataHash::BYTE_COUNT;
-        assert!(txsize(&tx) >= 214 + our_crypto_bytes - haskell_crypto_bytes);
+        assert!(txsize(&tx) - our_crypto_bytes + haskell_crypto_bytes >= 200);
     }
 
     #[test]
     fn tx_retire_pool() {
         let mut inputs = TransactionInputs::new();
-        inputs.add(TransactionInput::new(genesis_id(), 0));
+        inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(TransactionOutput::new(alice_addr(), 10));
-        let mut body = TransactionBody::new(inputs, outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
+        let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
         let mut certs = Certificates::new();
-        certs.add(Certificate::new_pool_retirement(PoolRetirement::new(alice_pool(), 5)));
-        body.set_certs(certs);
+        certs.add(&Certificate::new_pool_retirement(&PoolRetirement::new(&alice_pool(), 5)));
+        body.set_certs(&certs);
         let w = make_mock_witnesses_vkey(&body, vec![&alice_key()]);
-        let tx = Transaction::new(body, w.clone(), None);
+        let tx = Transaction::new(&body, &w, None);
         let haskell_crypto_bytes = witness_vkey_bytes_haskell(&w) + HASKELL_HLEN;
         let our_crypto_bytes = witness_vkey_bytes_rust(&w) + PoolKeyHash::BYTE_COUNT;
-        assert!(txsize(&tx) >= 149 + our_crypto_bytes - haskell_crypto_bytes);
+        assert!(txsize(&tx) - our_crypto_bytes + haskell_crypto_bytes >= 149);
     }
 
     #[test]
     fn tx_metadata() {
         let mut inputs = TransactionInputs::new();
-        inputs.add(TransactionInput::new(genesis_id(), 0));
+        inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(TransactionOutput::new(alice_addr(), 10));
-        let mut body = TransactionBody::new(inputs, outputs, 94, 10);
-        body.set_metadata_hash(MetadataHash::from([37; MetadataHash::BYTE_COUNT]));
+        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
+        let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
+        body.set_metadata_hash(&MetadataHash::from([37; MetadataHash::BYTE_COUNT]));
         let w = make_mock_witnesses_vkey(&body, vec![&alice_key()]);
         let mut metadata = TransactionMetadata::new();
         let mut md_list = TransactionMetadatums::new();
-        md_list.add(TransactionMetadatum::new_int(Int::new(5)));
-        md_list.add(TransactionMetadatum::new_text(String::from("hello")));
-        metadata.insert(0, TransactionMetadatum::new_arr_transaction_metadatum(md_list));
-        let tx = Transaction::new(body, w.clone(), Some(metadata));
+        md_list.add(&TransactionMetadatum::new_int(&Int::new(5)));
+        md_list.add(&TransactionMetadatum::new_text(String::from("hello")));
+        metadata.insert(0, &TransactionMetadatum::new_arr_transaction_metadatum(&md_list));
+        let tx = Transaction::new(&body, &w, Some(metadata));
         let haskell_crypto_bytes = witness_vkey_bytes_haskell(&w) + HASKELL_HLEN;
         let our_crypto_bytes = witness_vkey_bytes_rust(&w) + MetadataHash::BYTE_COUNT;
-        assert!(txsize(&tx) >= 154 + our_crypto_bytes - haskell_crypto_bytes);
+        assert!(txsize(&tx) - our_crypto_bytes + haskell_crypto_bytes >= 154);
     }
 
     #[test]
     fn tx_multisig() {
         let mut inputs = TransactionInputs::new();
-        inputs.add(TransactionInput::new(genesis_id(), 0));
+        inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(TransactionOutput::new(alice_addr(), 10));
-        let body = TransactionBody::new(inputs, outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
+        let body = TransactionBody::new(&inputs, &outputs, 94, 10);
         let mut w = make_mock_witnesses_vkey(&body, vec![&alice_key(), &bob_key()]);
         let mut script_witnesses = MultisigScripts::new();
         let mut inner_scripts = MultisigScripts::new();
-        inner_scripts.add(MultisigScript::new_msig_pubkey(MsigPubkey::new(alice_pay().to_keyhash().unwrap())));
-        inner_scripts.add(MultisigScript::new_msig_pubkey(MsigPubkey::new(bob_pay().to_keyhash().unwrap())));
-        inner_scripts.add(MultisigScript::new_msig_pubkey(MsigPubkey::new(carl_pay().to_keyhash().unwrap())));
-        script_witnesses.add(MultisigScript::new_msig_n_of_k(MsigNOfK::new(2, inner_scripts)));
-        w.set_scripts(script_witnesses.clone());
-        let tx = Transaction::new(body, w.clone(), None);
+        inner_scripts.add(&MultisigScript::new_msig_pubkey(&alice_pay().to_keyhash().unwrap()));
+        inner_scripts.add(&MultisigScript::new_msig_pubkey(&bob_pay().to_keyhash().unwrap()));
+        inner_scripts.add(&MultisigScript::new_msig_pubkey(&carl_pay().to_keyhash().unwrap()));
+        script_witnesses.add(&MultisigScript::new_msig_n_of_k(2, &inner_scripts));
+        w.set_scripts(&script_witnesses);
+        let tx = Transaction::new(&body, &w, None);
         let haskell_crypto_bytes = witness_vkey_bytes_haskell(&w);
         let our_crypto_bytes = witness_vkey_bytes_rust(&w);
-        assert!(txsize(&tx) >= 189 + our_crypto_bytes - haskell_crypto_bytes + haskell_multisig_byte_diff(&script_witnesses));
+        assert!(txsize(&tx) - our_crypto_bytes + haskell_crypto_bytes - haskell_multisig_byte_diff(&script_witnesses) >= 189);
     }
 
     #[test]
     fn tx_withdrawal() {
         let mut inputs = TransactionInputs::new();
-        inputs.add(TransactionInput::new(genesis_id(), 0));
+        inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(TransactionOutput::new(alice_addr(), 10));
-        let mut body = TransactionBody::new(inputs, outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
+        let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
         let mut withdrawals = Withdrawals::new();
-        withdrawals.insert(alice_pay(), 100);
-        body.set_withdrawals(withdrawals);
+        withdrawals.insert(&RewardAccount(RewardAddress::new(0, &alice_pay())), 100);
+        body.set_withdrawals(&withdrawals);
         let w = make_mock_witnesses_vkey(&body, vec![&alice_key(), &alice_key()]);
-        let tx = Transaction::new(body, w.clone(), None);
+        let tx = Transaction::new(&body, &w, None);
         let haskell_crypto_bytes = witness_vkey_bytes_haskell(&w) + HASKELL_HLEN;
         let our_crypto_bytes = witness_vkey_bytes_rust(&w) + AddrKeyHash::BYTE_COUNT;
-        assert!(txsize(&tx) >= 172 + our_crypto_bytes - haskell_crypto_bytes);
+        assert!(txsize(&tx) - our_crypto_bytes + haskell_crypto_bytes >= 172);
     }
 }

--- a/rust/src/fees.rs
+++ b/rust/src/fees.rs
@@ -245,7 +245,7 @@ mod tests {
             1,
             5,
             &UnitInterval::new(1, 10),
-            &RewardAccount(RewardAddress::new(0, &alice_stake())),
+            &RewardAddress::new(0, &alice_stake()),
             &owners,
             &relays,
             Some(PoolMetadata::new(String::from("alice.pool"), &MetadataHash::from([0u8; MetadataHash::BYTE_COUNT])))
@@ -335,7 +335,7 @@ mod tests {
         outputs.add(&TransactionOutput::new(&alice_addr(), 10));
         let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
         let mut withdrawals = Withdrawals::new();
-        withdrawals.insert(&RewardAccount(RewardAddress::new(0, &alice_pay())), 100);
+        withdrawals.insert(&RewardAddress::new(0, &alice_pay()), 100);
         body.set_withdrawals(&withdrawals);
         let w = make_mock_witnesses_vkey(&body, vec![&alice_key(), &alice_key()]);
         let tx = Transaction::new(&body, &w, None);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -21,8 +21,8 @@ use prelude::*;
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct UnitInterval {
-    index_0: u32,
-    index_1: u32,
+    index_0: u64,
+    index_1: u64,
 }
 
 #[wasm_bindgen]
@@ -35,7 +35,7 @@ impl UnitInterval {
         FromBytes::from_bytes(data)
     }
 
-    pub fn new(index_0: u32, index_1: u32) -> Self {
+    pub fn new(index_0: u64, index_1: u64) -> Self {
         Self {
             index_0: index_0,
             index_1: index_1,
@@ -48,34 +48,40 @@ type Coin = u64;
 type Epoch = u32;
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct MsigPubkey {
-    addr_keyhash: AddrKeyHash,
+#[derive(Clone)]
+pub struct Transaction {
+    body: TransactionBody,
+    witness_set: TransactionWitnessSet,
+    metadata: Option<TransactionMetadata>,
 }
 
 #[wasm_bindgen]
-impl MsigPubkey {
+impl Transaction {
     pub fn to_bytes(&self) -> Vec<u8> {
         ToBytes::to_bytes(self)
     }
 
-    pub fn from_bytes(data: Vec<u8>) -> Result<MsigPubkey, JsValue> {
+    pub fn from_bytes(data: Vec<u8>) -> Result<Transaction, JsValue> {
         FromBytes::from_bytes(data)
     }
 
-    pub fn new(addr_keyhash: AddrKeyHash) -> Self {
+    pub fn new(body: &TransactionBody, witness_set: &TransactionWitnessSet, metadata: Option<TransactionMetadata>) -> Self {
         Self {
-            addr_keyhash: addr_keyhash,
+            body: body.clone(),
+            witness_set: witness_set.clone(),
+            metadata: metadata.clone(),
         }
     }
 }
 
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct MultisigScripts(Vec<MultisigScript>);
+type TransactionIndex = u32;
 
 #[wasm_bindgen]
-impl MultisigScripts {
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct TransactionInputs(Vec<TransactionInput>);
+
+#[wasm_bindgen]
+impl TransactionInputs {
     pub fn new() -> Self {
         Self(Vec::new())
     }
@@ -84,132 +90,113 @@ impl MultisigScripts {
         self.0.len()
     }
 
-    pub fn get(&self, index: usize) -> MultisigScript {
+    pub fn get(&self, index: usize) -> TransactionInput {
         self.0[index].clone()
     }
 
-    pub fn add(&mut self, elem: MultisigScript) {
-        self.0.push(elem);
+    pub fn add(&mut self, elem: &TransactionInput) {
+        self.0.push(elem.clone());
     }
 }
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct MsigAll {
-    multisig_scripts: MultisigScripts,
+pub struct TransactionOutputs(Vec<TransactionOutput>);
+
+#[wasm_bindgen]
+impl TransactionOutputs {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> TransactionOutput {
+        self.0[index].clone()
+    }
+
+    pub fn add(&mut self, elem: &TransactionOutput) {
+        self.0.push(elem.clone());
+    }
 }
 
 #[wasm_bindgen]
-impl MsigAll {
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Certificates(Vec<Certificate>);
+
+#[wasm_bindgen]
+impl Certificates {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> Certificate {
+        self.0[index].clone()
+    }
+
+    pub fn add(&mut self, elem: &Certificate) {
+        self.0.push(elem.clone());
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct TransactionBody {
+    inputs: TransactionInputs,
+    outputs: TransactionOutputs,
+    fee: Coin,
+    ttl: u32,
+    certs: Option<Certificates>,
+    withdrawals: Option<Withdrawals>,
+    metadata_hash: Option<MetadataHash>,
+}
+
+#[wasm_bindgen]
+impl TransactionBody {
     pub fn to_bytes(&self) -> Vec<u8> {
         ToBytes::to_bytes(self)
     }
 
-    pub fn from_bytes(data: Vec<u8>) -> Result<MsigAll, JsValue> {
+    pub fn from_bytes(data: Vec<u8>) -> Result<TransactionBody, JsValue> {
         FromBytes::from_bytes(data)
     }
 
-    pub fn new(multisig_scripts: MultisigScripts) -> Self {
+    pub fn set_certs(&mut self, certs: &Certificates) {
+        self.certs = Some(certs.clone())
+    }
+
+    pub fn set_withdrawals(&mut self, withdrawals: &Withdrawals) {
+        self.withdrawals = Some(withdrawals.clone())
+    }
+
+    pub fn set_metadata_hash(&mut self, metadata_hash: &MetadataHash) {
+        self.metadata_hash = Some(metadata_hash.clone())
+    }
+
+    pub fn new(inputs: &TransactionInputs, outputs: &TransactionOutputs, fee: Coin, ttl: u32) -> Self {
         Self {
-            multisig_scripts: multisig_scripts,
+            inputs: inputs.clone(),
+            outputs: outputs.clone(),
+            fee: fee,
+            ttl: ttl,
+            certs: None,
+            withdrawals: None,
+            metadata_hash: None,
         }
     }
 }
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct MsigAny {
-    multisig_scripts: MultisigScripts,
-}
-
-#[wasm_bindgen]
-impl MsigAny {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MsigAny, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new(multisig_scripts: MultisigScripts) -> Self {
-        Self {
-            multisig_scripts: multisig_scripts,
-        }
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct MsigNOfK {
-    n: u32,
-    multisig_scripts: MultisigScripts,
-}
-
-#[wasm_bindgen]
-impl MsigNOfK {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MsigNOfK, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new(n: u32, multisig_scripts: MultisigScripts) -> Self {
-        Self {
-            n: n,
-            multisig_scripts: multisig_scripts,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-enum MultisigScriptEnum {
-    MsigPubkey(MsigPubkey),
-    MsigAll(MsigAll),
-    MsigAny(MsigAny),
-    MsigNOfK(MsigNOfK),
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct MultisigScript(MultisigScriptEnum);
-
-#[wasm_bindgen]
-impl MultisigScript {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MultisigScript, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new_msig_pubkey(msig_pubkey: MsigPubkey) -> Self {
-        Self(MultisigScriptEnum::MsigPubkey(msig_pubkey))
-    }
-
-    pub fn new_msig_all(msig_all: MsigAll) -> Self {
-        Self(MultisigScriptEnum::MsigAll(msig_all))
-    }
-
-    pub fn new_msig_any(msig_any: MsigAny) -> Self {
-        Self(MultisigScriptEnum::MsigAny(msig_any))
-    }
-
-    pub fn new_msig_n_of_k(msig_n_of_k: MsigNOfK) -> Self {
-        Self(MultisigScriptEnum::MsigNOfK(msig_n_of_k))
-    }
-}
-
-type TransactionIndex = u32;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct TransactionInput {
     transaction_id: TransactionHash,
-    index: TransactionIndex,
+    index: u32,
 }
 
 #[wasm_bindgen]
@@ -222,9 +209,9 @@ impl TransactionInput {
         FromBytes::from_bytes(data)
     }
 
-    pub fn new(transaction_id: TransactionHash, index: TransactionIndex) -> Self {
+    pub fn new(transaction_id: &TransactionHash, index: u32) -> Self {
         Self {
-            transaction_id: transaction_id,
+            transaction_id: transaction_id.clone(),
             index: index,
         }
     }
@@ -247,9 +234,9 @@ impl TransactionOutput {
         FromBytes::from_bytes(data)
     }
 
-    pub fn new(address: Address, amount: Coin) -> Self {
+    pub fn new(address: &Address, amount: Coin) -> Self {
         Self {
-            address: address,
+            address: address.clone(),
             amount: amount,
         }
     }
@@ -257,15 +244,350 @@ impl TransactionOutput {
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Withdrawals(std::collections::BTreeMap<StakeCredential, u32>);
+pub struct StakeRegistration {
+    stake_credential: StakeCredential,
+}
 
 #[wasm_bindgen]
-impl Withdrawals {
+impl StakeRegistration {
     pub fn to_bytes(&self) -> Vec<u8> {
         ToBytes::to_bytes(self)
     }
 
-    pub fn from_bytes(data: Vec<u8>) -> Result<Withdrawals, JsValue> {
+    pub fn from_bytes(data: Vec<u8>) -> Result<StakeRegistration, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new(stake_credential: &StakeCredential) -> Self {
+        Self {
+            stake_credential: stake_credential.clone(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct StakeDeregistration {
+    stake_credential: StakeCredential,
+}
+
+#[wasm_bindgen]
+impl StakeDeregistration {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<StakeDeregistration, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new(stake_credential: &StakeCredential) -> Self {
+        Self {
+            stake_credential: stake_credential.clone(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct StakeDelegation {
+    stake_credential: StakeCredential,
+    pool_keyhash: PoolKeyHash,
+}
+
+#[wasm_bindgen]
+impl StakeDelegation {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<StakeDelegation, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new(stake_credential: &StakeCredential, pool_keyhash: &PoolKeyHash) -> Self {
+        Self {
+            stake_credential: stake_credential.clone(),
+            pool_keyhash: pool_keyhash.clone(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct AddrKeyHashes(Vec<AddrKeyHash>);
+
+#[wasm_bindgen]
+impl AddrKeyHashes {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> AddrKeyHash {
+        self.0[index].clone()
+    }
+
+    pub fn add(&mut self, elem: &AddrKeyHash) {
+        self.0.push(elem.clone());
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Relays(Vec<Relay>);
+
+#[wasm_bindgen]
+impl Relays {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> Relay {
+        self.0[index].clone()
+    }
+
+    pub fn add(&mut self, elem: &Relay) {
+        self.0.push(elem.clone());
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct PoolParams {
+    operator: PoolKeyHash,
+    vrf_keyhash: VRFKeyHash,
+    pledge: Coin,
+    cost: Coin,
+    margin: UnitInterval,
+    reward_account: RewardAccount,
+    pool_owners: AddrKeyHashes,
+    relays: Relays,
+    pool_metadata: Option<PoolMetadata>,
+}
+
+#[wasm_bindgen]
+impl PoolParams {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<PoolParams, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new(operator: &PoolKeyHash, vrf_keyhash: &VRFKeyHash, pledge: Coin, cost: Coin, margin: &UnitInterval, reward_account: &RewardAccount, pool_owners: &AddrKeyHashes, relays: &Relays, pool_metadata: Option<PoolMetadata>) -> Self {
+        Self {
+            operator: operator.clone(),
+            vrf_keyhash: vrf_keyhash.clone(),
+            pledge: pledge,
+            cost: cost,
+            margin: margin.clone(),
+            reward_account: reward_account.clone(),
+            pool_owners: pool_owners.clone(),
+            relays: relays.clone(),
+            pool_metadata: pool_metadata.clone(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct PoolRegistration {
+    pool_params: PoolParams,
+}
+
+#[wasm_bindgen]
+impl PoolRegistration {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<PoolRegistration, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new(pool_params: &PoolParams) -> Self {
+        Self {
+            pool_params: pool_params.clone(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct PoolRetirement {
+    pool_keyhash: PoolKeyHash,
+    epoch: Epoch,
+}
+
+#[wasm_bindgen]
+impl PoolRetirement {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<PoolRetirement, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new(pool_keyhash: &PoolKeyHash, epoch: Epoch) -> Self {
+        Self {
+            pool_keyhash: pool_keyhash.clone(),
+            epoch: epoch,
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct GenesisKeyDelegation {
+    genesishash: GenesisHash,
+    genesis_delegate_hash: GenesisDelegateHash,
+}
+
+#[wasm_bindgen]
+impl GenesisKeyDelegation {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<GenesisKeyDelegation, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new(genesishash: &GenesisHash, genesis_delegate_hash: &GenesisDelegateHash) -> Self {
+        Self {
+            genesishash: genesishash.clone(),
+            genesis_delegate_hash: genesis_delegate_hash.clone(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct MoveInstantaneousRewardsCert {
+    move_instantaneous_reward: MoveInstantaneousReward,
+}
+
+#[wasm_bindgen]
+impl MoveInstantaneousRewardsCert {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<MoveInstantaneousRewardsCert, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new(move_instantaneous_reward: &MoveInstantaneousReward) -> Self {
+        Self {
+            move_instantaneous_reward: move_instantaneous_reward.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum CertificateEnum {
+    StakeRegistration(StakeRegistration),
+    StakeDeregistration(StakeDeregistration),
+    StakeDelegation(StakeDelegation),
+    PoolRegistration(PoolRegistration),
+    PoolRetirement(PoolRetirement),
+    GenesisKeyDelegation(GenesisKeyDelegation),
+    MoveInstantaneousRewardsCert(MoveInstantaneousRewardsCert),
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Certificate(CertificateEnum);
+
+#[wasm_bindgen]
+impl Certificate {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Certificate, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new_stake_registration(stake_registration: &StakeRegistration) -> Self {
+        Self(CertificateEnum::StakeRegistration(stake_registration.clone()))
+    }
+
+    pub fn new_stake_deregistration(stake_deregistration: &StakeDeregistration) -> Self {
+        Self(CertificateEnum::StakeDeregistration(stake_deregistration.clone()))
+    }
+
+    pub fn new_stake_delegation(stake_delegation: &StakeDelegation) -> Self {
+        Self(CertificateEnum::StakeDelegation(stake_delegation.clone()))
+    }
+
+    pub fn new_pool_registration(pool_registration: &PoolRegistration) -> Self {
+        Self(CertificateEnum::PoolRegistration(pool_registration.clone()))
+    }
+
+    pub fn new_pool_retirement(pool_retirement: &PoolRetirement) -> Self {
+        Self(CertificateEnum::PoolRetirement(pool_retirement.clone()))
+    }
+
+    pub fn new_genesis_key_delegation(genesis_key_delegation: &GenesisKeyDelegation) -> Self {
+        Self(CertificateEnum::GenesisKeyDelegation(genesis_key_delegation.clone()))
+    }
+
+    pub fn new_move_instantaneous_rewards_cert(move_instantaneous_rewards_cert: &MoveInstantaneousRewardsCert) -> Self {
+        Self(CertificateEnum::MoveInstantaneousRewardsCert(move_instantaneous_rewards_cert.clone()))
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum I0OrI1Enum {
+    I0,
+    I1,
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct I0OrI1(I0OrI1Enum);
+
+#[wasm_bindgen]
+impl I0OrI1 {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<I0OrI1, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new_i0() -> Self {
+        Self(I0OrI1Enum::I0)
+    }
+
+    pub fn new_i1() -> Self {
+        Self(I0OrI1Enum::I1)
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct MapStakeCredentialToCoin(std::collections::BTreeMap<StakeCredential, Coin>);
+
+#[wasm_bindgen]
+impl MapStakeCredentialToCoin {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<MapStakeCredentialToCoin, JsValue> {
         FromBytes::from_bytes(data)
     }
 
@@ -277,14 +599,17 @@ impl Withdrawals {
         self.0.len()
     }
 
-    pub fn insert(&mut self, key: StakeCredential, value: u32) -> Option<u32> {
-        self.0.insert(key, value)
+    pub fn insert(&mut self, key: &StakeCredential, value: Coin) -> Option<Coin> {
+        self.0.insert(key.clone(), value)
     }
 }
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct MoveInstantaneousReward(std::collections::BTreeMap<StakeCredential, u32>);
+pub struct MoveInstantaneousReward {
+    index_0: I0OrI1,
+    index_1: MapStakeCredentialToCoin,
+}
 
 #[wasm_bindgen]
 impl MoveInstantaneousReward {
@@ -296,131 +621,15 @@ impl MoveInstantaneousReward {
         FromBytes::from_bytes(data)
     }
 
-    pub fn new() -> Self {
-        Self(std::collections::BTreeMap::new())
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn insert(&mut self, key: StakeCredential, value: u32) -> Option<u32> {
-        self.0.insert(key, value)
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct SingleHostAddr {
-    port: Option<Port>,
-    ipv4: Option<Ipv4>,
-    ipv6: Option<Ipv6>,
-}
-
-#[wasm_bindgen]
-impl SingleHostAddr {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<SingleHostAddr, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new(port: Option<Port>, ipv4: Option<Ipv4>, ipv6: Option<Ipv6>) -> Self {
+    pub fn new(index_0: &I0OrI1, index_1: &MapStakeCredentialToCoin) -> Self {
         Self {
-            port: port,
-            ipv4: ipv4,
-            ipv6: ipv6,
+            index_0: index_0.clone(),
+            index_1: index_1.clone(),
         }
     }
 }
 
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct SingleHostName {
-    port: Option<Port>,
-    dns_name: DnsName,
-}
-
-#[wasm_bindgen]
-impl SingleHostName {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<SingleHostName, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new(port: Option<Port>, dns_name: DnsName) -> Self {
-        Self {
-            port: port,
-            dns_name: dns_name,
-        }
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct MultiHostName {
-    port: Option<Port>,
-    dns_name: DnsName,
-}
-
-#[wasm_bindgen]
-impl MultiHostName {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MultiHostName, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new(port: Option<Port>, dns_name: DnsName) -> Self {
-        Self {
-            port: port,
-            dns_name: dns_name,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-enum RelayEnum {
-    SingleHostAddr(SingleHostAddr),
-    SingleHostName(SingleHostName),
-    MultiHostName(MultiHostName),
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Relay(RelayEnum);
-
-#[wasm_bindgen]
-impl Relay {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<Relay, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new_single_host_addr(single_host_addr: SingleHostAddr) -> Self {
-        Self(RelayEnum::SingleHostAddr(single_host_addr))
-    }
-
-    pub fn new_single_host_name(single_host_name: SingleHostName) -> Self {
-        Self(RelayEnum::SingleHostName(single_host_name))
-    }
-
-    pub fn new_multi_host_name(multi_host_name: MultiHostName) -> Self {
-        Self(RelayEnum::MultiHostName(multi_host_name))
-    }
-}
-
-type Port = u32;
+type Port = u16;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -464,6 +673,115 @@ type DnsName = String;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct SingleHostAddr {
+    port: Option<Port>,
+    ipv4: Option<Ipv4>,
+    ipv6: Option<Ipv6>,
+}
+
+#[wasm_bindgen]
+impl SingleHostAddr {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<SingleHostAddr, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new(port: Option<Port>, ipv4: Option<Ipv4>, ipv6: Option<Ipv6>) -> Self {
+        Self {
+            port: port,
+            ipv4: ipv4.clone(),
+            ipv6: ipv6.clone(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct SingleHostName {
+    port: Option<Port>,
+    dns_name: DnsName,
+}
+
+#[wasm_bindgen]
+impl SingleHostName {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<SingleHostName, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new(port: Option<Port>, dns_name: DnsName) -> Self {
+        Self {
+            port: port,
+            dns_name: dns_name,
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct MultiHostName {
+    dns_name: DnsName,
+}
+
+#[wasm_bindgen]
+impl MultiHostName {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<MultiHostName, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new(dns_name: DnsName) -> Self {
+        Self {
+            dns_name: dns_name,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum RelayEnum {
+    SingleHostAddr(SingleHostAddr),
+    SingleHostName(SingleHostName),
+    MultiHostName(MultiHostName),
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Relay(RelayEnum);
+
+#[wasm_bindgen]
+impl Relay {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<Relay, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new_single_host_addr(single_host_addr: &SingleHostAddr) -> Self {
+        Self(RelayEnum::SingleHostAddr(single_host_addr.clone()))
+    }
+
+    pub fn new_single_host_name(single_host_name: &SingleHostName) -> Self {
+        Self(RelayEnum::SingleHostName(single_host_name.clone()))
+    }
+
+    pub fn new_multi_host_name(multi_host_name: &MultiHostName) -> Self {
+        Self(RelayEnum::MultiHostName(multi_host_name.clone()))
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct PoolMetadata {
     url: Url,
     metadata_hash: MetadataHash,
@@ -479,10 +797,10 @@ impl PoolMetadata {
         FromBytes::from_bytes(data)
     }
 
-    pub fn new(url: Url, metadata_hash: MetadataHash) -> Self {
+    pub fn new(url: Url, metadata_hash: &MetadataHash) -> Self {
         Self {
             url: url,
-            metadata_hash: metadata_hash,
+            metadata_hash: metadata_hash.clone(),
         }
     }
 }
@@ -491,81 +809,37 @@ type Url = String;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct StakeRegistration {
-    stake_credential: StakeCredential,
-}
+pub struct Withdrawals(std::collections::BTreeMap<RewardAccount, Coin>);
 
 #[wasm_bindgen]
-impl StakeRegistration {
+impl Withdrawals {
     pub fn to_bytes(&self) -> Vec<u8> {
         ToBytes::to_bytes(self)
     }
 
-    pub fn from_bytes(data: Vec<u8>) -> Result<StakeRegistration, JsValue> {
+    pub fn from_bytes(data: Vec<u8>) -> Result<Withdrawals, JsValue> {
         FromBytes::from_bytes(data)
     }
 
-    pub fn new(stake_credential: StakeCredential) -> Self {
-        Self {
-            stake_credential: stake_credential,
-        }
+    pub fn new() -> Self {
+        Self(std::collections::BTreeMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: &RewardAccount, value: Coin) -> Option<Coin> {
+        self.0.insert(key.clone(), value)
     }
 }
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct StakeDeregistration {
-    stake_credential: StakeCredential,
-}
+pub struct MultisigScripts(Vec<MultisigScript>);
 
 #[wasm_bindgen]
-impl StakeDeregistration {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<StakeDeregistration, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new(stake_credential: StakeCredential) -> Self {
-        Self {
-            stake_credential: stake_credential,
-        }
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct StakeDelegation {
-    stake_credential: StakeCredential,
-    pool_keyhash: PoolKeyHash,
-}
-
-#[wasm_bindgen]
-impl StakeDelegation {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<StakeDelegation, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new(stake_credential: StakeCredential, pool_keyhash: PoolKeyHash) -> Self {
-        Self {
-            stake_credential: stake_credential,
-            pool_keyhash: pool_keyhash,
-        }
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct AddrKeyHashes(Vec<AddrKeyHash>);
-
-#[wasm_bindgen]
-impl AddrKeyHashes {
+impl MultisigScripts {
     pub fn new() -> Self {
         Self(Vec::new())
     }
@@ -574,350 +848,12 @@ impl AddrKeyHashes {
         self.0.len()
     }
 
-    pub fn get(&self, index: usize) -> AddrKeyHash {
+    pub fn get(&self, index: usize) -> MultisigScript {
         self.0[index].clone()
     }
 
-    pub fn add(&mut self, elem: AddrKeyHash) {
-        self.0.push(elem);
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Relays(Vec<Relay>);
-
-#[wasm_bindgen]
-impl Relays {
-    pub fn new() -> Self {
-        Self(Vec::new())
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn get(&self, index: usize) -> Relay {
-        self.0[index].clone()
-    }
-
-    pub fn add(&mut self, elem: Relay) {
-        self.0.push(elem);
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct PoolParams {
-    operator: PoolKeyHash,
-    vrf_keyhash: VrfKeyHash,
-    pledge: Coin,
-    cost: Coin,
-    margin: UnitInterval,
-    reward_account: StakeCredential,
-    pool_owners: AddrKeyHashes,
-    relays: Relays,
-    pool_metadata: Option<PoolMetadata>,
-}
-
-#[wasm_bindgen]
-impl PoolParams {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<PoolParams, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new(operator: PoolKeyHash, vrf_keyhash: VrfKeyHash, pledge: Coin, cost: Coin, margin: UnitInterval, reward_account: StakeCredential, pool_owners: AddrKeyHashes, relays: Relays, pool_metadata: Option<PoolMetadata>) -> Self {
-        Self {
-            operator: operator,
-            vrf_keyhash: vrf_keyhash,
-            pledge: pledge,
-            cost: cost,
-            margin: margin,
-            reward_account: reward_account,
-            pool_owners: pool_owners,
-            relays: relays,
-            pool_metadata: pool_metadata,
-        }
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct PoolRegistration {
-    pool_params: PoolParams,
-}
-
-#[wasm_bindgen]
-impl PoolRegistration {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<PoolRegistration, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new(pool_params: PoolParams) -> Self {
-        Self {
-            pool_params: pool_params,
-        }
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct PoolRetirement {
-    pool_keyhash: PoolKeyHash,
-    epoch: u32,
-}
-
-#[wasm_bindgen]
-impl PoolRetirement {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<PoolRetirement, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new(pool_keyhash: PoolKeyHash, epoch: u32) -> Self {
-        Self {
-            pool_keyhash: pool_keyhash,
-            epoch: epoch,
-        }
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct GenesisKeyDelegation {
-    genesishash: GenesisHash,
-    genesis_delegate_hash: GenesisDelegateHash,
-}
-
-#[wasm_bindgen]
-impl GenesisKeyDelegation {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<GenesisKeyDelegation, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new(genesishash: GenesisHash, genesis_delegate_hash: GenesisDelegateHash) -> Self {
-        Self {
-            genesishash: genesishash,
-            genesis_delegate_hash: genesis_delegate_hash,
-        }
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct MoveInstantaneousRewardsCert {
-    move_instantaneous_reward: MoveInstantaneousReward,
-}
-
-#[wasm_bindgen]
-impl MoveInstantaneousRewardsCert {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MoveInstantaneousRewardsCert, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new(move_instantaneous_reward: MoveInstantaneousReward) -> Self {
-        Self {
-            move_instantaneous_reward: move_instantaneous_reward,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-enum CertificateEnum {
-    StakeRegistration(StakeRegistration),
-    StakeDeregistration(StakeDeregistration),
-    StakeDelegation(StakeDelegation),
-    PoolRegistration(PoolRegistration),
-    PoolRetirement(PoolRetirement),
-    GenesisKeyDelegation(GenesisKeyDelegation),
-    MoveInstantaneousRewardsCert(MoveInstantaneousRewardsCert),
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Certificate(CertificateEnum);
-
-#[wasm_bindgen]
-impl Certificate {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<Certificate, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn new_stake_registration(stake_registration: StakeRegistration) -> Self {
-        Self(CertificateEnum::StakeRegistration(stake_registration))
-    }
-
-    pub fn new_stake_deregistration(stake_deregistration: StakeDeregistration) -> Self {
-        Self(CertificateEnum::StakeDeregistration(stake_deregistration))
-    }
-
-    pub fn new_stake_delegation(stake_delegation: StakeDelegation) -> Self {
-        Self(CertificateEnum::StakeDelegation(stake_delegation))
-    }
-
-    pub fn new_pool_registration(pool_registration: PoolRegistration) -> Self {
-        Self(CertificateEnum::PoolRegistration(pool_registration))
-    }
-
-    pub fn new_pool_retirement(pool_retirement: PoolRetirement) -> Self {
-        Self(CertificateEnum::PoolRetirement(pool_retirement))
-    }
-
-    pub fn new_genesis_key_delegation(genesis_key_delegation: GenesisKeyDelegation) -> Self {
-        Self(CertificateEnum::GenesisKeyDelegation(genesis_key_delegation))
-    }
-
-    pub fn new_move_instantaneous_rewards_cert(move_instantaneous_rewards_cert: MoveInstantaneousRewardsCert) -> Self {
-        Self(CertificateEnum::MoveInstantaneousRewardsCert(move_instantaneous_rewards_cert))
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct TransactionInputs(Vec<TransactionInput>);
-
-#[wasm_bindgen]
-impl TransactionInputs {
-    pub fn new() -> Self {
-        Self(Vec::new())
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn get(&self, index: usize) -> TransactionInput {
-        self.0[index].clone()
-    }
-
-    pub fn add(&mut self, elem: TransactionInput) {
-        self.0.push(elem);
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct TransactionOutputs(Vec<TransactionOutput>);
-
-#[wasm_bindgen]
-impl TransactionOutputs {
-    pub fn new() -> Self {
-        Self(Vec::new())
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn get(&self, index: usize) -> TransactionOutput {
-        self.0[index].clone()
-    }
-
-    pub fn add(&mut self, elem: TransactionOutput) {
-        self.0.push(elem);
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Certificates(Vec<Certificate>);
-
-#[wasm_bindgen]
-impl Certificates {
-    pub fn new() -> Self {
-        Self(Vec::new())
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn get(&self, index: usize) -> Certificate {
-        self.0[index].clone()
-    }
-
-    pub fn add(&mut self, elem: Certificate) {
-        self.0.push(elem);
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct TransactionBody {
-    inputs: TransactionInputs,
-    outputs: TransactionOutputs,
-    fee: Coin,
-    ttl: u32,
-    certs: Option<Certificates>,
-    withdrawals: Option<Withdrawals>,
-    metadata_hash: Option<MetadataHash>,
-}
-
-#[wasm_bindgen]
-impl TransactionBody {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<TransactionBody, JsValue> {
-        FromBytes::from_bytes(data)
-    }
-
-    pub fn set_certs(&mut self, certs: Certificates) {
-        self.certs = Some(certs)
-    }
-
-    pub fn set_withdrawals(&mut self, withdrawals: Withdrawals) {
-        self.withdrawals = Some(withdrawals)
-    }
-    
-    pub fn set_metadata_hash(&mut self, metadata_hash: MetadataHash) {
-        self.metadata_hash = Some(metadata_hash)
-    }
-
-    pub fn new(inputs: TransactionInputs, outputs: TransactionOutputs, fee: Coin, ttl: u32) -> Self {
-        Self {
-            inputs,
-            outputs,
-            fee,
-            ttl,
-            certs: None,
-            withdrawals: None,
-            metadata_hash: None,
-        }
-    }
-
-    pub fn hash(&self) -> TransactionHash {
-        TransactionHash::from(crypto::blake2b256(self.to_bytes().as_ref()))
-    }
-
-    pub fn sign(&self, sk: &PrivateKey) -> Vkeywitness {
-        let tx_sign_data = self.hash();
-        let sig = sk.sign(tx_sign_data.0.as_ref());
-        Vkeywitness::new(Vkey::new(sk.to_public()), sig)
+    pub fn add(&mut self, elem: &MultisigScript) {
+        self.0.push(elem.clone());
     }
 }
 
@@ -926,6 +862,7 @@ impl TransactionBody {
 pub struct TransactionWitnessSet {
     vkeys: Option<Vkeywitnesses>,
     scripts: Option<MultisigScripts>,
+    bootstraps: Option<BootstrapWitnesses>,
 }
 
 #[wasm_bindgen]
@@ -938,22 +875,26 @@ impl TransactionWitnessSet {
         FromBytes::from_bytes(data)
     }
 
-    pub fn set_vkeys(&mut self, vkeys: Vkeywitnesses) {
-        self.vkeys = Some(vkeys)
+    pub fn set_vkeys(&mut self, vkeys: &Vkeywitnesses) {
+        self.vkeys = Some(vkeys.clone())
     }
 
-    pub fn set_scripts(&mut self, scripts: MultisigScripts) {
-        self.scripts = Some(scripts)
+    pub fn set_scripts(&mut self, scripts: &MultisigScripts) {
+        self.scripts = Some(scripts.clone())
+    }
+
+    pub fn set_bootstraps(&mut self, bootstraps: &BootstrapWitnesses) {
+        self.bootstraps = Some(bootstraps.clone())
     }
 
     pub fn new() -> Self {
         Self {
             vkeys: None,
             scripts: None,
+            bootstraps: None,
         }
     }
 }
-
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -977,8 +918,8 @@ impl MapTransactionMetadatumToTransactionMetadatum {
         self.0.len()
     }
 
-    pub fn insert(&mut self, key: TransactionMetadatum, value: TransactionMetadatum) -> Option<TransactionMetadatum> {
-        self.0.insert(key, value)
+    pub fn insert(&mut self, key: &TransactionMetadatum, value: &TransactionMetadatum) -> Option<TransactionMetadatum> {
+        self.0.insert(key.clone(), value.clone())
     }
 }
 
@@ -1000,8 +941,8 @@ impl TransactionMetadatums {
         self.0[index].clone()
     }
 
-    pub fn add(&mut self, elem: TransactionMetadatum) {
-        self.0.push(elem);
+    pub fn add(&mut self, elem: &TransactionMetadatum) {
+        self.0.push(elem.clone());
     }
 }
 
@@ -1028,16 +969,16 @@ impl TransactionMetadatum {
         FromBytes::from_bytes(data)
     }
 
-    pub fn new_map_transaction_metadatum_to_transaction_metadatum(map_transaction_metadatum_to_transaction_metadatum: MapTransactionMetadatumToTransactionMetadatum) -> Self {
-        Self(TransactionMetadatumEnum::MapTransactionMetadatumToTransactionMetadatum(map_transaction_metadatum_to_transaction_metadatum))
+    pub fn new_map_transaction_metadatum_to_transaction_metadatum(map_transaction_metadatum_to_transaction_metadatum: &MapTransactionMetadatumToTransactionMetadatum) -> Self {
+        Self(TransactionMetadatumEnum::MapTransactionMetadatumToTransactionMetadatum(map_transaction_metadatum_to_transaction_metadatum.clone()))
     }
 
-    pub fn new_arr_transaction_metadatum(arr_transaction_metadatum: TransactionMetadatums) -> Self {
-        Self(TransactionMetadatumEnum::ArrTransactionMetadatum(arr_transaction_metadatum))
+    pub fn new_arr_transaction_metadatum(arr_transaction_metadatum: &TransactionMetadatums) -> Self {
+        Self(TransactionMetadatumEnum::ArrTransactionMetadatum(arr_transaction_metadatum.clone()))
     }
 
-    pub fn new_int(int: Int) -> Self {
-        Self(TransactionMetadatumEnum::Int(int))
+    pub fn new_int(int: &Int) -> Self {
+        Self(TransactionMetadatumEnum::Int(int.clone()))
     }
 
     pub fn new_bytes(bytes: Vec<u8>) -> Self {
@@ -1049,7 +990,7 @@ impl TransactionMetadatum {
     }
 }
 
-type TransactionMetadadumLabel = u32;
+type TransactionMetadadumLabel = u64;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -1073,34 +1014,140 @@ impl TransactionMetadata {
         self.0.len()
     }
 
-    pub fn insert(&mut self, key: TransactionMetadadumLabel, value: TransactionMetadatum) -> Option<TransactionMetadatum> {
-        self.0.insert(key, value)
+    pub fn insert(&mut self, key: TransactionMetadadumLabel, value: &TransactionMetadatum) -> Option<TransactionMetadatum> {
+        self.0.insert(key, value.clone())
     }
 }
 
 #[wasm_bindgen]
-#[derive(Clone)]
-pub struct Transaction {
-    body: TransactionBody,
-    witness_set: TransactionWitnessSet,
-    metadata: Option<TransactionMetadata>,
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct MsigPubkey {
+    addr_keyhash: AddrKeyHash,
 }
 
 #[wasm_bindgen]
-impl Transaction {
+impl MsigPubkey {
     pub fn to_bytes(&self) -> Vec<u8> {
         ToBytes::to_bytes(self)
     }
 
-    pub fn from_bytes(data: Vec<u8>) -> Result<Transaction, JsValue> {
+    pub fn from_bytes(data: Vec<u8>) -> Result<MsigPubkey, JsValue> {
         FromBytes::from_bytes(data)
     }
 
-    pub fn new(body: TransactionBody, witness_set: TransactionWitnessSet, metadata: Option<TransactionMetadata>) -> Self {
+    pub fn new(addr_keyhash: &AddrKeyHash) -> Self {
         Self {
-            body,
-            witness_set,
-            metadata,
+            addr_keyhash: addr_keyhash.clone(),
         }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct MsigAll {
+    multisig_scripts: MultisigScripts,
+}
+
+#[wasm_bindgen]
+impl MsigAll {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<MsigAll, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new(multisig_scripts: &MultisigScripts) -> Self {
+        Self {
+            multisig_scripts: multisig_scripts.clone(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct MsigAny {
+    multisig_scripts: MultisigScripts,
+}
+
+#[wasm_bindgen]
+impl MsigAny {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<MsigAny, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new(multisig_scripts: &MultisigScripts) -> Self {
+        Self {
+            multisig_scripts: multisig_scripts.clone(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct MsigNOfK {
+    n: u32,
+    multisig_scripts: MultisigScripts,
+}
+
+#[wasm_bindgen]
+impl MsigNOfK {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<MsigNOfK, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new(n: u32, multisig_scripts: &MultisigScripts) -> Self {
+        Self {
+            n: n,
+            multisig_scripts: multisig_scripts.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum MultisigScriptEnum {
+    MsigPubkey(MsigPubkey),
+    MsigAll(MsigAll),
+    MsigAny(MsigAny),
+    MsigNOfK(MsigNOfK),
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct MultisigScript(MultisigScriptEnum);
+
+#[wasm_bindgen]
+impl MultisigScript {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(self)
+    }
+
+    pub fn from_bytes(data: Vec<u8>) -> Result<MultisigScript, JsValue> {
+        FromBytes::from_bytes(data)
+    }
+
+    pub fn new_msig_pubkey(addr_keyhash: &AddrKeyHash) -> Self {
+        Self(MultisigScriptEnum::MsigPubkey(MsigPubkey::new(addr_keyhash)))
+    }
+
+    pub fn new_msig_all(multisig_scripts: &MultisigScripts) -> Self {
+        Self(MultisigScriptEnum::MsigAll(MsigAll::new(multisig_scripts)))
+    }
+
+    pub fn new_msig_any(multisig_scripts: &MultisigScripts) -> Self {
+        Self(MultisigScriptEnum::MsigAny(MsigAny::new(multisig_scripts)))
+    }
+
+    pub fn new_msig_n_of_k(n: u32, multisig_scripts: &MultisigScripts) -> Self {
+        Self(MultisigScriptEnum::MsigNOfK(MsigNOfK::new(n, multisig_scripts)))
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -377,7 +377,7 @@ pub struct PoolParams {
     pledge: Coin,
     cost: Coin,
     margin: UnitInterval,
-    reward_account: RewardAccount,
+    reward_account: RewardAddress,
     pool_owners: AddrKeyHashes,
     relays: Relays,
     pool_metadata: Option<PoolMetadata>,
@@ -393,7 +393,7 @@ impl PoolParams {
         WasmFromBytes::from_bytes(data)
     }
 
-    pub fn new(operator: &PoolKeyHash, vrf_keyhash: &VRFKeyHash, pledge: Coin, cost: Coin, margin: &UnitInterval, reward_account: &RewardAccount, pool_owners: &AddrKeyHashes, relays: &Relays, pool_metadata: Option<PoolMetadata>) -> Self {
+    pub fn new(operator: &PoolKeyHash, vrf_keyhash: &VRFKeyHash, pledge: Coin, cost: Coin, margin: &UnitInterval, reward_account: &RewardAddress, pool_owners: &AddrKeyHashes, relays: &Relays, pool_metadata: Option<PoolMetadata>) -> Self {
         Self {
             operator: operator.clone(),
             vrf_keyhash: vrf_keyhash.clone(),
@@ -819,7 +819,7 @@ type Url = String;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Withdrawals(std::collections::BTreeMap<RewardAccount, Coin>);
+pub struct Withdrawals(std::collections::BTreeMap<RewardAddress, Coin>);
 
 #[wasm_bindgen]
 impl Withdrawals {
@@ -839,7 +839,7 @@ impl Withdrawals {
         self.0.len()
     }
 
-    pub fn insert(&mut self, key: &RewardAccount, value: Coin) -> Option<Coin> {
+    pub fn insert(&mut self, key: &RewardAddress, value: Coin) -> Option<Coin> {
         self.0.insert(key.clone(), value)
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -32,7 +32,7 @@ impl UnitInterval {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<UnitInterval, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(index_0: u64, index_1: u64) -> Self {
@@ -62,7 +62,7 @@ impl Transaction {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<Transaction, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(body: &TransactionBody, witness_set: &TransactionWitnessSet, metadata: Option<TransactionMetadata>) -> Self {
@@ -164,7 +164,7 @@ impl TransactionBody {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<TransactionBody, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn set_certs(&mut self, certs: &Certificates) {
@@ -206,7 +206,7 @@ impl TransactionInput {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<TransactionInput, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(transaction_id: &TransactionHash, index: u32) -> Self {
@@ -231,7 +231,7 @@ impl TransactionOutput {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<TransactionOutput, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(address: &Address, amount: Coin) -> Self {
@@ -255,7 +255,7 @@ impl StakeRegistration {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<StakeRegistration, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(stake_credential: &StakeCredential) -> Self {
@@ -278,7 +278,7 @@ impl StakeDeregistration {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<StakeDeregistration, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(stake_credential: &StakeCredential) -> Self {
@@ -302,7 +302,7 @@ impl StakeDelegation {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<StakeDelegation, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(stake_credential: &StakeCredential, pool_keyhash: &PoolKeyHash) -> Self {
@@ -380,7 +380,7 @@ impl PoolParams {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<PoolParams, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(operator: &PoolKeyHash, vrf_keyhash: &VRFKeyHash, pledge: Coin, cost: Coin, margin: &UnitInterval, reward_account: &RewardAccount, pool_owners: &AddrKeyHashes, relays: &Relays, pool_metadata: Option<PoolMetadata>) -> Self {
@@ -411,7 +411,7 @@ impl PoolRegistration {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<PoolRegistration, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(pool_params: &PoolParams) -> Self {
@@ -435,7 +435,7 @@ impl PoolRetirement {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<PoolRetirement, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(pool_keyhash: &PoolKeyHash, epoch: Epoch) -> Self {
@@ -460,7 +460,7 @@ impl GenesisKeyDelegation {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<GenesisKeyDelegation, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(genesishash: &GenesisHash, genesis_delegate_hash: &GenesisDelegateHash) -> Self {
@@ -484,7 +484,7 @@ impl MoveInstantaneousRewardsCert {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<MoveInstantaneousRewardsCert, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(move_instantaneous_reward: &MoveInstantaneousReward) -> Self {
@@ -516,7 +516,7 @@ impl Certificate {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<Certificate, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new_stake_registration(stake_registration: &StakeRegistration) -> Self {
@@ -565,7 +565,7 @@ impl I0OrI1 {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<I0OrI1, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new_i0() -> Self {
@@ -588,7 +588,7 @@ impl MapStakeCredentialToCoin {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<MapStakeCredentialToCoin, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new() -> Self {
@@ -618,7 +618,7 @@ impl MoveInstantaneousReward {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<MoveInstantaneousReward, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(index_0: &I0OrI1, index_1: &MapStakeCredentialToCoin) -> Self {
@@ -642,7 +642,7 @@ impl Ipv4 {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<Ipv4, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(data: Vec<u8>) -> Self {
@@ -661,7 +661,7 @@ impl Ipv6 {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<Ipv6, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(data: Vec<u8>) -> Self {
@@ -686,7 +686,7 @@ impl SingleHostAddr {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<SingleHostAddr, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(port: Option<Port>, ipv4: Option<Ipv4>, ipv6: Option<Ipv6>) -> Self {
@@ -712,7 +712,7 @@ impl SingleHostName {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<SingleHostName, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(port: Option<Port>, dns_name: DnsName) -> Self {
@@ -736,7 +736,7 @@ impl MultiHostName {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<MultiHostName, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(dns_name: DnsName) -> Self {
@@ -764,7 +764,7 @@ impl Relay {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<Relay, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new_single_host_addr(single_host_addr: &SingleHostAddr) -> Self {
@@ -794,7 +794,7 @@ impl PoolMetadata {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<PoolMetadata, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(url: Url, metadata_hash: &MetadataHash) -> Self {
@@ -818,7 +818,7 @@ impl Withdrawals {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<Withdrawals, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new() -> Self {
@@ -872,7 +872,7 @@ impl TransactionWitnessSet {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<TransactionWitnessSet, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn set_vkeys(&mut self, vkeys: &Vkeywitnesses) {
@@ -907,7 +907,7 @@ impl MapTransactionMetadatumToTransactionMetadatum {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<MapTransactionMetadatumToTransactionMetadatum, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new() -> Self {
@@ -966,7 +966,7 @@ impl TransactionMetadatum {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<TransactionMetadatum, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new_map_transaction_metadatum_to_transaction_metadatum(map_transaction_metadatum_to_transaction_metadatum: &MapTransactionMetadatumToTransactionMetadatum) -> Self {
@@ -1003,7 +1003,7 @@ impl TransactionMetadata {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<TransactionMetadata, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new() -> Self {
@@ -1032,7 +1032,7 @@ impl MsigPubkey {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<MsigPubkey, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(addr_keyhash: &AddrKeyHash) -> Self {
@@ -1055,7 +1055,7 @@ impl MsigAll {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<MsigAll, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(multisig_scripts: &MultisigScripts) -> Self {
@@ -1078,7 +1078,7 @@ impl MsigAny {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<MsigAny, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(multisig_scripts: &MultisigScripts) -> Self {
@@ -1102,7 +1102,7 @@ impl MsigNOfK {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<MsigNOfK, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new(n: u32, multisig_scripts: &MultisigScripts) -> Self {
@@ -1132,7 +1132,7 @@ impl MultisigScript {
     }
 
     pub fn from_bytes(data: Vec<u8>) -> Result<MultisigScript, JsValue> {
-        FromBytes::from_bytes(data)
+        WasmFromBytes::from_bytes(data)
     }
 
     pub fn new_msig_pubkey(addr_keyhash: &AddrKeyHash) -> Self {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -11,6 +11,7 @@ use cbor_event::Special as CBORSpecial;
 pub mod address;
 pub mod crypto;
 pub mod fees;
+#[macro_use]
 pub mod prelude;
 pub mod serialization;
 
@@ -25,16 +26,10 @@ pub struct UnitInterval {
     index_1: u64,
 }
 
+to_from_bytes!(UnitInterval);
+
 #[wasm_bindgen]
 impl UnitInterval {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<UnitInterval, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(index_0: u64, index_1: u64) -> Self {
         Self {
             index_0: index_0,
@@ -55,16 +50,10 @@ pub struct Transaction {
     metadata: Option<TransactionMetadata>,
 }
 
+to_from_bytes!(Transaction);
+
 #[wasm_bindgen]
 impl Transaction {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<Transaction, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(body: &TransactionBody, witness_set: &TransactionWitnessSet, metadata: Option<TransactionMetadata>) -> Self {
         Self {
             body: body.clone(),
@@ -79,6 +68,8 @@ type TransactionIndex = u32;
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct TransactionInputs(Vec<TransactionInput>);
+
+to_from_bytes!(TransactionInputs);
 
 #[wasm_bindgen]
 impl TransactionInputs {
@@ -103,6 +94,8 @@ impl TransactionInputs {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct TransactionOutputs(Vec<TransactionOutput>);
 
+to_from_bytes!(TransactionOutputs);
+
 #[wasm_bindgen]
 impl TransactionOutputs {
     pub fn new() -> Self {
@@ -125,6 +118,8 @@ impl TransactionOutputs {
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Certificates(Vec<Certificate>);
+
+to_from_bytes!(Certificates);
 
 #[wasm_bindgen]
 impl Certificates {
@@ -157,16 +152,10 @@ pub struct TransactionBody {
     metadata_hash: Option<MetadataHash>,
 }
 
+to_from_bytes!(TransactionBody);
+
 #[wasm_bindgen]
 impl TransactionBody {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<TransactionBody, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn set_certs(&mut self, certs: &Certificates) {
         self.certs = Some(certs.clone())
     }
@@ -209,16 +198,10 @@ pub struct TransactionInput {
     index: u32,
 }
 
+to_from_bytes!(TransactionInput);
+
 #[wasm_bindgen]
 impl TransactionInput {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<TransactionInput, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(transaction_id: &TransactionHash, index: u32) -> Self {
         Self {
             transaction_id: transaction_id.clone(),
@@ -234,16 +217,10 @@ pub struct TransactionOutput {
     amount: Coin,
 }
 
+to_from_bytes!(TransactionOutput);
+
 #[wasm_bindgen]
 impl TransactionOutput {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<TransactionOutput, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(address: &Address, amount: Coin) -> Self {
         Self {
             address: address.clone(),
@@ -258,16 +235,10 @@ pub struct StakeRegistration {
     stake_credential: StakeCredential,
 }
 
+to_from_bytes!(StakeRegistration);
+
 #[wasm_bindgen]
 impl StakeRegistration {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<StakeRegistration, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(stake_credential: &StakeCredential) -> Self {
         Self {
             stake_credential: stake_credential.clone(),
@@ -281,16 +252,10 @@ pub struct StakeDeregistration {
     stake_credential: StakeCredential,
 }
 
+to_from_bytes!(StakeDeregistration);
+
 #[wasm_bindgen]
 impl StakeDeregistration {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<StakeDeregistration, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(stake_credential: &StakeCredential) -> Self {
         Self {
             stake_credential: stake_credential.clone(),
@@ -305,16 +270,10 @@ pub struct StakeDelegation {
     pool_keyhash: PoolKeyHash,
 }
 
+to_from_bytes!(StakeDelegation);
+
 #[wasm_bindgen]
 impl StakeDelegation {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<StakeDelegation, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(stake_credential: &StakeCredential, pool_keyhash: &PoolKeyHash) -> Self {
         Self {
             stake_credential: stake_credential.clone(),
@@ -326,6 +285,8 @@ impl StakeDelegation {
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct AddrKeyHashes(Vec<AddrKeyHash>);
+
+to_from_bytes!(AddrKeyHashes);
 
 #[wasm_bindgen]
 impl AddrKeyHashes {
@@ -349,6 +310,8 @@ impl AddrKeyHashes {
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Relays(Vec<Relay>);
+
+to_from_bytes!(Relays);
 
 #[wasm_bindgen]
 impl Relays {
@@ -383,16 +346,10 @@ pub struct PoolParams {
     pool_metadata: Option<PoolMetadata>,
 }
 
+to_from_bytes!(PoolParams);
+
 #[wasm_bindgen]
 impl PoolParams {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<PoolParams, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(operator: &PoolKeyHash, vrf_keyhash: &VRFKeyHash, pledge: Coin, cost: Coin, margin: &UnitInterval, reward_account: &RewardAddress, pool_owners: &AddrKeyHashes, relays: &Relays, pool_metadata: Option<PoolMetadata>) -> Self {
         Self {
             operator: operator.clone(),
@@ -414,16 +371,10 @@ pub struct PoolRegistration {
     pool_params: PoolParams,
 }
 
+to_from_bytes!(PoolRegistration);
+
 #[wasm_bindgen]
 impl PoolRegistration {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<PoolRegistration, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(pool_params: &PoolParams) -> Self {
         Self {
             pool_params: pool_params.clone(),
@@ -438,16 +389,10 @@ pub struct PoolRetirement {
     epoch: Epoch,
 }
 
+to_from_bytes!(PoolRetirement);
+
 #[wasm_bindgen]
 impl PoolRetirement {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<PoolRetirement, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(pool_keyhash: &PoolKeyHash, epoch: Epoch) -> Self {
         Self {
             pool_keyhash: pool_keyhash.clone(),
@@ -463,16 +408,10 @@ pub struct GenesisKeyDelegation {
     genesis_delegate_hash: GenesisDelegateHash,
 }
 
+to_from_bytes!(GenesisKeyDelegation);
+
 #[wasm_bindgen]
 impl GenesisKeyDelegation {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<GenesisKeyDelegation, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(genesishash: &GenesisHash, genesis_delegate_hash: &GenesisDelegateHash) -> Self {
         Self {
             genesishash: genesishash.clone(),
@@ -487,16 +426,10 @@ pub struct MoveInstantaneousRewardsCert {
     move_instantaneous_reward: MoveInstantaneousReward,
 }
 
+to_from_bytes!(MoveInstantaneousRewardsCert);
+
 #[wasm_bindgen]
 impl MoveInstantaneousRewardsCert {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MoveInstantaneousRewardsCert, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(move_instantaneous_reward: &MoveInstantaneousReward) -> Self {
         Self {
             move_instantaneous_reward: move_instantaneous_reward.clone(),
@@ -519,16 +452,10 @@ enum CertificateEnum {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Certificate(CertificateEnum);
 
+to_from_bytes!(Certificate);
+
 #[wasm_bindgen]
 impl Certificate {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<Certificate, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new_stake_registration(stake_registration: &StakeRegistration) -> Self {
         Self(CertificateEnum::StakeRegistration(stake_registration.clone()))
     }
@@ -570,14 +497,6 @@ pub struct I0OrI1(I0OrI1Enum);
 
 #[wasm_bindgen]
 impl I0OrI1 {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<I0OrI1, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new_i0() -> Self {
         Self(I0OrI1Enum::I0)
     }
@@ -591,16 +510,10 @@ impl I0OrI1 {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct MapStakeCredentialToCoin(std::collections::BTreeMap<StakeCredential, Coin>);
 
+to_from_bytes!(MapStakeCredentialToCoin);
+
 #[wasm_bindgen]
 impl MapStakeCredentialToCoin {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MapStakeCredentialToCoin, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new() -> Self {
         Self(std::collections::BTreeMap::new())
     }
@@ -621,16 +534,10 @@ pub struct MoveInstantaneousReward {
     index_1: MapStakeCredentialToCoin,
 }
 
+to_from_bytes!(MoveInstantaneousReward);
+
 #[wasm_bindgen]
 impl MoveInstantaneousReward {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MoveInstantaneousReward, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(index_0: &I0OrI1, index_1: &MapStakeCredentialToCoin) -> Self {
         Self {
             index_0: index_0.clone(),
@@ -645,16 +552,10 @@ type Port = u16;
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Ipv4(Vec<u8>);
 
+to_from_bytes!(Ipv4);
+
 #[wasm_bindgen]
 impl Ipv4 {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<Ipv4, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(data: Vec<u8>) -> Self {
         Self(data)
     }
@@ -664,16 +565,10 @@ impl Ipv4 {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Ipv6(Vec<u8>);
 
+to_from_bytes!(Ipv6);
+
 #[wasm_bindgen]
 impl Ipv6 {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<Ipv6, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(data: Vec<u8>) -> Self {
         Self(data)
     }
@@ -689,16 +584,10 @@ pub struct SingleHostAddr {
     ipv6: Option<Ipv6>,
 }
 
+to_from_bytes!(SingleHostAddr);
+
 #[wasm_bindgen]
 impl SingleHostAddr {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<SingleHostAddr, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(port: Option<Port>, ipv4: Option<Ipv4>, ipv6: Option<Ipv6>) -> Self {
         Self {
             port: port,
@@ -715,16 +604,10 @@ pub struct SingleHostName {
     dns_name: DnsName,
 }
 
+to_from_bytes!(SingleHostName);
+
 #[wasm_bindgen]
 impl SingleHostName {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<SingleHostName, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(port: Option<Port>, dns_name: DnsName) -> Self {
         Self {
             port: port,
@@ -739,16 +622,10 @@ pub struct MultiHostName {
     dns_name: DnsName,
 }
 
+to_from_bytes!(MultiHostName);
+
 #[wasm_bindgen]
 impl MultiHostName {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MultiHostName, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(dns_name: DnsName) -> Self {
         Self {
             dns_name: dns_name,
@@ -767,16 +644,10 @@ enum RelayEnum {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Relay(RelayEnum);
 
+to_from_bytes!(Relay);
+
 #[wasm_bindgen]
 impl Relay {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<Relay, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new_single_host_addr(single_host_addr: &SingleHostAddr) -> Self {
         Self(RelayEnum::SingleHostAddr(single_host_addr.clone()))
     }
@@ -797,16 +668,10 @@ pub struct PoolMetadata {
     metadata_hash: MetadataHash,
 }
 
+to_from_bytes!(PoolMetadata);
+
 #[wasm_bindgen]
 impl PoolMetadata {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<PoolMetadata, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(url: Url, metadata_hash: &MetadataHash) -> Self {
         Self {
             url: url,
@@ -821,16 +686,10 @@ type Url = String;
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Withdrawals(std::collections::BTreeMap<RewardAddress, Coin>);
 
+to_from_bytes!(Withdrawals);
+
 #[wasm_bindgen]
 impl Withdrawals {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<Withdrawals, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new() -> Self {
         Self(std::collections::BTreeMap::new())
     }
@@ -847,6 +706,8 @@ impl Withdrawals {
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct MultisigScripts(Vec<MultisigScript>);
+
+to_from_bytes!(MultisigScripts);
 
 #[wasm_bindgen]
 impl MultisigScripts {
@@ -875,16 +736,10 @@ pub struct TransactionWitnessSet {
     bootstraps: Option<BootstrapWitnesses>,
 }
 
+to_from_bytes!(TransactionWitnessSet);
+
 #[wasm_bindgen]
 impl TransactionWitnessSet {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<TransactionWitnessSet, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn set_vkeys(&mut self, vkeys: &Vkeywitnesses) {
         self.vkeys = Some(vkeys.clone())
     }
@@ -910,16 +765,10 @@ impl TransactionWitnessSet {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct MapTransactionMetadatumToTransactionMetadatum(std::collections::BTreeMap<TransactionMetadatum, TransactionMetadatum>);
 
+to_from_bytes!(MapTransactionMetadatumToTransactionMetadatum);
+
 #[wasm_bindgen]
 impl MapTransactionMetadatumToTransactionMetadatum {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MapTransactionMetadatumToTransactionMetadatum, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new() -> Self {
         Self(std::collections::BTreeMap::new())
     }
@@ -936,6 +785,8 @@ impl MapTransactionMetadatumToTransactionMetadatum {
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct TransactionMetadatums(Vec<TransactionMetadatum>);
+
+to_from_bytes!(TransactionMetadatums);
 
 #[wasm_bindgen]
 impl TransactionMetadatums {
@@ -969,16 +820,10 @@ enum TransactionMetadatumEnum {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct TransactionMetadatum(TransactionMetadatumEnum);
 
+to_from_bytes!(TransactionMetadatum);
+
 #[wasm_bindgen]
 impl TransactionMetadatum {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<TransactionMetadatum, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new_map_transaction_metadatum_to_transaction_metadatum(map_transaction_metadatum_to_transaction_metadatum: &MapTransactionMetadatumToTransactionMetadatum) -> Self {
         Self(TransactionMetadatumEnum::MapTransactionMetadatumToTransactionMetadatum(map_transaction_metadatum_to_transaction_metadatum.clone()))
     }
@@ -1006,16 +851,10 @@ type TransactionMetadadumLabel = u64;
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct TransactionMetadata(std::collections::BTreeMap<TransactionMetadadumLabel, TransactionMetadatum>);
 
+to_from_bytes!(TransactionMetadata);
+
 #[wasm_bindgen]
 impl TransactionMetadata {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<TransactionMetadata, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new() -> Self {
         Self(std::collections::BTreeMap::new())
     }
@@ -1035,16 +874,10 @@ pub struct MsigPubkey {
     addr_keyhash: AddrKeyHash,
 }
 
+to_from_bytes!(MsigPubkey);
+
 #[wasm_bindgen]
 impl MsigPubkey {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MsigPubkey, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(addr_keyhash: &AddrKeyHash) -> Self {
         Self {
             addr_keyhash: addr_keyhash.clone(),
@@ -1058,16 +891,10 @@ pub struct MsigAll {
     multisig_scripts: MultisigScripts,
 }
 
+to_from_bytes!(MsigAll);
+
 #[wasm_bindgen]
 impl MsigAll {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MsigAll, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(multisig_scripts: &MultisigScripts) -> Self {
         Self {
             multisig_scripts: multisig_scripts.clone(),
@@ -1081,16 +908,10 @@ pub struct MsigAny {
     multisig_scripts: MultisigScripts,
 }
 
+to_from_bytes!(MsigAny);
+
 #[wasm_bindgen]
 impl MsigAny {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MsigAny, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(multisig_scripts: &MultisigScripts) -> Self {
         Self {
             multisig_scripts: multisig_scripts.clone(),
@@ -1105,16 +926,10 @@ pub struct MsigNOfK {
     multisig_scripts: MultisigScripts,
 }
 
+to_from_bytes!(MsigNOfK);
+
 #[wasm_bindgen]
 impl MsigNOfK {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MsigNOfK, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new(n: u32, multisig_scripts: &MultisigScripts) -> Self {
         Self {
             n: n,
@@ -1135,16 +950,10 @@ enum MultisigScriptEnum {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct MultisigScript(MultisigScriptEnum);
 
+to_from_bytes!(MultisigScript);
+
 #[wasm_bindgen]
 impl MultisigScript {
-    pub fn to_bytes(&self) -> Vec<u8> {
-        ToBytes::to_bytes(self)
-    }
-
-    pub fn from_bytes(data: Vec<u8>) -> Result<MultisigScript, JsValue> {
-        WasmFromBytes::from_bytes(data)
-    }
-
     pub fn new_msig_pubkey(addr_keyhash: &AddrKeyHash) -> Self {
         Self(MultisigScriptEnum::MsigPubkey(MsigPubkey::new(addr_keyhash)))
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -190,6 +190,16 @@ impl TransactionBody {
             metadata_hash: None,
         }
     }
+
+    pub fn hash(&self) -> TransactionHash {
+        TransactionHash::from(crypto::blake2b256(self.to_bytes().as_ref()))
+    }
+
+    pub fn sign(&self, sk: &PrivateKey) -> Vkeywitness {
+        let tx_sign_data = self.hash();
+        let sig = sk.sign(tx_sign_data.0.as_ref());
+        Vkeywitness::new(&Vkey::new(&sk.to_public()), &sig)
+    }
 }
 
 #[wasm_bindgen]

--- a/rust/src/serialization.rs
+++ b/rust/src/serialization.rs
@@ -683,7 +683,7 @@ impl DeserializeEmbeddedGroup for PoolParams {
             Ok(UnitInterval::deserialize(raw)?)
         })().map_err(|e| e.annotate("margin"))?;
         let reward_account = (|| -> Result<_, DeserializeError> {
-            Ok(RewardAccount::deserialize(raw)?)
+            Ok(RewardAddress::deserialize(raw)?)
         })().map_err(|e| e.annotate("reward_account"))?;
         let pool_owners = (|| -> Result<_, DeserializeError> {
             Ok(AddrKeyHashes::deserialize(raw)?)
@@ -1530,7 +1530,7 @@ impl Deserialize for Withdrawals {
                     assert_eq!(raw.special()?, CBORSpecial::Break);
                     break;
                 }
-                let key = RewardAccount::deserialize(raw)?;
+                let key = RewardAddress::deserialize(raw)?;
                 let value = Coin::deserialize(raw)?;
                 if table.insert(key.clone(), value).is_some() {
                     return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());

--- a/rust/src/serialization.rs
+++ b/rust/src/serialization.rs
@@ -1,5 +1,6 @@
 use super::*;
 use address::*;
+use crypto::*;
 use std::io::{Seek, SeekFrom};
 
 // This file was code-generated using an experimental CDDL to rust tool:
@@ -8,17 +9,8 @@ use std::io::{Seek, SeekFrom};
 impl cbor_event::se::Serialize for UnitInterval {
     fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer.write_tag(30u64)?;
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for UnitInterval {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Primitive(U32)
+        serializer.write_array(cbor_event::Len::Len(2))?;
         self.index_0.serialize(serializer)?;
-        // DEBUG - generated from: Primitive(U32)
         self.index_1.serialize(serializer)?;
         Ok(serializer)
     }
@@ -48,589 +40,25 @@ impl Deserialize for UnitInterval {
 impl DeserializeEmbeddedGroup for UnitInterval {
     fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
         let index_0 = (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            Ok(u32::deserialize(raw)?)
+            Ok(u64::deserialize(raw)?)
         })().map_err(|e| e.annotate("index_0"))?;
         let index_1 = (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_1");
-            Ok(u32::deserialize(raw)?)
+            Ok(u64::deserialize(raw)?)
         })().map_err(|e| e.annotate("index_1"))?;
-        Ok(UnitInterval::new(index_0, index_1))
+        Ok(UnitInterval {
+            index_0,
+            index_1,
+        })
     }
 }
 
-impl cbor_event::se::Serialize for MsigPubkey {
+impl cbor_event::se::Serialize for Transaction {
     fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for MsigPubkey {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Fixed(Uint(0))
-        serializer.write_unsigned_integer(0u64)?;
-        // DEBUG - generated from: Rust(RustIdent("Hash28"))
-        self.addr_keyhash.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for MsigPubkey {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("MsigPubkey"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for MsigPubkey {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            let index_0_value = raw.unsigned_integer()?;
-            if index_0_value != 0 {
-                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(0) }.into());
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("index_0"))?;
-        let addr_keyhash = (|| -> Result<_, DeserializeError> {
-            println!("deserializing addr_keyhash");
-            Ok(AddrKeyHash::deserialize(raw)?)
-        })().map_err(|e| e.annotate("addr_keyhash"))?;
-        Ok(MsigPubkey::new(addr_keyhash))
-    }
-}
-
-impl cbor_event::se::Serialize for MultisigScripts {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Len(self.0.len() as u64))?;
-        for element in &self.0 {
-            element.serialize(serializer)?;
-        }
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for MultisigScripts {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let mut arr = Vec::new();
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            while match len { cbor_event::Len::Len(n) => arr.len() < n as usize, cbor_event::Len::Indefinite => true, } {
-                if raw.cbor_type()? == CBORType::Special {
-                    assert_eq!(raw.special()?, CBORSpecial::Break);
-                    break;
-                }
-                println!("deserializing MultisigScripts");
-                arr.push(MultisigScript::deserialize(raw)?);
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("MultisigScripts"))?;
-        Ok(Self(arr))
-    }
-}
-
-impl cbor_event::se::Serialize for MsigAll {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for MsigAll {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Fixed(Uint(1))
-        serializer.write_unsigned_integer(1u64)?;
-        // DEBUG - generated from: Array(Rust(RustIdent("MultisigScript")))
-        self.multisig_scripts.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for MsigAll {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("MsigAll"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for MsigAll {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            let index_0_value = raw.unsigned_integer()?;
-            if index_0_value != 1 {
-                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("index_0"))?;
-        let multisig_scripts = (|| -> Result<_, DeserializeError> {
-            println!("deserializing multisig_scripts");
-            Ok(MultisigScripts::deserialize(raw)?)
-        })().map_err(|e| e.annotate("multisig_scripts"))?;
-        Ok(MsigAll::new(multisig_scripts))
-    }
-}
-
-impl cbor_event::se::Serialize for MsigAny {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for MsigAny {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Fixed(Uint(2))
-        serializer.write_unsigned_integer(2u64)?;
-        // DEBUG - generated from: Array(Rust(RustIdent("MultisigScript")))
-        self.multisig_scripts.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for MsigAny {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("MsigAny"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for MsigAny {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            let index_0_value = raw.unsigned_integer()?;
-            if index_0_value != 2 {
-                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(2) }.into());
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("index_0"))?;
-        let multisig_scripts = (|| -> Result<_, DeserializeError> {
-            println!("deserializing multisig_scripts");
-            Ok(MultisigScripts::deserialize(raw)?)
-        })().map_err(|e| e.annotate("multisig_scripts"))?;
-        Ok(MsigAny::new(multisig_scripts))
-    }
-}
-
-impl cbor_event::se::Serialize for MsigNOfK {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for MsigNOfK {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Fixed(Uint(3))
-        serializer.write_unsigned_integer(3u64)?;
-        // DEBUG - generated from: Primitive(U32)
-        self.n.serialize(serializer)?;
-        // DEBUG - generated from: Array(Rust(RustIdent("MultisigScript")))
-        self.multisig_scripts.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for MsigNOfK {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("MsigNOfK"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for MsigNOfK {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            let index_0_value = raw.unsigned_integer()?;
-            if index_0_value != 3 {
-                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(3) }.into());
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("index_0"))?;
-        let n = (|| -> Result<_, DeserializeError> {
-            println!("deserializing n");
-            Ok(u32::deserialize(raw)?)
-        })().map_err(|e| e.annotate("n"))?;
-        let multisig_scripts = (|| -> Result<_, DeserializeError> {
-            println!("deserializing multisig_scripts");
-            Ok(MultisigScripts::deserialize(raw)?)
-        })().map_err(|e| e.annotate("multisig_scripts"))?;
-        Ok(MsigNOfK::new(n, multisig_scripts))
-    }
-}
-
-impl cbor_event::se::Serialize for MultisigScriptEnum {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for MultisigScriptEnum {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        match self {
-            MultisigScriptEnum::MsigPubkey(x) => {
-                // DEBUG - generated from: Rust(RustIdent("MsigPubkey"))
-                x.serialize(serializer)
-            },
-            MultisigScriptEnum::MsigAll(x) => {
-                // DEBUG - generated from: Rust(RustIdent("MsigAll"))
-                x.serialize(serializer)
-            },
-            MultisigScriptEnum::MsigAny(x) => {
-                // DEBUG - generated from: Rust(RustIdent("MsigAny"))
-                x.serialize(serializer)
-            },
-            MultisigScriptEnum::MsigNOfK(x) => {
-                // DEBUG - generated from: Rust(RustIdent("MsigNOfK"))
-                x.serialize(serializer)
-            },
-        }
-    }
-}
-
-impl Deserialize for MultisigScriptEnum {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("MultisigScriptEnum"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for MultisigScriptEnum {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
-        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-            println!("deserializing msig_pubkey");
-            Ok(MsigPubkey::deserialize(raw)?)
-        })(raw)
-        {
-            Ok(variant) => return Ok(MultisigScriptEnum::MsigPubkey(variant)),
-            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-        };
-        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-            println!("deserializing msig_all");
-            Ok(MsigAll::deserialize(raw)?)
-        })(raw)
-        {
-            Ok(variant) => return Ok(MultisigScriptEnum::MsigAll(variant)),
-            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-        };
-        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-            println!("deserializing msig_any");
-            Ok(MsigAny::deserialize(raw)?)
-        })(raw)
-        {
-            Ok(variant) => return Ok(MultisigScriptEnum::MsigAny(variant)),
-            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-        };
-        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-            println!("deserializing msig_n_of_k");
-            Ok(MsigNOfK::deserialize(raw)?)
-        })(raw)
-        {
-            Ok(variant) => return Ok(MultisigScriptEnum::MsigNOfK(variant)),
-            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-        };
-        Err(DeserializeError::new("MultisigScriptEnum", DeserializeFailure::NoVariantMatched.into()))
-    }
-}
-
-impl cbor_event::se::Serialize for MultisigScript {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for MultisigScript {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        self.0.serialize_as_embedded_group(serializer)
-    }
-}
-
-impl Deserialize for MultisigScript {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        Ok(Self(MultisigScriptEnum::deserialize(raw)?))
-    }
-}
-
-impl cbor_event::se::Serialize for TransactionInput {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for TransactionInput {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Rust(RustIdent("Hash32"))
-        self.transaction_id.serialize(serializer)?;
-        // DEBUG - generated from: Primitive(U32)
-        self.index.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for TransactionInput {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("TransactionInput"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for TransactionInput {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        let transaction_id = (|| -> Result<_, DeserializeError> {
-            println!("deserializing transaction_id");
-            Ok(TransactionHash::deserialize(raw)?)
-        })().map_err(|e| e.annotate("transaction_id"))?;
-        let index = (|| -> Result<_, DeserializeError> {
-            println!("deserializing index");
-            Ok(u32::deserialize(raw)?)
-        })().map_err(|e| e.annotate("index"))?;
-        Ok(TransactionInput::new(transaction_id, index))
-    }
-}
-
-impl cbor_event::se::Serialize for TransactionOutput {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for TransactionOutput {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Rust(RustIdent("Address"))
-        self.address.serialize(serializer)?;
-        // DEBUG - generated from: Primitive(U32)
-        self.amount.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for TransactionOutput {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("TransactionOutput"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for TransactionOutput {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        let address = (|| -> Result<_, DeserializeError> {
-            println!("deserializing address");
-            Ok(Address::deserialize(raw)?)
-        })().map_err(|e| e.annotate("address"))?;
-        let amount = (|| -> Result<_, DeserializeError> {
-            println!("deserializing amount");
-            Ok(Coin::deserialize(raw)?)
-        })().map_err(|e| e.annotate("amount"))?;
-        Ok(TransactionOutput::new(address, amount))
-    }
-}
-
-impl cbor_event::se::Serialize for Withdrawals {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_map(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for Withdrawals {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        for (key, value) in &self.0 {
-            // DEBUG - generated from: Rust(RustIdent("StakeCredential"))
-            key.serialize(serializer)?;
-            // DEBUG - generated from: Primitive(U32)
-            value.serialize(serializer)?;
-        }
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for Withdrawals {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let mut table = std::collections::BTreeMap::new();
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.map()?;
-            while match len { cbor_event::Len::Len(n) => table.len() < n as usize, cbor_event::Len::Indefinite => true, } {
-                if raw.cbor_type()? == CBORType::Special {
-                    assert_eq!(raw.special()?, CBORSpecial::Break);
-                    break;
-                }
-                println!("deserializing key");
-                let key = StakeCredential::deserialize(raw)?;
-                println!("deserializing value");
-                let value = u32::deserialize(raw)?;
-                if table.insert(key.clone(), value).is_some() {
-                    return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
-                }
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("Withdrawals"))?;
-        Ok(Self(table))
-    }
-}
-
-impl cbor_event::se::Serialize for MoveInstantaneousReward {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_map(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for MoveInstantaneousReward {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        for (key, value) in &self.0 {
-            // DEBUG - generated from: Rust(RustIdent("StakeCredential"))
-            key.serialize(serializer)?;
-            // DEBUG - generated from: Primitive(U32)
-            value.serialize(serializer)?;
-        }
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for MoveInstantaneousReward {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let mut table = std::collections::BTreeMap::new();
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.map()?;
-            while match len { cbor_event::Len::Len(n) => table.len() < n as usize, cbor_event::Len::Indefinite => true, } {
-                if raw.cbor_type()? == CBORType::Special {
-                    assert_eq!(raw.special()?, CBORSpecial::Break);
-                    break;
-                }
-                println!("deserializing key");
-                let key = StakeCredential::deserialize(raw)?;
-                println!("deserializing value");
-                let value = u32::deserialize(raw)?;
-                if table.insert(key.clone(), value).is_some() {
-                    return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
-                }
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("MoveInstantaneousReward"))?;
-        Ok(Self(table))
-    }
-}
-
-impl cbor_event::se::Serialize for SingleHostAddr {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for SingleHostAddr {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Fixed(Uint(0))
-        serializer.write_unsigned_integer(0u64)?;
-        // DEBUG - generated from: Optional(Rust(RustIdent("Port")))
-        match &self.port {
+        serializer.write_array(cbor_event::Len::Len(3))?;
+        self.body.serialize(serializer)?;
+        self.witness_set.serialize(serializer)?;
+        match &self.metadata {
             Some(x) => {
-                // DEBUG - generated from: Rust(RustIdent("Port"))
-                x.serialize(serializer)
-            },
-            None => serializer.write_special(CBORSpecial::Null),
-        }?;
-        // DEBUG - generated from: Optional(Rust(RustIdent("Ipv4")))
-        match &self.ipv4 {
-            Some(x) => {
-                // DEBUG - generated from: Rust(RustIdent("Ipv4"))
-                x.serialize(serializer)
-            },
-            None => serializer.write_special(CBORSpecial::Null),
-        }?;
-        // DEBUG - generated from: Optional(Rust(RustIdent("Ipv6")))
-        match &self.ipv6 {
-            Some(x) => {
-                // DEBUG - generated from: Rust(RustIdent("Ipv6"))
                 x.serialize(serializer)
             },
             None => serializer.write_special(CBORSpecial::Null),
@@ -639,7 +67,7 @@ impl SerializeEmbeddedGroup for SingleHostAddr {
     }
 }
 
-impl Deserialize for SingleHostAddr {
+impl Deserialize for Transaction {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
         (|| -> Result<_, DeserializeError> {
             let len = raw.array()?;
@@ -652,1085 +80,36 @@ impl Deserialize for SingleHostAddr {
                 },
             }
             ret
-        })().map_err(|e| e.annotate("SingleHostAddr"))
+        })().map_err(|e| e.annotate("Transaction"))
     }
 }
 
-impl DeserializeEmbeddedGroup for SingleHostAddr {
+impl DeserializeEmbeddedGroup for Transaction {
     fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            let index_0_value = raw.unsigned_integer()?;
-            if index_0_value != 0 {
-                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(0) }.into());
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("index_0"))?;
-        let port = (|| -> Result<_, DeserializeError> {
-            println!("deserializing port");
+        let body = (|| -> Result<_, DeserializeError> {
+            Ok(TransactionBody::deserialize(raw)?)
+        })().map_err(|e| e.annotate("body"))?;
+        let witness_set = (|| -> Result<_, DeserializeError> {
+            Ok(TransactionWitnessSet::deserialize(raw)?)
+        })().map_err(|e| e.annotate("witness_set"))?;
+        let metadata = (|| -> Result<_, DeserializeError> {
             Ok(match raw.cbor_type()? != CBORType::Special {
                 true => {
-                    println!("deserializing port");
-                    Some(Port::deserialize(raw)?)
+                    Some(TransactionMetadata::deserialize(raw)?)
                 },
                 false => {
-                    println!("deserializing port");
                     if raw.special()? != CBORSpecial::Null {
                         return Err(DeserializeFailure::ExpectedNull.into());
                     }
                     None
                 }
             })
-        })().map_err(|e| e.annotate("port"))?;
-        let ipv4 = (|| -> Result<_, DeserializeError> {
-            println!("deserializing ipv4");
-            Ok(match raw.cbor_type()? != CBORType::Special {
-                true => {
-                    println!("deserializing ipv4");
-                    Some(Ipv4::deserialize(raw)?)
-                },
-                false => {
-                    println!("deserializing ipv4");
-                    if raw.special()? != CBORSpecial::Null {
-                        return Err(DeserializeFailure::ExpectedNull.into());
-                    }
-                    None
-                }
-            })
-        })().map_err(|e| e.annotate("ipv4"))?;
-        let ipv6 = (|| -> Result<_, DeserializeError> {
-            println!("deserializing ipv6");
-            Ok(match raw.cbor_type()? != CBORType::Special {
-                true => {
-                    println!("deserializing ipv6");
-                    Some(Ipv6::deserialize(raw)?)
-                },
-                false => {
-                    println!("deserializing ipv6");
-                    if raw.special()? != CBORSpecial::Null {
-                        return Err(DeserializeFailure::ExpectedNull.into());
-                    }
-                    None
-                }
-            })
-        })().map_err(|e| e.annotate("ipv6"))?;
-        Ok(SingleHostAddr::new(port, ipv4, ipv6))
-    }
-}
-
-impl cbor_event::se::Serialize for SingleHostName {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for SingleHostName {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Fixed(Uint(1))
-        serializer.write_unsigned_integer(1u64)?;
-        // DEBUG - generated from: Optional(Rust(RustIdent("Port")))
-        match &self.port {
-            Some(x) => {
-                // DEBUG - generated from: Rust(RustIdent("Port"))
-                x.serialize(serializer)
-            },
-            None => serializer.write_special(CBORSpecial::Null),
-        }?;
-        // DEBUG - generated from: Rust(RustIdent("DnsName"))
-        self.dns_name.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for SingleHostName {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("SingleHostName"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for SingleHostName {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            let index_0_value = raw.unsigned_integer()?;
-            if index_0_value != 1 {
-                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("index_0"))?;
-        let port = (|| -> Result<_, DeserializeError> {
-            println!("deserializing port");
-            Ok(match raw.cbor_type()? != CBORType::Special {
-                true => {
-                    println!("deserializing port");
-                    Some(Port::deserialize(raw)?)
-                },
-                false => {
-                    println!("deserializing port");
-                    if raw.special()? != CBORSpecial::Null {
-                        return Err(DeserializeFailure::ExpectedNull.into());
-                    }
-                    None
-                }
-            })
-        })().map_err(|e| e.annotate("port"))?;
-        let dns_name = (|| -> Result<_, DeserializeError> {
-            println!("deserializing dns_name");
-            Ok(DnsName::deserialize(raw)?)
-        })().map_err(|e| e.annotate("dns_name"))?;
-        Ok(SingleHostName::new(port, dns_name))
-    }
-}
-
-impl cbor_event::se::Serialize for MultiHostName {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for MultiHostName {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Fixed(Uint(2))
-        serializer.write_unsigned_integer(2u64)?;
-        // DEBUG - generated from: Optional(Rust(RustIdent("Port")))
-        match &self.port {
-            Some(x) => {
-                // DEBUG - generated from: Rust(RustIdent("Port"))
-                x.serialize(serializer)
-            },
-            None => serializer.write_special(CBORSpecial::Null),
-        }?;
-        // DEBUG - generated from: Rust(RustIdent("DnsName"))
-        self.dns_name.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for MultiHostName {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("MultiHostName"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for MultiHostName {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            let index_0_value = raw.unsigned_integer()?;
-            if index_0_value != 2 {
-                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(2) }.into());
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("index_0"))?;
-        let port = (|| -> Result<_, DeserializeError> {
-            println!("deserializing port");
-            Ok(match raw.cbor_type()? != CBORType::Special {
-                true => {
-                    println!("deserializing port");
-                    Some(Port::deserialize(raw)?)
-                },
-                false => {
-                    println!("deserializing port");
-                    if raw.special()? != CBORSpecial::Null {
-                        return Err(DeserializeFailure::ExpectedNull.into());
-                    }
-                    None
-                }
-            })
-        })().map_err(|e| e.annotate("port"))?;
-        let dns_name = (|| -> Result<_, DeserializeError> {
-            println!("deserializing dns_name");
-            Ok(DnsName::deserialize(raw)?)
-        })().map_err(|e| e.annotate("dns_name"))?;
-        Ok(MultiHostName::new(port, dns_name))
-    }
-}
-
-impl cbor_event::se::Serialize for RelayEnum {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for RelayEnum {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        match self {
-            RelayEnum::SingleHostAddr(x) => x.serialize_as_embedded_group(serializer),
-            RelayEnum::SingleHostName(x) => x.serialize_as_embedded_group(serializer),
-            RelayEnum::MultiHostName(x) => x.serialize_as_embedded_group(serializer),
-        }
-    }
-}
-
-impl Deserialize for RelayEnum {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("RelayEnum"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for RelayEnum {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
-        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-            println!("deserializing single_host_addr");
-            Ok(SingleHostAddr::deserialize_as_embedded_group(raw, len)?)
-        })(raw)
-        {
-            Ok(variant) => return Ok(RelayEnum::SingleHostAddr(variant)),
-            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-        };
-        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-            println!("deserializing single_host_name");
-            Ok(SingleHostName::deserialize_as_embedded_group(raw, len)?)
-        })(raw)
-        {
-            Ok(variant) => return Ok(RelayEnum::SingleHostName(variant)),
-            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-        };
-        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-            println!("deserializing multi_host_name");
-            Ok(MultiHostName::deserialize_as_embedded_group(raw, len)?)
-        })(raw)
-        {
-            Ok(variant) => return Ok(RelayEnum::MultiHostName(variant)),
-            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-        };
-        Err(DeserializeError::new("RelayEnum", DeserializeFailure::NoVariantMatched.into()))
-    }
-}
-
-impl cbor_event::se::Serialize for Relay {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for Relay {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        self.0.serialize_as_embedded_group(serializer)
-    }
-}
-
-impl Deserialize for Relay {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        Ok(Self(RelayEnum::deserialize(raw)?))
-    }
-}
-
-impl cbor_event::se::Serialize for Ipv4 {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Primitive(Bytes)
-        serializer.write_bytes(&self.0)
-    }
-}
-
-impl Deserialize for Ipv4 {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        println!("deserializing ");
-        Ok(Self(raw.bytes()?))
-    }
-}
-
-impl cbor_event::se::Serialize for Ipv6 {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Primitive(Bytes)
-        serializer.write_bytes(&self.0)
-    }
-}
-
-impl Deserialize for Ipv6 {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        println!("deserializing ");
-        Ok(Self(raw.bytes()?))
-    }
-}
-
-impl cbor_event::se::Serialize for PoolMetadata {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for PoolMetadata {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Rust(RustIdent("Url"))
-        self.url.serialize(serializer)?;
-        // DEBUG - generated from: Rust(RustIdent("Hash32"))
-        self.metadata_hash.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for PoolMetadata {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("PoolMetadata"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for PoolMetadata {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        let url = (|| -> Result<_, DeserializeError> {
-            println!("deserializing url");
-            Ok(Url::deserialize(raw)?)
-        })().map_err(|e| e.annotate("url"))?;
-        let metadata_hash = (|| -> Result<_, DeserializeError> {
-            println!("deserializing metadata_hash");
-            Ok(MetadataHash::deserialize(raw)?)
-        })().map_err(|e| e.annotate("metadata_hash"))?;
-        Ok(PoolMetadata::new(url, metadata_hash))
-    }
-}
-
-impl cbor_event::se::Serialize for StakeRegistration {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for StakeRegistration {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Fixed(Uint(0))
-        serializer.write_unsigned_integer(0u64)?;
-        // DEBUG - generated from: Rust(RustIdent("StakeCredential"))
-        self.stake_credential.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for StakeRegistration {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("StakeRegistration"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for StakeRegistration {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            let index_0_value = raw.unsigned_integer()?;
-            if index_0_value != 0 {
-                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(0) }.into());
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("index_0"))?;
-        let stake_credential = (|| -> Result<_, DeserializeError> {
-            println!("deserializing stake_credential");
-            Ok(StakeCredential::deserialize(raw)?)
-        })().map_err(|e| e.annotate("stake_credential"))?;
-        Ok(StakeRegistration::new(stake_credential))
-    }
-}
-
-impl cbor_event::se::Serialize for StakeDeregistration {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for StakeDeregistration {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Fixed(Uint(1))
-        serializer.write_unsigned_integer(1u64)?;
-        // DEBUG - generated from: Rust(RustIdent("StakeCredential"))
-        self.stake_credential.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for StakeDeregistration {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("StakeDeregistration"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for StakeDeregistration {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            let index_0_value = raw.unsigned_integer()?;
-            if index_0_value != 1 {
-                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("index_0"))?;
-        let stake_credential = (|| -> Result<_, DeserializeError> {
-            println!("deserializing stake_credential");
-            Ok(StakeCredential::deserialize(raw)?)
-        })().map_err(|e| e.annotate("stake_credential"))?;
-        Ok(StakeDeregistration::new(stake_credential))
-    }
-}
-
-impl cbor_event::se::Serialize for StakeDelegation {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for StakeDelegation {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Fixed(Uint(2))
-        serializer.write_unsigned_integer(2u64)?;
-        // DEBUG - generated from: Rust(RustIdent("StakeCredential"))
-        self.stake_credential.serialize(serializer)?;
-        // DEBUG - generated from: Rust(RustIdent("Hash32"))
-        self.pool_keyhash.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for StakeDelegation {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("StakeDelegation"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for StakeDelegation {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            let index_0_value = raw.unsigned_integer()?;
-            if index_0_value != 2 {
-                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(2) }.into());
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("index_0"))?;
-        let stake_credential = (|| -> Result<_, DeserializeError> {
-            println!("deserializing stake_credential");
-            Ok(StakeCredential::deserialize(raw)?)
-        })().map_err(|e| e.annotate("stake_credential"))?;
-        let pool_keyhash = (|| -> Result<_, DeserializeError> {
-            println!("deserializing pool_keyhash");
-            Ok(PoolKeyHash::deserialize(raw)?)
-        })().map_err(|e| e.annotate("pool_keyhash"))?;
-        Ok(StakeDelegation::new(stake_credential, pool_keyhash))
-    }
-}
-
-impl cbor_event::se::Serialize for AddrKeyHashes {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Len(self.0.len() as u64))?;
-        for element in &self.0 {
-            element.serialize(serializer)?;
-        }
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for AddrKeyHashes {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let mut arr = Vec::new();
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            while match len { cbor_event::Len::Len(n) => arr.len() < n as usize, cbor_event::Len::Indefinite => true, } {
-                if raw.cbor_type()? == CBORType::Special {
-                    assert_eq!(raw.special()?, CBORSpecial::Break);
-                    break;
-                }
-                println!("deserializing AddrKeyHashes");
-                arr.push(AddrKeyHash::deserialize(raw)?);
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("AddrKeyHashes"))?;
-        Ok(Self(arr))
-    }
-}
-
-impl cbor_event::se::Serialize for Relays {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Len(self.0.len() as u64))?;
-        for element in &self.0 {
-            element.serialize(serializer)?;
-        }
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for Relays {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let mut arr = Vec::new();
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            while match len { cbor_event::Len::Len(n) => arr.len() < n as usize, cbor_event::Len::Indefinite => true, } {
-                if raw.cbor_type()? == CBORType::Special {
-                    assert_eq!(raw.special()?, CBORSpecial::Break);
-                    break;
-                }
-                println!("deserializing Relays");
-                arr.push(Relay::deserialize(raw)?);
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("Relays"))?;
-        Ok(Self(arr))
-    }
-}
-
-impl cbor_event::se::Serialize for PoolParams {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for PoolParams {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Rust(RustIdent("Hash32"))
-        self.operator.serialize(serializer)?;
-        // DEBUG - generated from: Rust(RustIdent("Hash32"))
-        self.vrf_keyhash.serialize(serializer)?;
-        // DEBUG - generated from: Primitive(U32)
-        self.pledge.serialize(serializer)?;
-        // DEBUG - generated from: Primitive(U32)
-        self.cost.serialize(serializer)?;
-        // DEBUG - generated from: Rust(RustIdent("UnitInterval"))
-        self.margin.serialize(serializer)?;
-        // DEBUG - generated from: Rust(RustIdent("StakeCredential"))
-        self.reward_account.serialize(serializer)?;
-        // DEBUG - generated from: Array(Rust(RustIdent("Hash28")))
-        self.pool_owners.serialize(serializer)?;
-        // DEBUG - generated from: Array(Rust(RustIdent("Relay")))
-        self.relays.serialize(serializer)?;
-        // DEBUG - generated from: Optional(Rust(RustIdent("PoolMetadata")))
-        match &self.pool_metadata {
-            Some(x) => {
-                // DEBUG - generated from: Rust(RustIdent("PoolMetadata"))
-                x.serialize(serializer)
-            },
-            None => serializer.write_special(CBORSpecial::Null),
-        }?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for PoolParams {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("PoolParams"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for PoolParams {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        let operator = (|| -> Result<_, DeserializeError> {
-            println!("deserializing operator");
-            Ok(PoolKeyHash::deserialize(raw)?)
-        })().map_err(|e| e.annotate("operator"))?;
-        let vrf_keyhash = (|| -> Result<_, DeserializeError> {
-            println!("deserializing vrf_keyhash");
-            Ok(VrfKeyHash::deserialize(raw)?)
-        })().map_err(|e| e.annotate("vrf_keyhash"))?;
-        let pledge = (|| -> Result<_, DeserializeError> {
-            println!("deserializing pledge");
-            Ok(Coin::deserialize(raw)?)
-        })().map_err(|e| e.annotate("pledge"))?;
-        let cost = (|| -> Result<_, DeserializeError> {
-            println!("deserializing cost");
-            Ok(Coin::deserialize(raw)?)
-        })().map_err(|e| e.annotate("cost"))?;
-        let margin = (|| -> Result<_, DeserializeError> {
-            println!("deserializing margin");
-            Ok(UnitInterval::deserialize(raw)?)
-        })().map_err(|e| e.annotate("margin"))?;
-        let reward_account = (|| -> Result<_, DeserializeError> {
-            println!("deserializing reward_account");
-            Ok(StakeCredential::deserialize(raw)?)
-        })().map_err(|e| e.annotate("reward_account"))?;
-        let pool_owners = (|| -> Result<_, DeserializeError> {
-            println!("deserializing pool_owners");
-            Ok(AddrKeyHashes::deserialize(raw)?)
-        })().map_err(|e| e.annotate("pool_owners"))?;
-        let relays = (|| -> Result<_, DeserializeError> {
-            println!("deserializing relays");
-            Ok(Relays::deserialize(raw)?)
-        })().map_err(|e| e.annotate("relays"))?;
-        let pool_metadata = (|| -> Result<_, DeserializeError> {
-            println!("deserializing pool_metadata");
-            Ok(match raw.cbor_type()? != CBORType::Special {
-                true => {
-                    println!("deserializing pool_metadata");
-                    Some(PoolMetadata::deserialize(raw)?)
-                },
-                false => {
-                    println!("deserializing pool_metadata");
-                    if raw.special()? != CBORSpecial::Null {
-                        return Err(DeserializeFailure::ExpectedNull.into());
-                    }
-                    None
-                }
-            })
-        })().map_err(|e| e.annotate("pool_metadata"))?;
-        Ok(PoolParams::new(operator, vrf_keyhash, pledge, cost, margin, reward_account, pool_owners, relays, pool_metadata))
-    }
-}
-
-impl cbor_event::se::Serialize for PoolRegistration {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for PoolRegistration {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Fixed(Uint(3))
-        serializer.write_unsigned_integer(3u64)?;
-        // DEBUG - generated from: Rust(RustIdent("PoolParams"))
-        self.pool_params.serialize_as_embedded_group(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for PoolRegistration {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("PoolRegistration"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for PoolRegistration {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            let index_0_value = raw.unsigned_integer()?;
-            if index_0_value != 3 {
-                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(3) }.into());
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("index_0"))?;
-        let pool_params = (|| -> Result<_, DeserializeError> {
-            println!("deserializing pool_params");
-            Ok(PoolParams::deserialize_as_embedded_group(raw, len)?)
-        })().map_err(|e| e.annotate("pool_params"))?;
-        Ok(PoolRegistration::new(pool_params))
-    }
-}
-
-impl cbor_event::se::Serialize for PoolRetirement {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for PoolRetirement {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Fixed(Uint(4))
-        serializer.write_unsigned_integer(4u64)?;
-        // DEBUG - generated from: Rust(RustIdent("Hash32"))
-        self.pool_keyhash.serialize(serializer)?;
-        // DEBUG - generated from: Primitive(U32)
-        self.epoch.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for PoolRetirement {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("PoolRetirement"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for PoolRetirement {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            let index_0_value = raw.unsigned_integer()?;
-            if index_0_value != 4 {
-                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(4) }.into());
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("index_0"))?;
-        let pool_keyhash = (|| -> Result<_, DeserializeError> {
-            println!("deserializing pool_keyhash");
-            Ok(PoolKeyHash::deserialize(raw)?)
-        })().map_err(|e| e.annotate("pool_keyhash"))?;
-        let epoch = (|| -> Result<_, DeserializeError> {
-            println!("deserializing epoch");
-            Ok(u32::deserialize(raw)?)
-        })().map_err(|e| e.annotate("epoch"))?;
-        Ok(PoolRetirement::new(pool_keyhash, epoch))
-    }
-}
-
-impl cbor_event::se::Serialize for GenesisKeyDelegation {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for GenesisKeyDelegation {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Fixed(Uint(5))
-        serializer.write_unsigned_integer(5u64)?;
-        // DEBUG - generated from: Rust(RustIdent("Hash32"))
-        self.genesishash.serialize(serializer)?;
-        // DEBUG - generated from: Rust(RustIdent("Hash32"))
-        self.genesis_delegate_hash.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for GenesisKeyDelegation {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("GenesisKeyDelegation"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for GenesisKeyDelegation {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            let index_0_value = raw.unsigned_integer()?;
-            if index_0_value != 5 {
-                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(5) }.into());
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("index_0"))?;
-        let genesishash = (|| -> Result<_, DeserializeError> {
-            println!("deserializing genesishash");
-            Ok(GenesisHash::deserialize(raw)?)
-        })().map_err(|e| e.annotate("genesishash"))?;
-        let genesis_delegate_hash = (|| -> Result<_, DeserializeError> {
-            println!("deserializing genesis_delegate_hash");
-            Ok(GenesisDelegateHash::deserialize(raw)?)
-        })().map_err(|e| e.annotate("genesis_delegate_hash"))?;
-        Ok(GenesisKeyDelegation::new(genesishash, genesis_delegate_hash))
-    }
-}
-
-impl cbor_event::se::Serialize for MoveInstantaneousRewardsCert {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for MoveInstantaneousRewardsCert {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        // DEBUG - generated from: Fixed(Uint(6))
-        serializer.write_unsigned_integer(6u64)?;
-        // DEBUG - generated from: Rust(RustIdent("MoveInstantaneousReward"))
-        self.move_instantaneous_reward.serialize(serializer)?;
-        Ok(serializer)
-    }
-}
-
-impl Deserialize for MoveInstantaneousRewardsCert {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("MoveInstantaneousRewardsCert"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for MoveInstantaneousRewardsCert {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            println!("deserializing index_0");
-            let index_0_value = raw.unsigned_integer()?;
-            if index_0_value != 6 {
-                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(6) }.into());
-            }
-            Ok(())
-        })().map_err(|e| e.annotate("index_0"))?;
-        let move_instantaneous_reward = (|| -> Result<_, DeserializeError> {
-            println!("deserializing move_instantaneous_reward");
-            Ok(MoveInstantaneousReward::deserialize(raw)?)
-        })().map_err(|e| e.annotate("move_instantaneous_reward"))?;
-        Ok(MoveInstantaneousRewardsCert::new(move_instantaneous_reward))
-    }
-}
-
-impl cbor_event::se::Serialize for CertificateEnum {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for CertificateEnum {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        match self {
-            CertificateEnum::StakeRegistration(x) => {
-                // DEBUG - generated from: Rust(RustIdent("StakeRegistration"))
-                x.serialize(serializer)
-            },
-            CertificateEnum::StakeDeregistration(x) => {
-                // DEBUG - generated from: Rust(RustIdent("StakeDeregistration"))
-                x.serialize(serializer)
-            },
-            CertificateEnum::StakeDelegation(x) => {
-                // DEBUG - generated from: Rust(RustIdent("StakeDelegation"))
-                x.serialize(serializer)
-            },
-            CertificateEnum::PoolRegistration(x) => {
-                // DEBUG - generated from: Rust(RustIdent("PoolRegistration"))
-                x.serialize(serializer)
-            },
-            CertificateEnum::PoolRetirement(x) => {
-                // DEBUG - generated from: Rust(RustIdent("PoolRetirement"))
-                x.serialize(serializer)
-            },
-            CertificateEnum::GenesisKeyDelegation(x) => {
-                // DEBUG - generated from: Rust(RustIdent("GenesisKeyDelegation"))
-                x.serialize(serializer)
-            },
-            CertificateEnum::MoveInstantaneousRewardsCert(x) => {
-                // DEBUG - generated from: Rust(RustIdent("MoveInstantaneousRewardsCert"))
-                x.serialize(serializer)
-            },
-        }
-    }
-}
-
-impl Deserialize for CertificateEnum {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let len = raw.array()?;
-            let ret = Self::deserialize_as_embedded_group(raw, len);
-            match len {
-                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
-                cbor_event::Len::Indefinite => match raw.special()? {
-                    CBORSpecial::Break => /* it's ok */(),
-                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
-                },
-            }
-            ret
-        })().map_err(|e| e.annotate("CertificateEnum"))
-    }
-}
-
-impl DeserializeEmbeddedGroup for CertificateEnum {
-    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
-        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-            println!("deserializing stake_registration");
-            Ok(StakeRegistration::deserialize(raw)?)
-        })(raw)
-        {
-            Ok(variant) => return Ok(CertificateEnum::StakeRegistration(variant)),
-            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-        };
-        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-            println!("deserializing stake_deregistration");
-            Ok(StakeDeregistration::deserialize(raw)?)
-        })(raw)
-        {
-            Ok(variant) => return Ok(CertificateEnum::StakeDeregistration(variant)),
-            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-        };
-        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-            println!("deserializing stake_delegation");
-            Ok(StakeDelegation::deserialize(raw)?)
-        })(raw)
-        {
-            Ok(variant) => return Ok(CertificateEnum::StakeDelegation(variant)),
-            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-        };
-        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-            println!("deserializing pool_registration");
-            Ok(PoolRegistration::deserialize(raw)?)
-        })(raw)
-        {
-            Ok(variant) => return Ok(CertificateEnum::PoolRegistration(variant)),
-            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-        };
-        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-            println!("deserializing pool_retirement");
-            Ok(PoolRetirement::deserialize(raw)?)
-        })(raw)
-        {
-            Ok(variant) => return Ok(CertificateEnum::PoolRetirement(variant)),
-            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-        };
-        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-            println!("deserializing genesis_key_delegation");
-            Ok(GenesisKeyDelegation::deserialize(raw)?)
-        })(raw)
-        {
-            Ok(variant) => return Ok(CertificateEnum::GenesisKeyDelegation(variant)),
-            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-        };
-        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-            println!("deserializing move_instantaneous_rewards_cert");
-            Ok(MoveInstantaneousRewardsCert::deserialize(raw)?)
-        })(raw)
-        {
-            Ok(variant) => return Ok(CertificateEnum::MoveInstantaneousRewardsCert(variant)),
-            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-        };
-        Err(DeserializeError::new("CertificateEnum", DeserializeFailure::NoVariantMatched.into()))
-    }
-}
-
-impl cbor_event::se::Serialize for Certificate {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for Certificate {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        self.0.serialize_as_embedded_group(serializer)
-    }
-}
-
-impl Deserialize for Certificate {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        Ok(Self(CertificateEnum::deserialize(raw)?))
+        })().map_err(|e| e.annotate("metadata"))?;
+        Ok(Transaction {
+            body,
+            witness_set,
+            metadata,
+        })
     }
 }
 
@@ -1754,7 +133,6 @@ impl Deserialize for TransactionInputs {
                     assert_eq!(raw.special()?, CBORSpecial::Break);
                     break;
                 }
-                println!("deserializing TransactionInputs");
                 arr.push(TransactionInput::deserialize(raw)?);
             }
             Ok(())
@@ -1783,7 +161,6 @@ impl Deserialize for TransactionOutputs {
                     assert_eq!(raw.special()?, CBORSpecial::Break);
                     break;
                 }
-                println!("deserializing TransactionOutputs");
                 arr.push(TransactionOutput::deserialize(raw)?);
             }
             Ok(())
@@ -1812,7 +189,6 @@ impl Deserialize for Certificates {
                     assert_eq!(raw.special()?, CBORSpecial::Break);
                     break;
                 }
-                println!("deserializing Certificates");
                 arr.push(Certificate::deserialize(raw)?);
             }
             Ok(())
@@ -1823,39 +199,25 @@ impl Deserialize for Certificates {
 
 impl cbor_event::se::Serialize for TransactionBody {
     fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_map(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for TransactionBody {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map(cbor_event::Len::Len(4 + match &self.certs { Some(x) => 1, None => 0 } + match &self.withdrawals { Some(x) => 1, None => 0 } + match &self.metadata_hash { Some(x) => 1, None => 0 }))?;
         serializer.write_unsigned_integer(0)?;
-        // DEBUG - generated from: Array(Rust(RustIdent("TransactionInput")))
         self.inputs.serialize(serializer)?;
         serializer.write_unsigned_integer(1)?;
-        // DEBUG - generated from: Array(Rust(RustIdent("TransactionOutput")))
         self.outputs.serialize(serializer)?;
         serializer.write_unsigned_integer(2)?;
-        // DEBUG - generated from: Primitive(U32)
         self.fee.serialize(serializer)?;
         serializer.write_unsigned_integer(3)?;
-        // DEBUG - generated from: Primitive(U32)
         self.ttl.serialize(serializer)?;
         if let Some(field) = &self.certs {
             serializer.write_unsigned_integer(4)?;
-            // DEBUG - generated from: Array(Rust(RustIdent("Certificate")))
             field.serialize(serializer)?;
         }
         if let Some(field) = &self.withdrawals {
             serializer.write_unsigned_integer(5)?;
-            // DEBUG - generated from: Rust(RustIdent("Withdrawals"))
             field.serialize(serializer)?;
         }
         if let Some(field) = &self.metadata_hash {
             serializer.write_unsigned_integer(7)?;
-            // DEBUG - generated from: Rust(RustIdent("MetadataHash"))
             field.serialize(serializer)?;
         }
         Ok(serializer)
@@ -1889,7 +251,6 @@ impl DeserializeEmbeddedGroup for TransactionBody {
                             return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
                         }
                         inputs = Some((|| -> Result<_, DeserializeError> {
-                            println!("deserializing inputs");
                             Ok(TransactionInputs::deserialize(raw)?)
                         })().map_err(|e| e.annotate("inputs"))?);
                     },
@@ -1898,7 +259,6 @@ impl DeserializeEmbeddedGroup for TransactionBody {
                             return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
                         }
                         outputs = Some((|| -> Result<_, DeserializeError> {
-                            println!("deserializing outputs");
                             Ok(TransactionOutputs::deserialize(raw)?)
                         })().map_err(|e| e.annotate("outputs"))?);
                     },
@@ -1907,7 +267,6 @@ impl DeserializeEmbeddedGroup for TransactionBody {
                             return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
                         }
                         fee = Some((|| -> Result<_, DeserializeError> {
-                            println!("deserializing fee");
                             Ok(Coin::deserialize(raw)?)
                         })().map_err(|e| e.annotate("fee"))?);
                     },
@@ -1916,7 +275,6 @@ impl DeserializeEmbeddedGroup for TransactionBody {
                             return Err(DeserializeFailure::DuplicateKey(Key::Uint(3)).into());
                         }
                         ttl = Some((|| -> Result<_, DeserializeError> {
-                            println!("deserializing ttl");
                             Ok(u32::deserialize(raw)?)
                         })().map_err(|e| e.annotate("ttl"))?);
                     },
@@ -1925,7 +283,6 @@ impl DeserializeEmbeddedGroup for TransactionBody {
                             return Err(DeserializeFailure::DuplicateKey(Key::Uint(4)).into());
                         }
                         certs = Some((|| -> Result<_, DeserializeError> {
-                            println!("deserializing certs");
                             Ok(Certificates::deserialize(raw)?)
                         })().map_err(|e| e.annotate("certs"))?);
                     },
@@ -1934,7 +291,6 @@ impl DeserializeEmbeddedGroup for TransactionBody {
                             return Err(DeserializeFailure::DuplicateKey(Key::Uint(5)).into());
                         }
                         withdrawals = Some((|| -> Result<_, DeserializeError> {
-                            println!("deserializing withdrawals");
                             Ok(Withdrawals::deserialize(raw)?)
                         })().map_err(|e| e.annotate("withdrawals"))?);
                     },
@@ -1990,24 +346,1243 @@ impl DeserializeEmbeddedGroup for TransactionBody {
     }
 }
 
-impl cbor_event::se::Serialize for TransactionWitnessSet {
+impl cbor_event::se::Serialize for TransactionInput {
     fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_map(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
+        serializer.write_array(cbor_event::Len::Len(2))?;
+        self.transaction_id.serialize(serializer)?;
+        self.index.serialize(serializer)?;
+        Ok(serializer)
     }
 }
 
-impl SerializeEmbeddedGroup for TransactionWitnessSet {
+impl Deserialize for TransactionInput {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("TransactionInput"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for TransactionInput {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        let transaction_id = (|| -> Result<_, DeserializeError> {
+            Ok(TransactionHash::deserialize(raw)?)
+        })().map_err(|e| e.annotate("transaction_id"))?;
+        let index = (|| -> Result<_, DeserializeError> {
+            Ok(u32::deserialize(raw)?)
+        })().map_err(|e| e.annotate("index"))?;
+        Ok(TransactionInput {
+            transaction_id,
+            index,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for TransactionOutput {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(2))?;
+        self.address.serialize(serializer)?;
+        self.amount.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for TransactionOutput {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("TransactionOutput"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for TransactionOutput {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        let address = (|| -> Result<_, DeserializeError> {
+            Ok(Address::deserialize(raw)?)
+        })().map_err(|e| e.annotate("address"))?;
+        let amount = (|| -> Result<_, DeserializeError> {
+            Ok(Coin::deserialize(raw)?)
+        })().map_err(|e| e.annotate("amount"))?;
+        Ok(TransactionOutput {
+            address,
+            amount,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for StakeRegistration {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(2))?;
+        serializer.write_unsigned_integer(0u64)?;
+        self.stake_credential.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for StakeRegistration {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("StakeRegistration"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for StakeRegistration {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let index_0_value = raw.unsigned_integer()?;
+            if index_0_value != 0 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(0) }.into());
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("index_0"))?;
+        let stake_credential = (|| -> Result<_, DeserializeError> {
+            Ok(StakeCredential::deserialize(raw)?)
+        })().map_err(|e| e.annotate("stake_credential"))?;
+        Ok(StakeRegistration {
+            stake_credential,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for StakeDeregistration {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(2))?;
+        serializer.write_unsigned_integer(1u64)?;
+        self.stake_credential.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for StakeDeregistration {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("StakeDeregistration"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for StakeDeregistration {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let index_0_value = raw.unsigned_integer()?;
+            if index_0_value != 1 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("index_0"))?;
+        let stake_credential = (|| -> Result<_, DeserializeError> {
+            Ok(StakeCredential::deserialize(raw)?)
+        })().map_err(|e| e.annotate("stake_credential"))?;
+        Ok(StakeDeregistration {
+            stake_credential,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for StakeDelegation {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(3))?;
+        serializer.write_unsigned_integer(2u64)?;
+        self.stake_credential.serialize(serializer)?;
+        self.pool_keyhash.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for StakeDelegation {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("StakeDelegation"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for StakeDelegation {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let index_0_value = raw.unsigned_integer()?;
+            if index_0_value != 2 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(2) }.into());
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("index_0"))?;
+        let stake_credential = (|| -> Result<_, DeserializeError> {
+            Ok(StakeCredential::deserialize(raw)?)
+        })().map_err(|e| e.annotate("stake_credential"))?;
+        let pool_keyhash = (|| -> Result<_, DeserializeError> {
+            Ok(PoolKeyHash::deserialize(raw)?)
+        })().map_err(|e| e.annotate("pool_keyhash"))?;
+        Ok(StakeDelegation {
+            stake_credential,
+            pool_keyhash,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for AddrKeyHashes {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(self.0.len() as u64))?;
+        for element in &self.0 {
+            element.serialize(serializer)?;
+        }
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for AddrKeyHashes {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let mut arr = Vec::new();
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            while match len { cbor_event::Len::Len(n) => arr.len() < n as usize, cbor_event::Len::Indefinite => true, } {
+                if raw.cbor_type()? == CBORType::Special {
+                    assert_eq!(raw.special()?, CBORSpecial::Break);
+                    break;
+                }
+                arr.push(AddrKeyHash::deserialize(raw)?);
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("AddrKeyHashes"))?;
+        Ok(Self(arr))
+    }
+}
+
+impl cbor_event::se::Serialize for Relays {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(self.0.len() as u64))?;
+        for element in &self.0 {
+            element.serialize(serializer)?;
+        }
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for Relays {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let mut arr = Vec::new();
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            while match len { cbor_event::Len::Len(n) => arr.len() < n as usize, cbor_event::Len::Indefinite => true, } {
+                if raw.cbor_type()? == CBORType::Special {
+                    assert_eq!(raw.special()?, CBORSpecial::Break);
+                    break;
+                }
+                arr.push(Relay::deserialize(raw)?);
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("Relays"))?;
+        Ok(Self(arr))
+    }
+}
+
+impl cbor_event::se::Serialize for PoolParams {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(9))?;
+        self.serialize_as_embedded_group(serializer)
+    }
+}
+
+impl SerializeEmbeddedGroup for PoolParams {
     fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        self.operator.serialize(serializer)?;
+        self.vrf_keyhash.serialize(serializer)?;
+        self.pledge.serialize(serializer)?;
+        self.cost.serialize(serializer)?;
+        self.margin.serialize(serializer)?;
+        self.reward_account.serialize(serializer)?;
+        self.pool_owners.serialize(serializer)?;
+        self.relays.serialize(serializer)?;
+        match &self.pool_metadata {
+            Some(x) => {
+                x.serialize(serializer)
+            },
+            None => serializer.write_special(CBORSpecial::Null),
+        }?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for PoolParams {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("PoolParams"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for PoolParams {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        let operator = (|| -> Result<_, DeserializeError> {
+            Ok(PoolKeyHash::deserialize(raw)?)
+        })().map_err(|e| e.annotate("operator"))?;
+        let vrf_keyhash = (|| -> Result<_, DeserializeError> {
+            Ok(VRFKeyHash::deserialize(raw)?)
+        })().map_err(|e| e.annotate("vrf_keyhash"))?;
+        let pledge = (|| -> Result<_, DeserializeError> {
+            Ok(Coin::deserialize(raw)?)
+        })().map_err(|e| e.annotate("pledge"))?;
+        let cost = (|| -> Result<_, DeserializeError> {
+            Ok(Coin::deserialize(raw)?)
+        })().map_err(|e| e.annotate("cost"))?;
+        let margin = (|| -> Result<_, DeserializeError> {
+            Ok(UnitInterval::deserialize(raw)?)
+        })().map_err(|e| e.annotate("margin"))?;
+        let reward_account = (|| -> Result<_, DeserializeError> {
+            Ok(RewardAccount::deserialize(raw)?)
+        })().map_err(|e| e.annotate("reward_account"))?;
+        let pool_owners = (|| -> Result<_, DeserializeError> {
+            Ok(AddrKeyHashes::deserialize(raw)?)
+        })().map_err(|e| e.annotate("pool_owners"))?;
+        let relays = (|| -> Result<_, DeserializeError> {
+            Ok(Relays::deserialize(raw)?)
+        })().map_err(|e| e.annotate("relays"))?;
+        let pool_metadata = (|| -> Result<_, DeserializeError> {
+            Ok(match raw.cbor_type()? != CBORType::Special {
+                true => {
+                    Some(PoolMetadata::deserialize(raw)?)
+                },
+                false => {
+                    if raw.special()? != CBORSpecial::Null {
+                        return Err(DeserializeFailure::ExpectedNull.into());
+                    }
+                    None
+                }
+            })
+        })().map_err(|e| e.annotate("pool_metadata"))?;
+        Ok(PoolParams {
+            operator,
+            vrf_keyhash,
+            pledge,
+            cost,
+            margin,
+            reward_account,
+            pool_owners,
+            relays,
+            pool_metadata,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for PoolRegistration {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(10))?;
+        serializer.write_unsigned_integer(3u64)?;
+        self.pool_params.serialize_as_embedded_group(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for PoolRegistration {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("PoolRegistration"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for PoolRegistration {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let index_0_value = raw.unsigned_integer()?;
+            if index_0_value != 3 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(3) }.into());
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("index_0"))?;
+        let pool_params = (|| -> Result<_, DeserializeError> {
+            Ok(PoolParams::deserialize_as_embedded_group(raw, len)?)
+        })().map_err(|e| e.annotate("pool_params"))?;
+        Ok(PoolRegistration {
+            pool_params,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for PoolRetirement {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(3))?;
+        serializer.write_unsigned_integer(4u64)?;
+        self.pool_keyhash.serialize(serializer)?;
+        self.epoch.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for PoolRetirement {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("PoolRetirement"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for PoolRetirement {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let index_0_value = raw.unsigned_integer()?;
+            if index_0_value != 4 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(4) }.into());
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("index_0"))?;
+        let pool_keyhash = (|| -> Result<_, DeserializeError> {
+            Ok(PoolKeyHash::deserialize(raw)?)
+        })().map_err(|e| e.annotate("pool_keyhash"))?;
+        let epoch = (|| -> Result<_, DeserializeError> {
+            Ok(Epoch::deserialize(raw)?)
+        })().map_err(|e| e.annotate("epoch"))?;
+        Ok(PoolRetirement {
+            pool_keyhash,
+            epoch,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for GenesisKeyDelegation {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(3))?;
+        serializer.write_unsigned_integer(5u64)?;
+        self.genesishash.serialize(serializer)?;
+        self.genesis_delegate_hash.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for GenesisKeyDelegation {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("GenesisKeyDelegation"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for GenesisKeyDelegation {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let index_0_value = raw.unsigned_integer()?;
+            if index_0_value != 5 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(5) }.into());
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("index_0"))?;
+        let genesishash = (|| -> Result<_, DeserializeError> {
+            Ok(GenesisHash::deserialize(raw)?)
+        })().map_err(|e| e.annotate("genesishash"))?;
+        let genesis_delegate_hash = (|| -> Result<_, DeserializeError> {
+            Ok(GenesisDelegateHash::deserialize(raw)?)
+        })().map_err(|e| e.annotate("genesis_delegate_hash"))?;
+        Ok(GenesisKeyDelegation {
+            genesishash,
+            genesis_delegate_hash,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for MoveInstantaneousRewardsCert {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(2))?;
+        serializer.write_unsigned_integer(6u64)?;
+        self.move_instantaneous_reward.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for MoveInstantaneousRewardsCert {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("MoveInstantaneousRewardsCert"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for MoveInstantaneousRewardsCert {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let index_0_value = raw.unsigned_integer()?;
+            if index_0_value != 6 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(6) }.into());
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("index_0"))?;
+        let move_instantaneous_reward = (|| -> Result<_, DeserializeError> {
+            Ok(MoveInstantaneousReward::deserialize(raw)?)
+        })().map_err(|e| e.annotate("move_instantaneous_reward"))?;
+        Ok(MoveInstantaneousRewardsCert {
+            move_instantaneous_reward,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for CertificateEnum {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            CertificateEnum::StakeRegistration(x) => {
+                serializer.write_array(cbor_event::Len::Len(1))?;
+                x.serialize(serializer)
+            },
+            CertificateEnum::StakeDeregistration(x) => {
+                serializer.write_array(cbor_event::Len::Len(1))?;
+                x.serialize(serializer)
+            },
+            CertificateEnum::StakeDelegation(x) => {
+                serializer.write_array(cbor_event::Len::Len(1))?;
+                x.serialize(serializer)
+            },
+            CertificateEnum::PoolRegistration(x) => {
+                serializer.write_array(cbor_event::Len::Len(1))?;
+                x.serialize(serializer)
+            },
+            CertificateEnum::PoolRetirement(x) => {
+                serializer.write_array(cbor_event::Len::Len(1))?;
+                x.serialize(serializer)
+            },
+            CertificateEnum::GenesisKeyDelegation(x) => {
+                serializer.write_array(cbor_event::Len::Len(1))?;
+                x.serialize(serializer)
+            },
+            CertificateEnum::MoveInstantaneousRewardsCert(x) => {
+                serializer.write_array(cbor_event::Len::Len(1))?;
+                x.serialize(serializer)
+            },
+        }
+    }
+}
+
+impl Deserialize for CertificateEnum {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("CertificateEnum"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for CertificateEnum {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            Ok(StakeRegistration::deserialize(raw)?)
+        })(raw)
+        {
+            Ok(variant) => return Ok(CertificateEnum::StakeRegistration(variant)),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            Ok(StakeDeregistration::deserialize(raw)?)
+        })(raw)
+        {
+            Ok(variant) => return Ok(CertificateEnum::StakeDeregistration(variant)),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            Ok(StakeDelegation::deserialize(raw)?)
+        })(raw)
+        {
+            Ok(variant) => return Ok(CertificateEnum::StakeDelegation(variant)),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            Ok(PoolRegistration::deserialize(raw)?)
+        })(raw)
+        {
+            Ok(variant) => return Ok(CertificateEnum::PoolRegistration(variant)),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            Ok(PoolRetirement::deserialize(raw)?)
+        })(raw)
+        {
+            Ok(variant) => return Ok(CertificateEnum::PoolRetirement(variant)),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            Ok(GenesisKeyDelegation::deserialize(raw)?)
+        })(raw)
+        {
+            Ok(variant) => return Ok(CertificateEnum::GenesisKeyDelegation(variant)),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            Ok(MoveInstantaneousRewardsCert::deserialize(raw)?)
+        })(raw)
+        {
+            Ok(variant) => return Ok(CertificateEnum::MoveInstantaneousRewardsCert(variant)),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        Err(DeserializeError::new("CertificateEnum", DeserializeFailure::NoVariantMatched.into()))
+    }
+}
+
+impl cbor_event::se::Serialize for Certificate {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl Deserialize for Certificate {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Ok(Self(CertificateEnum::deserialize(raw)?))
+    }
+}
+
+impl cbor_event::se::Serialize for I0OrI1Enum {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            I0OrI1Enum::I0 => {
+                serializer.write_unsigned_integer(0u64)
+            },
+            I0OrI1Enum::I1 => {
+                serializer.write_unsigned_integer(1u64)
+            },
+        }
+    }
+}
+
+impl Deserialize for I0OrI1Enum {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let i0_value = raw.unsigned_integer()?;
+            if i0_value != 0 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(i0_value), expected: Key::Uint(0) }.into());
+            }
+            Ok(())
+        })(raw)
+        {
+            Ok(()) => return Ok(I0OrI1Enum::I0),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            let i1_value = raw.unsigned_integer()?;
+            if i1_value != 1 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(i1_value), expected: Key::Uint(1) }.into());
+            }
+            Ok(())
+        })(raw)
+        {
+            Ok(()) => return Ok(I0OrI1Enum::I1),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        Err(DeserializeError::new("I0OrI1Enum", DeserializeFailure::NoVariantMatched.into()))
+    }
+}
+
+impl cbor_event::se::Serialize for I0OrI1 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl Deserialize for I0OrI1 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Ok(Self(I0OrI1Enum::deserialize(raw)?))
+    }
+}
+
+impl cbor_event::se::Serialize for MapStakeCredentialToCoin {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map(cbor_event::Len::Len(self.0.len() as u64))?;
+        for (key, value) in &self.0 {
+            key.serialize(serializer)?;
+            value.serialize(serializer)?;
+        }
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for MapStakeCredentialToCoin {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let mut table = std::collections::BTreeMap::new();
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.map()?;
+            while match len { cbor_event::Len::Len(n) => table.len() < n as usize, cbor_event::Len::Indefinite => true, } {
+                if raw.cbor_type()? == CBORType::Special {
+                    assert_eq!(raw.special()?, CBORSpecial::Break);
+                    break;
+                }
+                let key = StakeCredential::deserialize(raw)?;
+                let value = Coin::deserialize(raw)?;
+                if table.insert(key.clone(), value).is_some() {
+                    return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                }
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("MapStakeCredentialToCoin"))?;
+        Ok(Self(table))
+    }
+}
+
+impl cbor_event::se::Serialize for MoveInstantaneousReward {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(2))?;
+        self.index_0.serialize(serializer)?;
+        self.index_1.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for MoveInstantaneousReward {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("MoveInstantaneousReward"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for MoveInstantaneousReward {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        let index_0 = (|| -> Result<_, DeserializeError> {
+            Ok(I0OrI1::deserialize(raw)?)
+        })().map_err(|e| e.annotate("index_0"))?;
+        let index_1 = (|| -> Result<_, DeserializeError> {
+            Ok(MapStakeCredentialToCoin::deserialize(raw)?)
+        })().map_err(|e| e.annotate("index_1"))?;
+        Ok(MoveInstantaneousReward {
+            index_0,
+            index_1,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for Ipv4 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes(&self.0)
+    }
+}
+
+impl Deserialize for Ipv4 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Ok(Self(raw.bytes()?))
+    }
+}
+
+impl cbor_event::se::Serialize for Ipv6 {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes(&self.0)
+    }
+}
+
+impl Deserialize for Ipv6 {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Ok(Self(raw.bytes()?))
+    }
+}
+
+impl cbor_event::se::Serialize for SingleHostAddr {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(4))?;
+        self.serialize_as_embedded_group(serializer)
+    }
+}
+
+impl SerializeEmbeddedGroup for SingleHostAddr {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer(0u64)?;
+        match &self.port {
+            Some(x) => {
+                x.serialize(serializer)
+            },
+            None => serializer.write_special(CBORSpecial::Null),
+        }?;
+        match &self.ipv4 {
+            Some(x) => {
+                x.serialize(serializer)
+            },
+            None => serializer.write_special(CBORSpecial::Null),
+        }?;
+        match &self.ipv6 {
+            Some(x) => {
+                x.serialize(serializer)
+            },
+            None => serializer.write_special(CBORSpecial::Null),
+        }?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for SingleHostAddr {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("SingleHostAddr"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for SingleHostAddr {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let index_0_value = raw.unsigned_integer()?;
+            if index_0_value != 0 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(0) }.into());
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("index_0"))?;
+        let port = (|| -> Result<_, DeserializeError> {
+            Ok(match raw.cbor_type()? != CBORType::Special {
+                true => {
+                    Some(Port::deserialize(raw)?)
+                },
+                false => {
+                    if raw.special()? != CBORSpecial::Null {
+                        return Err(DeserializeFailure::ExpectedNull.into());
+                    }
+                    None
+                }
+            })
+        })().map_err(|e| e.annotate("port"))?;
+        let ipv4 = (|| -> Result<_, DeserializeError> {
+            Ok(match raw.cbor_type()? != CBORType::Special {
+                true => {
+                    Some(Ipv4::deserialize(raw)?)
+                },
+                false => {
+                    if raw.special()? != CBORSpecial::Null {
+                        return Err(DeserializeFailure::ExpectedNull.into());
+                    }
+                    None
+                }
+            })
+        })().map_err(|e| e.annotate("ipv4"))?;
+        let ipv6 = (|| -> Result<_, DeserializeError> {
+            Ok(match raw.cbor_type()? != CBORType::Special {
+                true => {
+                    Some(Ipv6::deserialize(raw)?)
+                },
+                false => {
+                    if raw.special()? != CBORSpecial::Null {
+                        return Err(DeserializeFailure::ExpectedNull.into());
+                    }
+                    None
+                }
+            })
+        })().map_err(|e| e.annotate("ipv6"))?;
+        Ok(SingleHostAddr {
+            port,
+            ipv4,
+            ipv6,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for SingleHostName {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(3))?;
+        self.serialize_as_embedded_group(serializer)
+    }
+}
+
+impl SerializeEmbeddedGroup for SingleHostName {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer(1u64)?;
+        match &self.port {
+            Some(x) => {
+                x.serialize(serializer)
+            },
+            None => serializer.write_special(CBORSpecial::Null),
+        }?;
+        serializer.write_text(&self.dns_name)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for SingleHostName {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("SingleHostName"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for SingleHostName {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let index_0_value = raw.unsigned_integer()?;
+            if index_0_value != 1 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("index_0"))?;
+        let port = (|| -> Result<_, DeserializeError> {
+            Ok(match raw.cbor_type()? != CBORType::Special {
+                true => {
+                    Some(Port::deserialize(raw)?)
+                },
+                false => {
+                    if raw.special()? != CBORSpecial::Null {
+                        return Err(DeserializeFailure::ExpectedNull.into());
+                    }
+                    None
+                }
+            })
+        })().map_err(|e| e.annotate("port"))?;
+        let dns_name = (|| -> Result<_, DeserializeError> {
+            Ok(String::deserialize(raw)?)
+        })().map_err(|e| e.annotate("dns_name"))?;
+        Ok(SingleHostName {
+            port,
+            dns_name,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for MultiHostName {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(2))?;
+        self.serialize_as_embedded_group(serializer)
+    }
+}
+
+impl SerializeEmbeddedGroup for MultiHostName {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer(2u64)?;
+        serializer.write_text(&self.dns_name)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for MultiHostName {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("MultiHostName"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for MultiHostName {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let index_0_value = raw.unsigned_integer()?;
+            if index_0_value != 2 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(2) }.into());
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("index_0"))?;
+        let dns_name = (|| -> Result<_, DeserializeError> {
+            Ok(String::deserialize(raw)?)
+        })().map_err(|e| e.annotate("dns_name"))?;
+        Ok(MultiHostName {
+            dns_name,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for RelayEnum {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            RelayEnum::SingleHostAddr(x) => x.serialize(serializer),
+            RelayEnum::SingleHostName(x) => x.serialize(serializer),
+            RelayEnum::MultiHostName(x) => x.serialize(serializer),
+        }
+    }
+}
+
+impl Deserialize for RelayEnum {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("RelayEnum"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for RelayEnum {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            Ok(SingleHostAddr::deserialize_as_embedded_group(raw, len)?)
+        })(raw)
+        {
+            Ok(variant) => return Ok(RelayEnum::SingleHostAddr(variant)),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            Ok(SingleHostName::deserialize_as_embedded_group(raw, len)?)
+        })(raw)
+        {
+            Ok(variant) => return Ok(RelayEnum::SingleHostName(variant)),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            Ok(MultiHostName::deserialize_as_embedded_group(raw, len)?)
+        })(raw)
+        {
+            Ok(variant) => return Ok(RelayEnum::MultiHostName(variant)),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        Err(DeserializeError::new("RelayEnum", DeserializeFailure::NoVariantMatched.into()))
+    }
+}
+
+impl cbor_event::se::Serialize for Relay {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl Deserialize for Relay {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Ok(Self(RelayEnum::deserialize(raw)?))
+    }
+}
+
+impl cbor_event::se::Serialize for PoolMetadata {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(2))?;
+        serializer.write_text(&self.url)?;
+        self.metadata_hash.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for PoolMetadata {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("PoolMetadata"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for PoolMetadata {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        let url = (|| -> Result<_, DeserializeError> {
+            Ok(String::deserialize(raw)?)
+        })().map_err(|e| e.annotate("url"))?;
+        let metadata_hash = (|| -> Result<_, DeserializeError> {
+            Ok(MetadataHash::deserialize(raw)?)
+        })().map_err(|e| e.annotate("metadata_hash"))?;
+        Ok(PoolMetadata {
+            url,
+            metadata_hash,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for Withdrawals {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map(cbor_event::Len::Len(self.0.len() as u64))?;
+        for (key, value) in &self.0 {
+            key.serialize(serializer)?;
+            value.serialize(serializer)?;
+        }
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for Withdrawals {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let mut table = std::collections::BTreeMap::new();
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.map()?;
+            while match len { cbor_event::Len::Len(n) => table.len() < n as usize, cbor_event::Len::Indefinite => true, } {
+                if raw.cbor_type()? == CBORType::Special {
+                    assert_eq!(raw.special()?, CBORSpecial::Break);
+                    break;
+                }
+                let key = RewardAccount::deserialize(raw)?;
+                let value = Coin::deserialize(raw)?;
+                if table.insert(key.clone(), value).is_some() {
+                    return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                }
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("Withdrawals"))?;
+        Ok(Self(table))
+    }
+}
+
+impl cbor_event::se::Serialize for MultisigScripts {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(self.0.len() as u64))?;
+        for element in &self.0 {
+            element.serialize(serializer)?;
+        }
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for MultisigScripts {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let mut arr = Vec::new();
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            while match len { cbor_event::Len::Len(n) => arr.len() < n as usize, cbor_event::Len::Indefinite => true, } {
+                if raw.cbor_type()? == CBORType::Special {
+                    assert_eq!(raw.special()?, CBORSpecial::Break);
+                    break;
+                }
+                arr.push(MultisigScript::deserialize(raw)?);
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("MultisigScripts"))?;
+        Ok(Self(arr))
+    }
+}
+
+impl cbor_event::se::Serialize for TransactionWitnessSet {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map(cbor_event::Len::Len(match &self.vkeys { Some(x) => 1, None => 0 } + match &self.scripts { Some(x) => 1, None => 0 } + match &self.bootstraps { Some(x) => 1, None => 0 }))?;
         if let Some(field) = &self.vkeys {
             serializer.write_unsigned_integer(0)?;
-            // DEBUG - generated from: Array(Rust(RustIdent("Vkeywitness")))
             field.serialize(serializer)?;
         }
         if let Some(field) = &self.scripts {
             serializer.write_unsigned_integer(1)?;
-            // DEBUG - generated from: Array(Rust(RustIdent("MultisigScript")))
+            field.serialize(serializer)?;
+        }
+        if let Some(field) = &self.bootstraps {
+            serializer.write_unsigned_integer(2)?;
             field.serialize(serializer)?;
         }
         Ok(serializer)
@@ -2027,6 +1602,7 @@ impl DeserializeEmbeddedGroup for TransactionWitnessSet {
     fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
         let mut vkeys = None;
         let mut scripts = None;
+        let mut bootstraps = None;
         let mut read = 0;
         while match len { cbor_event::Len::Len(n) => read < n as usize, cbor_event::Len::Indefinite => true, } {
             match raw.cbor_type()? {
@@ -2036,7 +1612,6 @@ impl DeserializeEmbeddedGroup for TransactionWitnessSet {
                             return Err(DeserializeFailure::DuplicateKey(Key::Uint(0)).into());
                         }
                         vkeys = Some((|| -> Result<_, DeserializeError> {
-                            println!("deserializing vkeys");
                             Ok(Vkeywitnesses::deserialize(raw)?)
                         })().map_err(|e| e.annotate("vkeys"))?);
                     },
@@ -2045,9 +1620,16 @@ impl DeserializeEmbeddedGroup for TransactionWitnessSet {
                             return Err(DeserializeFailure::DuplicateKey(Key::Uint(1)).into());
                         }
                         scripts = Some((|| -> Result<_, DeserializeError> {
-                            println!("deserializing scripts");
                             Ok(MultisigScripts::deserialize(raw)?)
                         })().map_err(|e| e.annotate("scripts"))?);
+                    },
+                    2 =>  {
+                        if bootstraps.is_some() {
+                            return Err(DeserializeFailure::DuplicateKey(Key::Uint(2)).into());
+                        }
+                        bootstraps = Some((|| -> Result<_, DeserializeError> {
+                            Ok(BootstrapWitnesses::deserialize(raw)?)
+                        })().map_err(|e| e.annotate("bootstraps"))?);
                     },
                     unknown_key => return Err(DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()),
                 },
@@ -2068,21 +1650,14 @@ impl DeserializeEmbeddedGroup for TransactionWitnessSet {
         Ok(Self {
             vkeys,
             scripts,
+            bootstraps,
         })
     }
 }
 
-
 impl cbor_event::se::Serialize for MapTransactionMetadatumToTransactionMetadatum {
     fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_map(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for MapTransactionMetadatumToTransactionMetadatum {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map(cbor_event::Len::Len(self.0.len() as u64))?;
         for (key, value) in &self.0 {
             key.serialize(serializer)?;
             value.serialize(serializer)?;
@@ -2143,12 +1718,6 @@ impl Deserialize for TransactionMetadatums {
 
 impl cbor_event::se::Serialize for TransactionMetadatumEnum {
     fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        self.serialize_as_embedded_group(serializer)
-    }
-}
-
-impl SerializeEmbeddedGroup for TransactionMetadatumEnum {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
         match self {
             TransactionMetadatumEnum::MapTransactionMetadatumToTransactionMetadatum(x) => {
                 x.serialize(serializer)
@@ -2213,13 +1782,7 @@ impl Deserialize for TransactionMetadatumEnum {
 
 impl cbor_event::se::Serialize for TransactionMetadatum {
     fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        self.serialize_as_embedded_group(serializer)
-    }
-}
-
-impl SerializeEmbeddedGroup for TransactionMetadatum {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        self.0.serialize_as_embedded_group(serializer)
+        self.0.serialize(serializer)
     }
 }
 
@@ -2231,14 +1794,7 @@ impl Deserialize for TransactionMetadatum {
 
 impl cbor_event::se::Serialize for TransactionMetadata {
     fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_map(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
-    }
-}
-
-impl SerializeEmbeddedGroup for TransactionMetadata {
-    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map(cbor_event::Len::Len(self.0.len() as u64))?;
         for (key, value) in &self.0 {
             key.serialize(serializer)?;
             value.serialize(serializer)?;
@@ -2257,10 +1813,10 @@ impl Deserialize for TransactionMetadata {
                     assert_eq!(raw.special()?, CBORSpecial::Break);
                     break;
                 }
-                let key = u32::deserialize(raw)?;
+                let key = TransactionMetadadumLabel::deserialize(raw)?;
                 let value = TransactionMetadatum::deserialize(raw)?;
                 if table.insert(key.clone(), value).is_some() {
-                    return Err(DeserializeFailure::DuplicateKey(Key::Uint(key.into())).into());
+                    return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
                 }
             }
             Ok(())
@@ -2269,29 +1825,22 @@ impl Deserialize for TransactionMetadata {
     }
 }
 
-impl cbor_event::se::Serialize for Transaction {
+impl cbor_event::se::Serialize for MsigPubkey {
     fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_array(cbor_event::Len::Indefinite)?;
-        self.serialize_as_embedded_group(serializer)?;
-        serializer.write_special(CBORSpecial::Break)
+        serializer.write_array(cbor_event::Len::Len(2))?;
+        self.serialize_as_embedded_group(serializer)
     }
 }
 
-impl SerializeEmbeddedGroup for Transaction {
+impl SerializeEmbeddedGroup for MsigPubkey {
     fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        self.body.serialize(serializer)?;
-        self.witness_set.serialize(serializer)?;
-        match &self.metadata {
-            Some(x) => {
-                x.serialize(serializer)
-            },
-            None => serializer.write_special(CBORSpecial::Null),
-        }?;
+        serializer.write_unsigned_integer(0u64)?;
+        self.addr_keyhash.serialize(serializer)?;
         Ok(serializer)
     }
 }
 
-impl Deserialize for Transaction {
+impl Deserialize for MsigPubkey {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
         (|| -> Result<_, DeserializeError> {
             let len = raw.array()?;
@@ -2304,31 +1853,254 @@ impl Deserialize for Transaction {
                 },
             }
             ret
-        })().map_err(|e| e.annotate("Transaction"))
+        })().map_err(|e| e.annotate("MsigPubkey"))
     }
 }
 
-impl DeserializeEmbeddedGroup for Transaction {
+impl DeserializeEmbeddedGroup for MsigPubkey {
     fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
-        let body = (|| -> Result<_, DeserializeError> {
-            Ok(TransactionBody::deserialize(raw)?)
-        })().map_err(|e| e.annotate("body"))?;
-        let witness_set = (|| -> Result<_, DeserializeError> {
-            Ok(TransactionWitnessSet::deserialize(raw)?)
-        })().map_err(|e| e.annotate("witness_set"))?;
-        let metadata = (|| -> Result<_, DeserializeError> {
-            Ok(match raw.cbor_type()? != CBORType::Special {
-                true => {
-                    Some(TransactionMetadata::deserialize(raw)?)
+        (|| -> Result<_, DeserializeError> {
+            let index_0_value = raw.unsigned_integer()?;
+            if index_0_value != 0 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(0) }.into());
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("index_0"))?;
+        let addr_keyhash = (|| -> Result<_, DeserializeError> {
+            Ok(AddrKeyHash::deserialize(raw)?)
+        })().map_err(|e| e.annotate("addr_keyhash"))?;
+        Ok(MsigPubkey {
+            addr_keyhash,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for MsigAll {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(2))?;
+        self.serialize_as_embedded_group(serializer)
+    }
+}
+
+impl SerializeEmbeddedGroup for MsigAll {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer(1u64)?;
+        self.multisig_scripts.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for MsigAll {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
                 },
-                false => {
-                    if raw.special()? != CBORSpecial::Null {
-                        return Err(DeserializeFailure::ExpectedNull.into());
-                    }
-                    None
-                }
-            })
-        })().map_err(|e| e.annotate("metadata"))?;
-        Ok(Transaction::new(body, witness_set, metadata))
+            }
+            ret
+        })().map_err(|e| e.annotate("MsigAll"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for MsigAll {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let index_0_value = raw.unsigned_integer()?;
+            if index_0_value != 1 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(1) }.into());
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("index_0"))?;
+        let multisig_scripts = (|| -> Result<_, DeserializeError> {
+            Ok(MultisigScripts::deserialize(raw)?)
+        })().map_err(|e| e.annotate("multisig_scripts"))?;
+        Ok(MsigAll {
+            multisig_scripts,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for MsigAny {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(2))?;
+        self.serialize_as_embedded_group(serializer)
+    }
+}
+
+impl SerializeEmbeddedGroup for MsigAny {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer(2u64)?;
+        self.multisig_scripts.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for MsigAny {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("MsigAny"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for MsigAny {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let index_0_value = raw.unsigned_integer()?;
+            if index_0_value != 2 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(2) }.into());
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("index_0"))?;
+        let multisig_scripts = (|| -> Result<_, DeserializeError> {
+            Ok(MultisigScripts::deserialize(raw)?)
+        })().map_err(|e| e.annotate("multisig_scripts"))?;
+        Ok(MsigAny {
+            multisig_scripts,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for MsigNOfK {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(3))?;
+        self.serialize_as_embedded_group(serializer)
+    }
+}
+
+impl SerializeEmbeddedGroup for MsigNOfK {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer(3u64)?;
+        self.n.serialize(serializer)?;
+        self.multisig_scripts.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for MsigNOfK {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("MsigNOfK"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for MsigNOfK {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let index_0_value = raw.unsigned_integer()?;
+            if index_0_value != 3 {
+                return Err(DeserializeFailure::FixedValueMismatch{ found: Key::Uint(index_0_value), expected: Key::Uint(3) }.into());
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("index_0"))?;
+        let n = (|| -> Result<_, DeserializeError> {
+            Ok(u32::deserialize(raw)?)
+        })().map_err(|e| e.annotate("n"))?;
+        let multisig_scripts = (|| -> Result<_, DeserializeError> {
+            Ok(MultisigScripts::deserialize(raw)?)
+        })().map_err(|e| e.annotate("multisig_scripts"))?;
+        Ok(MsigNOfK {
+            n,
+            multisig_scripts,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for MultisigScriptEnum {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        match self {
+            MultisigScriptEnum::MsigPubkey(x) => x.serialize(serializer),
+            MultisigScriptEnum::MsigAll(x) => x.serialize(serializer),
+            MultisigScriptEnum::MsigAny(x) => x.serialize(serializer),
+            MultisigScriptEnum::MsigNOfK(x) => x.serialize(serializer),
+        }
+    }
+}
+
+impl Deserialize for MultisigScriptEnum {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("MultisigScriptEnum"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for MultisigScriptEnum {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            Ok(MsigPubkey::deserialize_as_embedded_group(raw, len)?)
+        })(raw)
+        {
+            Ok(variant) => return Ok(MultisigScriptEnum::MsigPubkey(variant)),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            Ok(MsigAll::deserialize_as_embedded_group(raw, len)?)
+        })(raw)
+        {
+            Ok(variant) => return Ok(MultisigScriptEnum::MsigAll(variant)),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            Ok(MsigAny::deserialize_as_embedded_group(raw, len)?)
+        })(raw)
+        {
+            Ok(variant) => return Ok(MultisigScriptEnum::MsigAny(variant)),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
+            Ok(MsigNOfK::deserialize_as_embedded_group(raw, len)?)
+        })(raw)
+        {
+            Ok(variant) => return Ok(MultisigScriptEnum::MsigNOfK(variant)),
+            Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
+        };
+        Err(DeserializeError::new("MultisigScriptEnum", DeserializeFailure::NoVariantMatched.into()))
+    }
+}
+
+impl cbor_event::se::Serialize for MultisigScript {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl Deserialize for MultisigScript {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Ok(Self(MultisigScriptEnum::deserialize(raw)?))
     }
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -66,58 +66,51 @@ describe('Addresses', () => {
 
 describe('Transactions', () => {
   it('create transaction', () => {
-    // const txInputs = CardanoWasm.TransactionInputs.new();
-    // {
-    //   txInputs.add(
-    //     CardanoWasm.TransactionInput.new(
-    //       CardanoWasm.TransactionHash.from_bytes(
-    //         Buffer.from('3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7', 'hex'),
-    //       ),
-    //       0, // index
-    //     )
-    //   );
-    // }
-    // const txOutputs = CardanoWasm.TransactionOutputs.new();
-    // {
-    //   txOutputs.add(
-    //     CardanoWasm.TransactionOutput.new(
-    //       CardanoWasm.Address.from_bytes(
-    //         Buffer.from('61a6274badf4c9ca583df893a73139625ff4dc73aaa3082e67d6d5d08e0ce3daa4', 'hex'),
-    //       ),
-    //       BigInt(1),
-    //     )
-    //   );
-    // }
-    // const txBody = CardanoWasm.TransactionBody.new(
-    //   txInputs,
-    //   txOutputs,
-    //   BigInt(42), // fee
-    //   10, // ttl
-    // );
+    const txInputs = CardanoWasm.TransactionInputs.new();
+    {
+      txInputs.add(
+        CardanoWasm.TransactionInput.new(
+          CardanoWasm.TransactionHash.from_bytes(
+            Buffer.from('3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7', 'hex'),
+          ),
+          0, // index
+        )
+      );
+    }
+    const txOutputs = CardanoWasm.TransactionOutputs.new();
+    {
+      txOutputs.add(
+        CardanoWasm.TransactionOutput.new(
+          CardanoWasm.Address.from_bytes(
+            // Buffer.from('61a6274badf4c9ca583df893a73139625ff4dc73aaa3082e67d6d5d08e0ce3daa4', 'hex'),
+            Buffer.from('61a6274badf4c9ca583df893a73139625ff4dc73aaa3082e67d6d5d08e', 'hex'),
+          ),
+          BigInt(1),
+        )
+      );
+    }
+    const txBody = CardanoWasm.TransactionBody.new(
+      txInputs,
+      txOutputs,
+      BigInt(42), // fee
+      10, // ttl
+    );
     
-    // const witnesses = CardanoWasm.TransactionWitnessSet.new();
-    // {
-    //   const vkeyWitnesses = CardanoWasm.Vkeywitnesses.new();
+    const witnesses = CardanoWasm.TransactionWitnessSet.new();
+    {
+      const vkeyWitnesses = CardanoWasm.Vkeywitnesses.new();
 
-      // const prvKey = CardanoWasm.PrivateKey.from_normal_bytes(
-      //   Buffer.from('f7955ca7a24889e892a74851712975c924d536d503eeb1c900a7431900633fb8', 'hex')
-      // );
-      // vkeyWitnesses.add(
-      //   CardanoWasm.Vkeywitness.new(
-      //     CardanoWasm.Vkey.from_bytes(
-      //       Buffer.from('e7d33eeb6f1df124f9f4c226428bc46b4c93ac4bc89dacc85748d1a2b47ded13', 'hex')
-      //     ),
-      //     prvKey.sign(
-      //       // TODO
-      //       Buffer.from('ff', 'hex')
-      //     ),
-      //   )
-      // );
-    //   witnesses.set_vkeys(vkeyWitnesses);
-    // }
-    // CardanoWasm.Transaction.new(
-    //   txBody,
-    //   witnesses,
-    // );
+      const prvKey = CardanoWasm.PrivateKey.from_normal_bytes(
+        Buffer.from('f7955ca7a24889e892a74851712975c924d536d503eeb1c900a7431900633fb8', 'hex')
+      );
+      vkeyWitnesses.add(
+        txBody.sign(prvKey)
+      );
+      witnesses.set_vkeys(vkeyWitnesses);
+    }
+    CardanoWasm.Transaction.new(
+      txBody,
+      witnesses,
+    );
   })
 });


### PR DESCRIPTION
1) Swap all wasm-exposed functions to take by-ref for rust-wasm structs
   and clone to be more foolproof memory-wise from js/wasm

2) Serialize everything using definite encoding instead of indefinite
   which a) should be more likely to be compatible with IOHK's haskell
   code and b) takes up 5% or so less space for txs

3) Some additions to shelley.cddl were made by IOHK since we last generated
    using it as well like reward accounts so those were added too.

4) Fixed up tx creation js test to use signing

5) from_bytes functions now auto-choose JsValue vs DeserializeError based on current compilation target (necessary because JsValue panics when used on non-wasm)

The ordering of the lib/serialization files is totally changes since
this time I used the shelley.cddl file mostly untouched, whereas last
time it was edited to get rid of out-of-order declarations e.g.
transaction being declared before transaction_body which it references,
but now cddl-codegen can handle that.