### PR TITLE
Add minimum UTXO value support

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -2193,9 +2193,13 @@ declare export class TransactionBuilder {
 
   /**
    * @param {LinearFee} linear_fee
+   * @param {BigNum} minimum_utxo_val
    * @returns {TransactionBuilder}
    */
-  static new(linear_fee: LinearFee): TransactionBuilder;
+  static new(
+    linear_fee: LinearFee,
+    minimum_utxo_val: BigNum
+  ): TransactionBuilder;
 
   /**
    * @returns {BigNum}


### PR DESCRIPTION
Haskell Shelley has a concept of a minimum value for a newly created UTXO entry. It's set by a protocol parameter that can change over time. We expose this as an input into our transaction builder.