### PR TITLE
Move coins to utils file

### DIFF
--- a/rust/src/fees.rs
+++ b/rust/src/fees.rs
@@ -1,4 +1,5 @@
 use super::*;
+use utils::*;
 
 // size (including major type tag) in CBOR for a uint
 fn cbor_uint_length(x: u64) -> usize {
@@ -34,7 +35,7 @@ fn txsize(tx: &Transaction) -> usize {
     const OUTPUT_SIZE: usize = SMALL_ARRAY + UINT + ADDRESS;
     let input_bytes = tx.body.inputs.to_bytes().len();
     let output_bytes = tx.body.outputs.to_bytes().len();
-    let fee_bytes = cbor_uint_length(tx.body.fee.0);
+    let fee_bytes = cbor_uint_length(tx.body.fee.unwrap());
     let extra_size = input_bytes + output_bytes + fee_bytes;
     let rest = tx.to_bytes().len() - extra_size;
     tx.body.inputs.len() * INPUT_SIZE + tx.body.outputs.len() * OUTPUT_SIZE + rest

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -11,6 +11,7 @@ use cbor_event::Special as CBORSpecial;
 pub mod address;
 pub mod crypto;
 pub mod fees;
+pub mod utils;
 #[macro_use]
 pub mod prelude;
 pub mod serialization;
@@ -18,6 +19,7 @@ pub mod serialization;
 use address::*;
 use crypto::*;
 use prelude::*;
+use utils::*;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -42,58 +44,6 @@ impl UnitInterval {
         Self {
             index_0: index_0,
             index_1: index_1,
-        }
-    }
-}
-
-// Specifies an amount of ADA in terms of lovelace
-// String functions are for environments that don't support u64 or BigInt/etc
-#[wasm_bindgen]
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Coin(u64);
-
-to_from_bytes!(Coin);
-
-#[wasm_bindgen]
-impl Coin {
-    // May not be supported in all environments as it maps to BigInt with wasm_bindgen
-    pub fn new(value: u64) -> Coin {
-        Self(value)
-    }
-    pub fn unwrap(&self) -> u64 {
-        self.0
-    }
-
-    // Create a Coin from a standard rust string representation
-    pub fn from_str(string: &str) -> Result<Coin, JsValue> {
-        string.parse::<u64>()
-            .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
-            .map(Coin)
-    }
-
-    // String representation of the Coin value for use from environments that don't support BigInt
-    pub fn to_str(&self) -> String {
-        format!("{}", self.0)
-    }
-
-    pub fn checked_mul(&self, other: &Coin) -> Result<Coin, JsValue> {
-        match self.0.checked_mul(other.0) {
-            Some(value) => Ok(Coin(value)),
-            None => Err(JsValue::from_str("overflow")),
-        }
-    }
-
-    pub fn checked_add(&self, other: &Coin) -> Result<Coin, JsValue> {
-        match self.0.checked_add(other.0) {
-            Some(value) => Ok(Coin(value)),
-            None => Err(JsValue::from_str("overflow")),
-        }
-    }
-
-    pub fn checked_sub(&self, other: &Coin) -> Result<Coin, JsValue> {
-        match self.0.checked_sub(other.0) {
-            Some(value) => Ok(Coin(value)),
-            None => Err(JsValue::from_str("underflow")),
         }
     }
 }

--- a/rust/src/serialization.rs
+++ b/rust/src/serialization.rs
@@ -52,21 +52,6 @@ impl DeserializeEmbeddedGroup for UnitInterval {
     }
 }
 
-impl cbor_event::se::Serialize for Coin {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_unsigned_integer(self.0)
-    }
-}
-
-impl Deserialize for Coin {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        match raw.unsigned_integer() {
-            Ok(value) => Ok(Self(value)),
-            Err(e) => Err(DeserializeError::new("Coin", DeserializeFailure::CBOR(e))),
-        }
-    }
-}
-
 impl cbor_event::se::Serialize for Transaction {
     fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer.write_array(cbor_event::Len::Len(3))?;

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -1,0 +1,69 @@
+
+use super::*;
+
+// Specifies an amount of ADA in terms of lovelace
+// String functions are for environments that don't support u64 or BigInt/etc
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Coin(u64);
+
+to_from_bytes!(Coin);
+
+#[wasm_bindgen]
+impl Coin {
+    // May not be supported in all environments as it maps to BigInt with wasm_bindgen
+    pub fn new(value: u64) -> Coin {
+        Self(value)
+    }
+    pub fn unwrap(&self) -> u64 {
+        self.0
+    }
+
+    // Create a Coin from a standard rust string representation
+    pub fn from_str(string: &str) -> Result<Coin, JsValue> {
+        string.parse::<u64>()
+            .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
+            .map(Coin)
+    }
+
+    // String representation of the Coin value for use from environments that don't support BigInt
+    pub fn to_str(&self) -> String {
+        format!("{}", self.0)
+    }
+
+    pub fn checked_mul(&self, other: &Coin) -> Result<Coin, JsValue> {
+        match self.0.checked_mul(other.0) {
+            Some(value) => Ok(Coin(value)),
+            None => Err(JsValue::from_str("overflow")),
+        }
+    }
+
+    pub fn checked_add(&self, other: &Coin) -> Result<Coin, JsValue> {
+        match self.0.checked_add(other.0) {
+            Some(value) => Ok(Coin(value)),
+            None => Err(JsValue::from_str("overflow")),
+        }
+    }
+
+    pub fn checked_sub(&self, other: &Coin) -> Result<Coin, JsValue> {
+        match self.0.checked_sub(other.0) {
+            Some(value) => Ok(Coin(value)),
+            None => Err(JsValue::from_str("underflow")),
+        }
+    }
+}
+
+impl cbor_event::se::Serialize for Coin {
+  fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+      serializer.write_unsigned_integer(self.0)
+  }
+}
+
+impl Deserialize for Coin {
+  fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+      match raw.unsigned_integer() {
+          Ok(value) => Ok(Self(value)),
+          Err(e) => Err(DeserializeError::new("Coin", DeserializeFailure::CBOR(e))),
+      }
+  }
+}


### PR DESCRIPTION
This moves the `Coin` definition to a utils file like we've discussed before. The idea is to make sure `lib.rs` and `serialization` have as little hand-written code as possible