### PR TITLE
Change hash sizes

### DIFF
--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -672,10 +672,9 @@ macro_rules! impl_hash_type {
 
 impl_hash_type!(AddrKeyHash, 28);
 impl_hash_type!(ScriptHash, 28);
-
 impl_hash_type!(TransactionHash, 32);
-impl_hash_type!(GenesisDelegateHash, 32);
-impl_hash_type!(PoolKeyHash, 32);
-impl_hash_type!(GenesisHash, 32);
+impl_hash_type!(GenesisDelegateHash, 28);
+impl_hash_type!(PoolKeyHash, 28);
+impl_hash_type!(GenesisHash, 28);
 impl_hash_type!(MetadataHash, 32);
-impl_hash_type!(VRFKeyHash, 32);
+impl_hash_type!(VRFKeyHash, 28);


### PR DESCRIPTION
The Haskell codebase changed all keyhashes to 28 bytes so we follow suit.