### PR TITLE
feat: allow different bech32 address prefixes

### DIFF
--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -380,8 +380,8 @@ impl Address {
         })().map_err(|e| e.annotate("Address"))
     }
 
-    pub fn to_bech32(&self) -> String {
-        bech32::encode("addr", self.to_bytes().to_base32()).unwrap()
+    pub fn to_bech32(&self, prefix: Option<String>) -> String {
+        bech32::encode(&prefix.unwrap_or("addr".to_string()), self.to_bytes().to_base32()).unwrap()
     }
 
     pub fn from_bech32(bech_str: &str) -> Result<Address, JsValue> {
@@ -695,9 +695,9 @@ mod tests {
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
         let stake_cred = StakeCredential::from_keyhash(&stake.to_raw_key().hash());
         let addr_net_0 = BaseAddress::new(0, &spend_cred, &stake_cred).to_address();
-        assert_eq!(addr_net_0.to_bech32(), "addr1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqcyl47r");
+        assert_eq!(addr_net_0.to_bech32(None), "addr1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqcyl47r");
         let addr_net_3 = BaseAddress::new(3, &spend_cred, &stake_cred).to_address();
-        assert_eq!(addr_net_3.to_bech32(), "addr1qw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqzhyupd");
+        assert_eq!(addr_net_3.to_bech32(None), "addr1qw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqzhyupd");
     }
 
     #[test]
@@ -711,9 +711,9 @@ mod tests {
             .to_public();
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
         let addr_net_0 = EnterpriseAddress::new(0, &spend_cred).to_address();
-        assert_eq!(addr_net_0.to_bech32(), "addr1vz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers6g8jlq");
+        assert_eq!(addr_net_0.to_bech32(None), "addr1vz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers6g8jlq");
         let addr_net_3 = EnterpriseAddress::new(3, &spend_cred).to_address();
-        assert_eq!(addr_net_3.to_bech32(), "addr1vw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers6h7glf");
+        assert_eq!(addr_net_3.to_bech32(None), "addr1vw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers6h7glf");
     }
 
     #[test]
@@ -727,9 +727,9 @@ mod tests {
             .to_public();
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
         let addr_net_0 = PointerAddress::new(0, &spend_cred, &Pointer::new(1, 2, 3)).to_address();
-        assert_eq!(addr_net_0.to_bech32(), "addr1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspqgpslhplej");
+        assert_eq!(addr_net_0.to_bech32(None), "addr1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspqgpslhplej");
         let addr_net_3 = PointerAddress::new(3, &spend_cred, &Pointer::new(24157, 177, 42)).to_address();
-        assert_eq!(addr_net_3.to_bech32(), "addr1gw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5ph3wczvf2x4v58t");
+        assert_eq!(addr_net_3.to_bech32(None), "addr1gw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5ph3wczvf2x4v58t");
     }
 
     #[test]
@@ -751,9 +751,9 @@ mod tests {
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
         let stake_cred = StakeCredential::from_keyhash(&stake.to_raw_key().hash());
         let addr_net_0 = BaseAddress::new(0, &spend_cred, &stake_cred).to_address();
-        assert_eq!(addr_net_0.to_bech32(), "addr1qpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qwmnp2v");
+        assert_eq!(addr_net_0.to_bech32(None), "addr1qpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qwmnp2v");
         let addr_net_3 = BaseAddress::new(3, &spend_cred, &stake_cred).to_address();
-        assert_eq!(addr_net_3.to_bech32(), "addr1qdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2q5ggg4z");
+        assert_eq!(addr_net_3.to_bech32(None), "addr1qdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2q5ggg4z");
     }
 
     #[test]
@@ -767,9 +767,9 @@ mod tests {
             .to_public();
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
         let addr_net_0 = EnterpriseAddress::new(0, &spend_cred).to_address();
-        assert_eq!(addr_net_0.to_bech32(), "addr1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0yu80w");
+        assert_eq!(addr_net_0.to_bech32(None), "addr1vpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0yu80w");
         let addr_net_3 = EnterpriseAddress::new(3, &spend_cred).to_address();
-        assert_eq!(addr_net_3.to_bech32(), "addr1vdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0m9a08");
+        assert_eq!(addr_net_3.to_bech32(None), "addr1vdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5eg0m9a08");
     }
 
     #[test]
@@ -783,9 +783,9 @@ mod tests {
             .to_public();
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
         let addr_net_0 = PointerAddress::new(0, &spend_cred, &Pointer::new(1, 2, 3)).to_address();
-        assert_eq!(addr_net_0.to_bech32(), "addr1gpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5egpqgpsjej5ck");
+        assert_eq!(addr_net_0.to_bech32(None), "addr1gpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5egpqgpsjej5ck");
         let addr_net_3 = PointerAddress::new(3, &spend_cred, &Pointer::new(24157, 177, 42)).to_address();
-        assert_eq!(addr_net_3.to_bech32(), "addr1gdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5evph3wczvf27l8yfx");
+        assert_eq!(addr_net_3.to_bech32(None), "addr1gdu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5evph3wczvf27l8yfx");
     }
 
     #[test]
@@ -825,9 +825,9 @@ mod tests {
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
         let stake_cred = StakeCredential::from_keyhash(&stake.to_raw_key().hash());
         let addr_net_0 = BaseAddress::new(0, &spend_cred, &stake_cred).to_address();
-        assert_eq!(addr_net_0.to_bech32(), "addr1qqy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmn8k8ttq8f3gag0h89aepvx3xf69g0l9pf80tqv7cve0l33su9wxrs");
+        assert_eq!(addr_net_0.to_bech32(None), "addr1qqy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmn8k8ttq8f3gag0h89aepvx3xf69g0l9pf80tqv7cve0l33su9wxrs");
         let addr_net_3 = BaseAddress::new(3, &spend_cred, &stake_cred).to_address();
-        assert_eq!(addr_net_3.to_bech32(), "addr1qvy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmn8k8ttq8f3gag0h89aepvx3xf69g0l9pf80tqv7cve0l33sxk40u7");
+        assert_eq!(addr_net_3.to_bech32(None), "addr1qvy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmn8k8ttq8f3gag0h89aepvx3xf69g0l9pf80tqv7cve0l33sxk40u7");
     }
 
     #[test]
@@ -841,9 +841,9 @@ mod tests {
             .to_public();
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
         let addr_net_0 = EnterpriseAddress::new(0, &spend_cred).to_address();
-        assert_eq!(addr_net_0.to_bech32(), "addr1vqy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnqsg0y49");
+        assert_eq!(addr_net_0.to_bech32(None), "addr1vqy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnqsg0y49");
         let addr_net_3 = EnterpriseAddress::new(3, &spend_cred).to_address();
-        assert_eq!(addr_net_3.to_bech32(), "addr1vvy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnqshk74v");
+        assert_eq!(addr_net_3.to_bech32(None), "addr1vvy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnqshk74v");
     }
 
     #[test]
@@ -857,8 +857,8 @@ mod tests {
             .to_public();
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
         let addr_net_0 = PointerAddress::new(0, &spend_cred, &Pointer::new(1, 2, 3)).to_address();
-        assert_eq!(addr_net_0.to_bech32(), "addr1gqy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnqpqgpst4xf0c");
+        assert_eq!(addr_net_0.to_bech32(None), "addr1gqy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnqpqgpst4xf0c");
         let addr_net_3 = PointerAddress::new(3, &spend_cred, &Pointer::new(24157, 177, 42)).to_address();
-        assert_eq!(addr_net_3.to_bech32(), "addr1gvy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnyph3wczvf29j6huk");
+        assert_eq!(addr_net_3.to_bech32(None), "addr1gvy6nhfyks7wdu3dudslys37v252w2nwhv0fw2nfawemmnyph3wczvf29j6huk");
     }
 }


### PR DESCRIPTION
# Decription

This PR allows custom bech32 prefixes.

BREAKING CHANGE: Rust API requires an new `Option` parameter. JS bindings will accept `undefined` and default value will be used.

Closes: #32

# Questions

@SebastienGllmt in order to remove draft status there are two main things I need to finish / decide:

1. Do you like the `Option` approach or do you think it's best to add a new function? Something like:

```rust
pub fn to_bech32_with_prefix(&self, prefix: &str) -> String {
}
```
As far as I understand, it's breaking the Rust API but not the TS / Flow one. I'm not sure how this lib is used (we are using it from NodeJS) so it might be a better idea to keep the API stable. Let me know and I'll change it.

2. What do you think it's the best approach to test this? I can create a test vector using `cardano-cli` or try to generate one for each test you already have (I think you took them from [here](https://gist.github.com/KtorZ/b2e4e1459425a46df51c023fda9609c8))
