### PR TITLE
Add Coin wrapper + Refactor MoveInstantaneousRewards 

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -420,6 +420,49 @@ declare export class Certificates {
    */
   add(elem: Certificate): void;
 }
+declare export class Coin {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {Coin}
+   */
+  static from_bytes(bytes: Uint8Array): Coin;
+
+  /**
+   * @param {BigInt} value
+   * @returns {Coin}
+   */
+  static new(value: BigInt): Coin;
+
+  /**
+   * @param {string} string
+   * @returns {Coin}
+   */
+  static from_str(string: string): Coin;
+
+  /**
+   * @returns {string}
+   */
+  to_str(): string;
+
+  /**
+   * @param {Coin} other
+   * @returns {Coin}
+   */
+  checked_add(other: Coin): Coin;
+
+  /**
+   * @param {Coin} other
+   * @returns {Coin}
+   */
+  checked_sub(other: Coin): Coin;
+}
 declare export class Ed25519Signature {
   free(): void;
 
@@ -660,10 +703,10 @@ declare export class MoveInstantaneousReward {
 
   /**
    * @param {StakeCredential} key
-   * @param {BigInt} value
-   * @returns {BigInt | void}
+   * @param {Coin} value
+   * @returns {Coin | void}
    */
-  insert(key: StakeCredential, value: BigInt): BigInt | void;
+  insert(key: StakeCredential, value: Coin): Coin | void;
 }
 declare export class MoveInstantaneousRewardsCert {
   free(): void;
@@ -958,8 +1001,8 @@ declare export class PoolParams {
   /**
    * @param {PoolKeyHash} operator
    * @param {VRFKeyHash} vrf_keyhash
-   * @param {BigInt} pledge
-   * @param {BigInt} cost
+   * @param {Coin} pledge
+   * @param {Coin} cost
    * @param {UnitInterval} margin
    * @param {RewardAddress} reward_account
    * @param {AddrKeyHashes} pool_owners
@@ -970,8 +1013,8 @@ declare export class PoolParams {
   static new(
     operator: PoolKeyHash,
     vrf_keyhash: VRFKeyHash,
-    pledge: BigInt,
-    cost: BigInt,
+    pledge: Coin,
+    cost: Coin,
     margin: UnitInterval,
     reward_account: RewardAddress,
     pool_owners: AddrKeyHashes,
@@ -1427,14 +1470,14 @@ declare export class TransactionBody {
   /**
    * @param {TransactionInputs} inputs
    * @param {TransactionOutputs} outputs
-   * @param {BigInt} fee
+   * @param {Coin} fee
    * @param {number} ttl
    * @returns {TransactionBody}
    */
   static new(
     inputs: TransactionInputs,
     outputs: TransactionOutputs,
-    fee: BigInt,
+    fee: Coin,
     ttl: number
   ): TransactionBody;
 
@@ -1649,10 +1692,10 @@ declare export class TransactionOutput {
 
   /**
    * @param {Address} address
-   * @param {BigInt} amount
+   * @param {Coin} amount
    * @returns {TransactionOutput}
    */
-  static new(address: Address, amount: BigInt): TransactionOutput;
+  static new(address: Address, amount: Coin): TransactionOutput;
 }
 declare export class TransactionOutputs {
   free(): void;
@@ -1849,8 +1892,8 @@ declare export class Withdrawals {
 
   /**
    * @param {RewardAddress} key
-   * @param {BigInt} value
-   * @returns {BigInt | void}
+   * @param {Coin} value
+   * @returns {Coin | void}
    */
-  insert(key: RewardAddress, value: BigInt): BigInt | void;
+  insert(key: RewardAddress, value: Coin): Coin | void;
 }

--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -10,6 +10,14 @@
  * @returns {number}
  */
 declare export function min_fee(tx: Transaction): number;
+
+/**
+ */
+
+declare export var MIRPot: {|
+  +Reserves: 0, // 0
+  +Treasury: 1, // 1
+|};
 declare export class AddrKeyHash {
   free(): void;
 
@@ -520,19 +528,6 @@ declare export class GenesisKeyDelegation {
     genesis_delegate_hash: GenesisDelegateHash
   ): GenesisKeyDelegation;
 }
-declare export class I0OrI1 {
-  free(): void;
-
-  /**
-   * @returns {I0OrI1}
-   */
-  static new_i0(): I0OrI1;
-
-  /**
-   * @returns {I0OrI1}
-   */
-  static new_i1(): I0OrI1;
-}
 declare export class Int {
   free(): void;
 
@@ -587,37 +582,6 @@ declare export class Ipv6 {
    * @returns {Ipv6}
    */
   static new(data: Uint8Array): Ipv6;
-}
-declare export class MapStakeCredentialToCoin {
-  free(): void;
-
-  /**
-   * @returns {Uint8Array}
-   */
-  to_bytes(): Uint8Array;
-
-  /**
-   * @param {Uint8Array} bytes
-   * @returns {MapStakeCredentialToCoin}
-   */
-  static from_bytes(bytes: Uint8Array): MapStakeCredentialToCoin;
-
-  /**
-   * @returns {MapStakeCredentialToCoin}
-   */
-  static new(): MapStakeCredentialToCoin;
-
-  /**
-   * @returns {number}
-   */
-  len(): number;
-
-  /**
-   * @param {StakeCredential} key
-   * @param {BigInt} value
-   * @returns {BigInt | void}
-   */
-  insert(key: StakeCredential, value: BigInt): BigInt | void;
 }
 declare export class MapTransactionMetadatumToTransactionMetadatum {
   free(): void;
@@ -684,14 +648,22 @@ declare export class MoveInstantaneousReward {
   static from_bytes(bytes: Uint8Array): MoveInstantaneousReward;
 
   /**
-   * @param {I0OrI1} index_0
-   * @param {MapStakeCredentialToCoin} index_1
+   * @param {number} pot
    * @returns {MoveInstantaneousReward}
    */
-  static new(
-    index_0: I0OrI1,
-    index_1: MapStakeCredentialToCoin
-  ): MoveInstantaneousReward;
+  static new(pot: number): MoveInstantaneousReward;
+
+  /**
+   * @returns {number}
+   */
+  len(): number;
+
+  /**
+   * @param {StakeCredential} key
+   * @param {BigInt} value
+   * @returns {BigInt | void}
+   */
+  insert(key: StakeCredential, value: BigInt): BigInt | void;
 }
 declare export class MoveInstantaneousRewardsCert {
   free(): void;

--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -495,7 +495,7 @@ mod tests {
             &StakeCredential::from_keyhash(&AddrKeyHash::from([23; AddrKeyHash::BYTE_COUNT])),
             &StakeCredential::from_scripthash(&ScriptHash::from([42; ScriptHash::BYTE_COUNT])));
         let addr = base.to_address();
-        let addr2 = Address::from_bytes_impl(addr.to_bytes().as_ref()).unwrap();
+        let addr2 = Address::from_bytes(addr.to_bytes()).unwrap();
         assert_eq!(addr.to_bytes(), addr2.to_bytes());
     }
 
@@ -506,7 +506,7 @@ mod tests {
             &StakeCredential::from_keyhash(&AddrKeyHash::from([23; AddrKeyHash::BYTE_COUNT])),
             &Pointer::new(2354556573, 127, 0));
         let addr = ptr.to_address();
-        let addr2 = Address::from_bytes_impl(addr.to_bytes().as_ref()).unwrap();
+        let addr2 = Address::from_bytes(addr.to_bytes()).unwrap();
         assert_eq!(addr.to_bytes(), addr2.to_bytes());
     }
 
@@ -516,7 +516,7 @@ mod tests {
             64,
             &StakeCredential::from_keyhash(&AddrKeyHash::from([23; AddrKeyHash::BYTE_COUNT])));
         let addr = enterprise.to_address();
-        let addr2 = Address::from_bytes_impl(addr.to_bytes().as_ref()).unwrap();
+        let addr2 = Address::from_bytes(addr.to_bytes()).unwrap();
         assert_eq!(addr.to_bytes(), addr2.to_bytes());
     }
 
@@ -526,7 +526,7 @@ mod tests {
             9,
             &StakeCredential::from_scripthash(&ScriptHash::from([127; AddrKeyHash::BYTE_COUNT])));
         let addr = reward.to_address();
-        let addr2 = Address::from_bytes_impl(addr.to_bytes().as_ref()).unwrap();
+        let addr2 = Address::from_bytes(addr.to_bytes()).unwrap();
         assert_eq!(addr.to_bytes(), addr2.to_bytes());
     }
 

--- a/rust/src/fees.rs
+++ b/rust/src/fees.rs
@@ -36,7 +36,7 @@ fn txsize(tx: &Transaction) -> usize {
     const OUTPUT_SIZE: usize = SMALL_ARRAY + UINT + ADDRESS;
     let input_bytes = tx.body.inputs.to_bytes().len();
     let output_bytes = tx.body.outputs.to_bytes().len();
-    let fee_bytes = cbor_uint_length(tx.body.fee);
+    let fee_bytes = cbor_uint_length(tx.body.fee.0);
     let extra_size = input_bytes + output_bytes + fee_bytes;
     let rest = tx.to_bytes().len() - extra_size;
     tx.body.inputs.len() * INPUT_SIZE + tx.body.outputs.len() * OUTPUT_SIZE + rest
@@ -148,8 +148,8 @@ mod tests {
         let mut inputs = TransactionInputs::new();
         inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
-        let body = TransactionBody::new(&inputs, &outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), Coin::new(10)));
+        let body = TransactionBody::new(&inputs, &outputs, Coin::new(94), 10);
         let w = make_mock_witnesses_vkey(&body, vec![&alice_key()]);
         let tx = Transaction::new(&body, &w, None);
         let haskell_crypto_bytes = witness_vkey_bytes_haskell(&w);
@@ -163,12 +163,12 @@ mod tests {
         inputs.add(&TransactionInput::new(&genesis_id(), 0));
         inputs.add(&TransactionInput::new(&genesis_id(), 1));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
-        outputs.add(&TransactionOutput::new(&alice_addr(), 20));
-        outputs.add(&TransactionOutput::new(&alice_addr(), 30));
-        outputs.add(&TransactionOutput::new(&bob_addr(), 40));
-        outputs.add(&TransactionOutput::new(&bob_addr(), 50));
-        let body = TransactionBody::new(&inputs, &outputs, 199, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), Coin::new(10)));
+        outputs.add(&TransactionOutput::new(&alice_addr(), Coin::new(20)));
+        outputs.add(&TransactionOutput::new(&alice_addr(), Coin::new(30)));
+        outputs.add(&TransactionOutput::new(&bob_addr(), Coin::new(40)));
+        outputs.add(&TransactionOutput::new(&bob_addr(), Coin::new(50)));
+        let body = TransactionBody::new(&inputs, &outputs, Coin::new(199), 10);
         let w = make_mock_witnesses_vkey(&body, vec![&alice_key(), &bob_key()]);
         let tx = Transaction::new(&body, &w, None);
         let haskell_crypto_bytes = witness_vkey_bytes_haskell(&w);
@@ -181,8 +181,8 @@ mod tests {
         let mut inputs = TransactionInputs::new();
         inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
-        let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), Coin::new(10)));
+        let mut body = TransactionBody::new(&inputs, &outputs, Coin::new(94), 10);
         let mut certs = Certificates::new();
         certs.add(&Certificate::new_stake_registration(&StakeRegistration::new(&alice_pay())));
         body.set_certs(&certs);
@@ -198,8 +198,8 @@ mod tests {
         let mut inputs = TransactionInputs::new();
         inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
-        let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), Coin::new(10)));
+        let mut body = TransactionBody::new(&inputs, &outputs, Coin::new(94), 10);
         let mut certs = Certificates::new();
         certs.add(&Certificate::new_stake_delegation(&StakeDelegation::new(&bob_stake(), &alice_pool())));
         body.set_certs(&certs);
@@ -215,8 +215,8 @@ mod tests {
         let mut inputs = TransactionInputs::new();
         inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
-        let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), Coin::new(10)));
+        let mut body = TransactionBody::new(&inputs, &outputs, Coin::new(94), 10);
         let mut certs = Certificates::new();
         certs.add(&Certificate::new_stake_deregistration(&StakeDeregistration::new(&alice_pay())));
         body.set_certs(&certs);
@@ -232,8 +232,8 @@ mod tests {
         let mut inputs = TransactionInputs::new();
         inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
-        let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), Coin::new(10)));
+        let mut body = TransactionBody::new(&inputs, &outputs, Coin::new(94), 10);
         let mut certs = Certificates::new();
         let mut owners = AddrKeyHashes::new();
         owners.add(&(alice_stake().to_keyhash().unwrap()));
@@ -242,8 +242,8 @@ mod tests {
         let params = PoolParams::new(
             &alice_pool(),
             &VRFKeyHash::from([0u8; VRFKeyHash::BYTE_COUNT]),
-            1,
-            5,
+            Coin::new(1),
+            Coin::new(5),
             &UnitInterval::new(1, 10),
             &RewardAddress::new(0, &alice_stake()),
             &owners,
@@ -274,8 +274,8 @@ mod tests {
         let mut inputs = TransactionInputs::new();
         inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
-        let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), Coin::new(10)));
+        let mut body = TransactionBody::new(&inputs, &outputs, Coin::new(94), 10);
         let mut certs = Certificates::new();
         certs.add(&Certificate::new_pool_retirement(&PoolRetirement::new(&alice_pool(), 5)));
         body.set_certs(&certs);
@@ -291,8 +291,8 @@ mod tests {
         let mut inputs = TransactionInputs::new();
         inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
-        let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), Coin::new(10)));
+        let mut body = TransactionBody::new(&inputs, &outputs, Coin::new(94), 10);
         body.set_metadata_hash(&MetadataHash::from([37; MetadataHash::BYTE_COUNT]));
         let w = make_mock_witnesses_vkey(&body, vec![&alice_key()]);
         let mut metadata = TransactionMetadata::new();
@@ -311,8 +311,8 @@ mod tests {
         let mut inputs = TransactionInputs::new();
         inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
-        let body = TransactionBody::new(&inputs, &outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), Coin::new(10)));
+        let body = TransactionBody::new(&inputs, &outputs, Coin::new(94), 10);
         let mut w = make_mock_witnesses_vkey(&body, vec![&alice_key(), &bob_key()]);
         let mut script_witnesses = MultisigScripts::new();
         let mut inner_scripts = MultisigScripts::new();
@@ -332,10 +332,10 @@ mod tests {
         let mut inputs = TransactionInputs::new();
         inputs.add(&TransactionInput::new(&genesis_id(), 0));
         let mut outputs = TransactionOutputs::new();
-        outputs.add(&TransactionOutput::new(&alice_addr(), 10));
-        let mut body = TransactionBody::new(&inputs, &outputs, 94, 10);
+        outputs.add(&TransactionOutput::new(&alice_addr(), Coin::new(10)));
+        let mut body = TransactionBody::new(&inputs, &outputs, Coin::new(94), 10);
         let mut withdrawals = Withdrawals::new();
-        withdrawals.insert(&RewardAddress::new(0, &alice_pay()), 100);
+        withdrawals.insert(&RewardAddress::new(0, &alice_pay()), Coin::new(100));
         body.set_withdrawals(&withdrawals);
         let w = make_mock_witnesses_vkey(&body, vec![&alice_key(), &alice_key()]);
         let tx = Transaction::new(&body, &w, None);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -38,7 +38,47 @@ impl UnitInterval {
     }
 }
 
-type Coin = u64;
+// Specifies an amount of ADA in terms of lovelace
+// String functions are for environemnts that don't support u64 or BigInt/etc
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Coin(u64);
+
+to_from_bytes!(Coin);
+
+#[wasm_bindgen]
+impl Coin {
+    // May not be supported in all environments as it maps to BigInt with wasm_bindgen
+    pub fn new(value: u64) -> Coin {
+        Self(value)
+    }
+
+    // Create a Coin from a standard rust string representation
+    pub fn from_str(string: &str) -> Result<Coin, JsValue> {
+        string.parse::<u64>()
+            .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
+            .map(Coin)
+    }
+
+    // String representation of the Coin value for use from environemtnst hat don't support BigInt
+    pub fn to_str(&self) -> String {
+        format!("{}", self.0)
+    }
+
+    pub fn checked_add(&self, other: &Coin) -> Result<Coin, JsValue> {
+        match self.0.checked_add(other.0) {
+            Some(value) => Ok(Coin(value)),
+            None => Err(JsValue::from_str("overflow")),
+        }
+    }
+
+    pub fn checked_sub(&self, other: &Coin) -> Result<Coin, JsValue> {
+        match self.0.checked_sub(other.0) {
+            Some(value) => Ok(Coin(value)),
+            None => Err(JsValue::from_str("underflow")),
+        }
+    }
+}
 
 type Epoch = u32;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -485,64 +485,37 @@ impl Certificate {
     }
 }
 
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-enum I0OrI1Enum {
-    I0,
-    I1,
-}
-
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct I0OrI1(I0OrI1Enum);
-
-#[wasm_bindgen]
-impl I0OrI1 {
-    pub fn new_i0() -> Self {
-        Self(I0OrI1Enum::I0)
-    }
-
-    pub fn new_i1() -> Self {
-        Self(I0OrI1Enum::I1)
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct MapStakeCredentialToCoin(std::collections::BTreeMap<StakeCredential, Coin>);
-
-to_from_bytes!(MapStakeCredentialToCoin);
-
-#[wasm_bindgen]
-impl MapStakeCredentialToCoin {
-    pub fn new() -> Self {
-        Self(std::collections::BTreeMap::new())
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn insert(&mut self, key: &StakeCredential, value: Coin) -> Option<Coin> {
-        self.0.insert(key.clone(), value)
-    }
+pub enum MIRPot {
+    Reserves,
+    Treasury,
 }
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct MoveInstantaneousReward {
-    index_0: I0OrI1,
-    index_1: MapStakeCredentialToCoin,
+    pot: MIRPot,
+    rewards: std::collections::BTreeMap<StakeCredential, Coin>,
 }
 
 to_from_bytes!(MoveInstantaneousReward);
 
 #[wasm_bindgen]
 impl MoveInstantaneousReward {
-    pub fn new(index_0: &I0OrI1, index_1: &MapStakeCredentialToCoin) -> Self {
+    pub fn new(pot: MIRPot) -> Self {
         Self {
-            index_0: index_0.clone(),
-            index_1: index_1.clone(),
+            pot,
+            rewards: std::collections::BTreeMap::new()
         }
+    }
+
+    pub fn len(&self) -> usize {
+        self.rewards.len()
+    }
+
+    pub fn insert(&mut self, key: &StakeCredential, value: Coin) -> Option<Coin> {
+        self.rewards.insert(key.clone(), value)
     }
 }
 

--- a/rust/src/serialization.rs
+++ b/rust/src/serialization.rs
@@ -52,6 +52,21 @@ impl DeserializeEmbeddedGroup for UnitInterval {
     }
 }
 
+impl cbor_event::se::Serialize for Coin {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_unsigned_integer(self.0)
+    }
+}
+
+impl Deserialize for Coin {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        match raw.unsigned_integer() {
+            Ok(value) => Ok(Self(value)),
+            Err(e) => Err(DeserializeError::new("Coin", DeserializeFailure::CBOR(e))),
+        }
+    }
+}
+
 impl cbor_event::se::Serialize for Transaction {
     fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer.write_array(cbor_event::Len::Len(3))?;

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -82,17 +82,17 @@ describe('Transactions', () => {
       txOutputs.add(
         CardanoWasm.TransactionOutput.new(
           CardanoWasm.Address.from_bytes(
-            // Buffer.from('61a6274badf4c9ca583df893a73139625ff4dc73aaa3082e67d6d5d08e0ce3daa4', 'hex'),
             Buffer.from('61a6274badf4c9ca583df893a73139625ff4dc73aaa3082e67d6d5d08e', 'hex'),
           ),
-          BigInt(1),
+          // we can construct Coin from both BigInt (here) or from a string (below in fee)
+          CardanoWasm.Coin.new(BigInt(1)),
         )
       );
     }
     const txBody = CardanoWasm.TransactionBody.new(
       txInputs,
       txOutputs,
-      BigInt(42), // fee
+      CardanoWasm.Coin.from_str("42"), // fee
       10, // ttl
     );
     


### PR DESCRIPTION
Coin:

Instead of just a u64, which is converted to BigNum in wasm, we have our
own wrapper type similar to js-chain-libs.

The reason for this is that BigNum might not exist in all frameworks (e.g. ReactNative) so we need to have the ability to create/get them as strings.

MoveInstantaneousRewards:

In the last shelley.cddl re-gen I didn't notice move_instantaneous_reward added in a source enum but it's just specified as `0 / 1` in the spec which gives really ugly confusing code so I just made it a proper enum and cleaned up the classes and merged the two.

They're just in one PR since they're small and MoveInstantaneousRewards uses Coin