### PR TITLE
Fixed serialization issue with MoveInstantaneousReward

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -6,13 +6,6 @@
  */
 
 /**
- * @param {Transaction} tx
- * @param {LinearFee} linear_fee
- * @returns {BigNum}
- */
-declare export function min_fee(tx: Transaction, linear_fee: LinearFee): BigNum;
-
-/**
  * @param {TransactionHash} tx_body_hash
  * @param {ByronAddress} addr
  * @param {LegacyDaedalusPrivateKey} key
@@ -85,6 +78,13 @@ declare export function get_deposit(
   pool_deposit: BigNum,
   key_deposit: BigNum
 ): BigNum;
+
+/**
+ * @param {Transaction} tx
+ * @param {LinearFee} linear_fee
+ * @returns {BigNum}
+ */
+declare export function min_fee(tx: Transaction, linear_fee: LinearFee): BigNum;
 
 /**
  */

--- a/rust/src/serialization.rs
+++ b/rust/src/serialization.rs
@@ -1082,7 +1082,7 @@ impl Deserialize for StakeCredentials {
 
 impl cbor_event::se::Serialize for MoveInstantaneousReward {
     fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_map(cbor_event::Len::Len(2))?;
+        serializer.write_array(cbor_event::Len::Len(2))?;
         match self.pot {
             MIRPot::Reserves => serializer.write_unsigned_integer(0u64),
             MIRPot::Treasury => serializer.write_unsigned_integer(1u64),


### PR DESCRIPTION
The incorrect CBOR tag (map) was written instead of an array tag.