### PR TITLE
Fix withdrawal/cert transactions

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -2212,22 +2212,34 @@ declare export class TransactionBuilder {
   /**
    * @param {LinearFee} linear_fee
    * @param {BigNum} minimum_utxo_val
+   * @param {BigNum} pool_deposit
+   * @param {BigNum} key_deposit
    * @returns {TransactionBuilder}
    */
   static new(
     linear_fee: LinearFee,
-    minimum_utxo_val: BigNum
+    minimum_utxo_val: BigNum,
+    pool_deposit: BigNum,
+    key_deposit: BigNum
   ): TransactionBuilder;
 
   /**
+   * does not include refunds or withdrawals
    * @returns {BigNum}
    */
-  get_input_total(): BigNum;
+  get_explicit_input(): BigNum;
 
   /**
+   * withdrawals and refunds
    * @returns {BigNum}
    */
-  get_feeless_output_total(): BigNum;
+  get_implicit_input(): BigNum;
+
+  /**
+   * does not include fee
+   * @returns {BigNum}
+   */
+  get_explicit_output(): BigNum;
 
   /**
    * @returns {BigNum}
@@ -2235,6 +2247,7 @@ declare export class TransactionBuilder {
   get_fee_or_calc(): BigNum;
 
   /**
+   * Warning: this function will mutate the /fee/ field
    * @param {Address} address
    * @returns {boolean}
    */

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -262,7 +262,6 @@ impl TransactionBuilder {
                 .try_fold(
                     Coin::new(0),
                     |acc, ref cert| match &cert.0 {
-                        // tx builder doesn't take into account refunds on deregistration
                         CertificateEnum::PoolRetirement(_cert) => acc.checked_add(&self.pool_deposit),
                         CertificateEnum::StakeDeregistration(_cert) => acc.checked_add(&self.key_deposit),
                         _ => Ok(acc),


### PR DESCRIPTION
This PR makes a fix fixes to the tx builder:

1) Probably takes withdrawals into account for change calculation
3) Fix the fee calculation on stake key registration (accidentally added one vkey too many)
4) Add key registration and deregistration deposits&refunds into tx builder