### PR TITLE
Generate Block-related structs

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -413,6 +413,72 @@ declare export class Bip32PublicKey {
 }
 /**
  */
+declare export class Block {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {Block}
+   */
+  static from_bytes(bytes: Uint8Array): Block;
+
+  /**
+   * @returns {Header}
+   */
+  header(): Header;
+
+  /**
+   * @returns {TransactionBodies}
+   */
+  transaction_bodies(): TransactionBodies;
+
+  /**
+   * @returns {TransactionWitnessSets}
+   */
+  transaction_witness_sets(): TransactionWitnessSets;
+
+  /**
+   * @returns {MapTransactionIndexToTransactionMetadata}
+   */
+  transaction_metadata_set(): MapTransactionIndexToTransactionMetadata;
+
+  /**
+   * @param {Header} header
+   * @param {TransactionBodies} transaction_bodies
+   * @param {TransactionWitnessSets} transaction_witness_sets
+   * @param {MapTransactionIndexToTransactionMetadata} transaction_metadata_set
+   * @returns {Block}
+   */
+  static new(
+    header: Header,
+    transaction_bodies: TransactionBodies,
+    transaction_witness_sets: TransactionWitnessSets,
+    transaction_metadata_set: MapTransactionIndexToTransactionMetadata
+  ): Block;
+}
+/**
+ */
+declare export class BlockHash {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {BlockHash}
+   */
+  static from_bytes(bytes: Uint8Array): BlockHash;
+}
+/**
+ */
 declare export class BootstrapWitness {
   free(): void;
 
@@ -921,6 +987,138 @@ declare export class GenesisKeyDelegation {
 }
 /**
  */
+declare export class Header {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {Header}
+   */
+  static from_bytes(bytes: Uint8Array): Header;
+
+  /**
+   * @returns {HeaderBody}
+   */
+  header_body(): HeaderBody;
+
+  /**
+   * @returns {KESSignature}
+   */
+  body_signature(): KESSignature;
+
+  /**
+   * @param {HeaderBody} header_body
+   * @param {KESSignature} body_signature
+   * @returns {Header}
+   */
+  static new(header_body: HeaderBody, body_signature: KESSignature): Header;
+}
+/**
+ */
+declare export class HeaderBody {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {HeaderBody}
+   */
+  static from_bytes(bytes: Uint8Array): HeaderBody;
+
+  /**
+   * @returns {number}
+   */
+  block_number(): number;
+
+  /**
+   * @returns {number}
+   */
+  slot(): number;
+
+  /**
+   * @returns {BlockHash | void}
+   */
+  prev_hash(): BlockHash | void;
+
+  /**
+   * @returns {Vkey}
+   */
+  issuer_vkey(): Vkey;
+
+  /**
+   * @returns {VRFVKey}
+   */
+  vrf_vkey(): VRFVKey;
+
+  /**
+   * @returns {VRFCert}
+   */
+  nonce_vrf(): VRFCert;
+
+  /**
+   * @returns {VRFCert}
+   */
+  leader_vrf(): VRFCert;
+
+  /**
+   * @returns {number}
+   */
+  block_body_size(): number;
+
+  /**
+   * @returns {BlockHash}
+   */
+  block_body_hash(): BlockHash;
+
+  /**
+   * @returns {OperationalCert}
+   */
+  operational_cert(): OperationalCert;
+
+  /**
+   * @returns {ProtocolVersion}
+   */
+  protocol_version(): ProtocolVersion;
+
+  /**
+   * @param {number} block_number
+   * @param {number} slot
+   * @param {BlockHash | void} prev_hash
+   * @param {Vkey} issuer_vkey
+   * @param {VRFVKey} vrf_vkey
+   * @param {VRFCert} nonce_vrf
+   * @param {VRFCert} leader_vrf
+   * @param {number} block_body_size
+   * @param {BlockHash} block_body_hash
+   * @param {OperationalCert} operational_cert
+   * @param {ProtocolVersion} protocol_version
+   * @returns {HeaderBody}
+   */
+  static new(
+    block_number: number,
+    slot: number,
+    prev_hash: BlockHash | void,
+    issuer_vkey: Vkey,
+    vrf_vkey: VRFVKey,
+    nonce_vrf: VRFCert,
+    leader_vrf: VRFCert,
+    block_body_size: number,
+    block_body_hash: BlockHash,
+    operational_cert: OperationalCert,
+    protocol_version: ProtocolVersion
+  ): HeaderBody;
+}
+/**
+ */
 declare export class Int {
   free(): void;
 
@@ -982,6 +1180,38 @@ declare export class Ipv6 {
 }
 /**
  */
+declare export class KESSignature {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {KESSignature}
+   */
+  static from_bytes(bytes: Uint8Array): KESSignature;
+}
+/**
+ */
+declare export class KESVKey {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {KESVKey}
+   */
+  static from_bytes(bytes: Uint8Array): KESVKey;
+}
+/**
+ */
 declare export class LegacyDaedalusPrivateKey {
   free(): void;
 
@@ -1022,6 +1252,39 @@ declare export class LinearFee {
    * @returns {LinearFee}
    */
   static new(coefficient: BigNum, constant: BigNum): LinearFee;
+}
+/**
+ */
+declare export class MapTransactionIndexToTransactionMetadata {
+  free(): void;
+
+  /**
+   * @returns {MapTransactionIndexToTransactionMetadata}
+   */
+  static new(): MapTransactionIndexToTransactionMetadata;
+
+  /**
+   * @returns {number}
+   */
+  len(): number;
+
+  /**
+   * @param {number} key
+   * @param {TransactionMetadata} value
+   * @returns {TransactionMetadata | void}
+   */
+  insert(key: number, value: TransactionMetadata): TransactionMetadata | void;
+
+  /**
+   * @param {number} key
+   * @returns {TransactionMetadata | void}
+   */
+  get(key: number): TransactionMetadata | void;
+
+  /**
+   * @returns {Uint32Array}
+   */
+  keys(): Uint32Array;
 }
 /**
  */
@@ -1440,6 +1703,56 @@ declare export class Nonce {
    * @returns {Uint8Array | void}
    */
   get_hash(): Uint8Array | void;
+}
+/**
+ */
+declare export class OperationalCert {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {OperationalCert}
+   */
+  static from_bytes(bytes: Uint8Array): OperationalCert;
+
+  /**
+   * @returns {KESVKey}
+   */
+  hot_vkey(): KESVKey;
+
+  /**
+   * @returns {number}
+   */
+  sequence_number(): number;
+
+  /**
+   * @returns {number}
+   */
+  kes_period(): number;
+
+  /**
+   * @returns {Ed25519Signature}
+   */
+  sigma(): Ed25519Signature;
+
+  /**
+   * @param {KESVKey} hot_vkey
+   * @param {number} sequence_number
+   * @param {number} kes_period
+   * @param {Ed25519Signature} sigma
+   * @returns {OperationalCert}
+   */
+  static new(
+    hot_vkey: KESVKey,
+    sequence_number: number,
+    kes_period: number,
+    sigma: Ed25519Signature
+  ): OperationalCert;
 }
 /**
  */
@@ -2560,6 +2873,43 @@ declare export class Transaction {
 }
 /**
  */
+declare export class TransactionBodies {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {TransactionBodies}
+   */
+  static from_bytes(bytes: Uint8Array): TransactionBodies;
+
+  /**
+   * @returns {TransactionBodies}
+   */
+  static new(): TransactionBodies;
+
+  /**
+   * @returns {number}
+   */
+  len(): number;
+
+  /**
+   * @param {number} index
+   * @returns {TransactionBody}
+   */
+  get(index: number): TransactionBody;
+
+  /**
+   * @param {TransactionBody} elem
+   */
+  add(elem: TransactionBody): void;
+}
+/**
+ */
 declare export class TransactionBody {
   free(): void;
 
@@ -3185,6 +3535,43 @@ declare export class TransactionWitnessSet {
 }
 /**
  */
+declare export class TransactionWitnessSets {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {TransactionWitnessSets}
+   */
+  static from_bytes(bytes: Uint8Array): TransactionWitnessSets;
+
+  /**
+   * @returns {TransactionWitnessSets}
+   */
+  static new(): TransactionWitnessSets;
+
+  /**
+   * @returns {number}
+   */
+  len(): number;
+
+  /**
+   * @param {number} index
+   * @returns {TransactionWitnessSet}
+   */
+  get(index: number): TransactionWitnessSet;
+
+  /**
+   * @param {TransactionWitnessSet} elem
+   */
+  add(elem: TransactionWitnessSet): void;
+}
+/**
+ */
 declare export class UnitInterval {
   free(): void;
 
@@ -3254,6 +3641,39 @@ declare export class Update {
 }
 /**
  */
+declare export class VRFCert {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {VRFCert}
+   */
+  static from_bytes(bytes: Uint8Array): VRFCert;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  output(): Uint8Array;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  proof(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} output
+   * @param {Uint8Array} proof
+   * @returns {VRFCert}
+   */
+  static new(output: Uint8Array, proof: Uint8Array): VRFCert;
+}
+/**
+ */
 declare export class VRFKeyHash {
   free(): void;
 
@@ -3267,6 +3687,22 @@ declare export class VRFKeyHash {
    * @returns {VRFKeyHash}
    */
   static from_bytes(bytes: Uint8Array): VRFKeyHash;
+}
+/**
+ */
+declare export class VRFVKey {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {VRFVKey}
+   */
+  static from_bytes(bytes: Uint8Array): VRFVKey;
 }
 /**
  */

--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -728,6 +728,12 @@ impl_hash_type!(GenesisDelegateHash, 28);
 impl_hash_type!(GenesisHash, 28);
 impl_hash_type!(MetadataHash, 32);
 impl_hash_type!(VRFKeyHash, 28);
+impl_hash_type!(BlockHash, 32);
+// We might want to make these two vkeys normal classes later but for now it's just arbitrary bytes for us (used in block parsing)
+impl_hash_type!(VRFVKey, 8);
+impl_hash_type!(KESVKey, 8);
+// same for this signature
+impl_hash_type!(KESSignature, 32);
 
 // Evolving nonce type (used for Update's crypto)
 #[wasm_bindgen]
@@ -819,6 +825,77 @@ impl Deserialize for Nonce {
                 hash,
             })
         })().map_err(|e| e.annotate(stringify!($name)))
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct VRFCert {
+    output: Vec<u8>,
+    proof: Vec<u8>,
+}
+
+impl VRFCert {
+    pub const PROOF_LEN: usize = 10;
+}
+
+to_from_bytes!(VRFCert);
+
+#[wasm_bindgen]
+impl VRFCert {
+    pub fn output(&self) -> Vec<u8> {
+        self.output.clone()
+    }
+
+    pub fn proof(&self) -> Vec<u8> {
+        self.proof.clone()
+    }
+
+    pub fn new(output: Vec<u8>, proof: Vec<u8>) -> Result<VRFCert, JsValue> {
+        if proof.len() != Self::PROOF_LEN {
+            return Err(JsValue::from_str(&format!("proof len must be {} - found {}", Self::PROOF_LEN, proof.len())));
+        }
+        Ok(Self {
+            output: output,
+            proof: proof,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for VRFCert {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(2))?;
+        serializer.write_bytes(&self.output)?;
+        serializer.write_bytes(&self.proof)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for VRFCert {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let output = (|| -> Result<_, DeserializeError> {
+                Ok(raw.bytes()?)
+            })().map_err(|e| e.annotate("output"))?;
+            let proof = (|| -> Result<_, DeserializeError> {
+                Ok(raw.bytes()?)
+            })().map_err(|e| e.annotate("proof"))?;
+            if proof.len() != Self::PROOF_LEN {
+                return Err(DeserializeFailure::CBOR(cbor_event::Error::WrongLen(Self::PROOF_LEN as u64, cbor_event::Len::Len(proof.len() as u64), "proof length")).into());
+            }
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(VRFCert {
+                output,
+                proof,
+            })
+        })().map_err(|e| e.annotate("VRFCert"))
     }
 }
 

--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -730,10 +730,10 @@ impl_hash_type!(MetadataHash, 32);
 impl_hash_type!(VRFKeyHash, 28);
 impl_hash_type!(BlockHash, 32);
 // We might want to make these two vkeys normal classes later but for now it's just arbitrary bytes for us (used in block parsing)
-impl_hash_type!(VRFVKey, 8);
-impl_hash_type!(KESVKey, 8);
+impl_hash_type!(VRFVKey, 32);
+impl_hash_type!(KESVKey, 32);
 // same for this signature
-impl_hash_type!(KESSignature, 32);
+impl_hash_type!(KESSignature, 448);
 
 // Evolving nonce type (used for Update's crypto)
 #[wasm_bindgen]
@@ -836,7 +836,7 @@ pub struct VRFCert {
 }
 
 impl VRFCert {
-    pub const PROOF_LEN: usize = 10;
+    pub const PROOF_LEN: usize = 80;
 }
 
 to_from_bytes!(VRFCert);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1783,3 +1783,267 @@ impl ProtocolParamUpdate {
         }
     }
 }
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct TransactionBodies(Vec<TransactionBody>);
+
+to_from_bytes!(TransactionBodies);
+
+#[wasm_bindgen]
+impl TransactionBodies {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> TransactionBody {
+        self.0[index].clone()
+    }
+
+    pub fn add(&mut self, elem: &TransactionBody) {
+        self.0.push(elem.clone());
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct TransactionWitnessSets(Vec<TransactionWitnessSet>);
+
+to_from_bytes!(TransactionWitnessSets);
+#[wasm_bindgen]
+impl TransactionWitnessSets {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn get(&self, index: usize) -> TransactionWitnessSet {
+        self.0[index].clone()
+    }
+
+    pub fn add(&mut self, elem: &TransactionWitnessSet) {
+        self.0.push(elem.clone());
+    }
+}
+
+pub type TransactionIndexes = Vec<TransactionIndex>;
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct MapTransactionIndexToTransactionMetadata(std::collections::BTreeMap<TransactionIndex, TransactionMetadata>);
+
+#[wasm_bindgen]
+impl MapTransactionIndexToTransactionMetadata {
+    pub fn new() -> Self {
+        Self(std::collections::BTreeMap::new())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn insert(&mut self, key: TransactionIndex, value: &TransactionMetadata) -> Option<TransactionMetadata> {
+        self.0.insert(key, value.clone())
+    }
+
+    pub fn get(&self, key: TransactionIndex) -> Option<TransactionMetadata> {
+        self.0.get(&key).map(|v| v.clone())
+    }
+
+    pub fn keys(&self) -> TransactionIndexes {
+        self.0.iter().map(|(k, _v)| k.clone()).collect::<Vec<TransactionIndex>>()
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct Block {
+    header: Header,
+    transaction_bodies: TransactionBodies,
+    transaction_witness_sets: TransactionWitnessSets,
+    transaction_metadata_set: MapTransactionIndexToTransactionMetadata,
+}
+
+to_from_bytes!(Block);
+
+#[wasm_bindgen]
+impl Block {
+    pub fn header(&self) -> Header {
+        self.header.clone()
+    }
+
+    pub fn transaction_bodies(&self) -> TransactionBodies {
+        self.transaction_bodies.clone()
+    }
+
+    pub fn transaction_witness_sets(&self) -> TransactionWitnessSets {
+        self.transaction_witness_sets.clone()
+    }
+
+    pub fn transaction_metadata_set(&self) -> MapTransactionIndexToTransactionMetadata {
+        self.transaction_metadata_set.clone()
+    }
+
+    pub fn new(header: &Header, transaction_bodies: &TransactionBodies, transaction_witness_sets: &TransactionWitnessSets, transaction_metadata_set: &MapTransactionIndexToTransactionMetadata) -> Self {
+        Self {
+            header: header.clone(),
+            transaction_bodies: transaction_bodies.clone(),
+            transaction_witness_sets: transaction_witness_sets.clone(),
+            transaction_metadata_set: transaction_metadata_set.clone(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct Header {
+    header_body: HeaderBody,
+    body_signature: KESSignature,
+}
+
+to_from_bytes!(Header);
+
+#[wasm_bindgen]
+impl Header {
+    pub fn header_body(&self) -> HeaderBody {
+        self.header_body.clone()
+    }
+
+    pub fn body_signature(&self) -> KESSignature {
+        self.body_signature.clone()
+    }
+
+    pub fn new(header_body: &HeaderBody, body_signature: &KESSignature) -> Self {
+        Self {
+            header_body: header_body.clone(),
+            body_signature: body_signature.clone(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct OperationalCert {
+    hot_vkey: KESVKey,
+    sequence_number: u32,
+    kes_period: u32,
+    sigma: Ed25519Signature,
+}
+
+to_from_bytes!(OperationalCert);
+
+#[wasm_bindgen]
+impl OperationalCert {
+    pub fn hot_vkey(&self) -> KESVKey {
+        self.hot_vkey.clone()
+    }
+
+    pub fn sequence_number(&self) -> u32 {
+        self.sequence_number.clone()
+    }
+
+    pub fn kes_period(&self) -> u32 {
+        self.kes_period.clone()
+    }
+
+    pub fn sigma(&self) -> Ed25519Signature {
+        self.sigma.clone()
+    }
+
+    pub fn new(hot_vkey: &KESVKey, sequence_number: u32, kes_period: u32, sigma: &Ed25519Signature) -> Self {
+        Self {
+            hot_vkey: hot_vkey.clone(),
+            sequence_number: sequence_number,
+            kes_period: kes_period,
+            sigma: sigma.clone(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct HeaderBody {
+    block_number: u32,
+    slot: Slot,
+    prev_hash: Option<BlockHash>,
+    issuer_vkey: Vkey,
+    vrf_vkey: VRFVKey,
+    nonce_vrf: VRFCert,
+    leader_vrf: VRFCert,
+    block_body_size: u32,
+    block_body_hash: BlockHash,
+    operational_cert: OperationalCert,
+    protocol_version: ProtocolVersion,
+}
+
+to_from_bytes!(HeaderBody);
+
+#[wasm_bindgen]
+impl HeaderBody {
+    pub fn block_number(&self) -> u32 {
+        self.block_number.clone()
+    }
+
+    pub fn slot(&self) -> Slot {
+        self.slot.clone()
+    }
+
+    pub fn prev_hash(&self) -> Option<BlockHash> {
+        self.prev_hash.clone()
+    }
+
+    pub fn issuer_vkey(&self) -> Vkey {
+        self.issuer_vkey.clone()
+    }
+
+    pub fn vrf_vkey(&self) -> VRFVKey {
+        self.vrf_vkey.clone()
+    }
+
+    pub fn nonce_vrf(&self) -> VRFCert {
+        self.nonce_vrf.clone()
+    }
+
+    pub fn leader_vrf(&self) -> VRFCert {
+        self.leader_vrf.clone()
+    }
+
+    pub fn block_body_size(&self) -> u32 {
+        self.block_body_size.clone()
+    }
+
+    pub fn block_body_hash(&self) -> BlockHash {
+        self.block_body_hash.clone()
+    }
+
+    pub fn operational_cert(&self) -> OperationalCert {
+        self.operational_cert.clone()
+    }
+
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.protocol_version.clone()
+    }
+
+    pub fn new(block_number: u32, slot: Slot, prev_hash: Option<BlockHash>, issuer_vkey: &Vkey, vrf_vkey: &VRFVKey, nonce_vrf: &VRFCert, leader_vrf: &VRFCert, block_body_size: u32, block_body_hash: &BlockHash, operational_cert: &OperationalCert, protocol_version: &ProtocolVersion) -> Self {
+        Self {
+            block_number: block_number,
+            slot: slot,
+            prev_hash: prev_hash.clone(),
+            issuer_vkey: issuer_vkey.clone(),
+            vrf_vkey: vrf_vkey.clone(),
+            nonce_vrf: nonce_vrf.clone(),
+            leader_vrf: leader_vrf.clone(),
+            block_body_size: block_body_size,
+            block_body_hash: block_body_hash.clone(),
+            operational_cert: operational_cert.clone(),
+            protocol_version: protocol_version.clone(),
+        }
+    }
+}

--- a/rust/src/serialization.rs
+++ b/rust/src/serialization.rs
@@ -2603,3 +2603,342 @@ impl DeserializeEmbeddedGroup for ProtocolParamUpdate {
         })
     }
 }
+
+impl cbor_event::se::Serialize for TransactionBodies {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(self.0.len() as u64))?;
+        for element in &self.0 {
+            element.serialize(serializer)?;
+        }
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for TransactionBodies {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let mut arr = Vec::new();
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            while match len { cbor_event::Len::Len(n) => arr.len() < n as usize, cbor_event::Len::Indefinite => true, } {
+                if raw.cbor_type()? == CBORType::Special {
+                    assert_eq!(raw.special()?, CBORSpecial::Break);
+                    break;
+                }
+                arr.push(TransactionBody::deserialize(raw)?);
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("TransactionBodies"))?;
+        Ok(Self(arr))
+    }
+}
+
+impl cbor_event::se::Serialize for TransactionWitnessSets {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(self.0.len() as u64))?;
+        for element in &self.0 {
+            element.serialize(serializer)?;
+        }
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for TransactionWitnessSets {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let mut arr = Vec::new();
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            while match len { cbor_event::Len::Len(n) => arr.len() < n as usize, cbor_event::Len::Indefinite => true, } {
+                if raw.cbor_type()? == CBORType::Special {
+                    assert_eq!(raw.special()?, CBORSpecial::Break);
+                    break;
+                }
+                arr.push(TransactionWitnessSet::deserialize(raw)?);
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("TransactionWitnessSets"))?;
+        Ok(Self(arr))
+    }
+}
+
+impl cbor_event::se::Serialize for MapTransactionIndexToTransactionMetadata {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_map(cbor_event::Len::Len(self.0.len() as u64))?;
+        for (key, value) in &self.0 {
+            key.serialize(serializer)?;
+            value.serialize(serializer)?;
+        }
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for MapTransactionIndexToTransactionMetadata {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let mut table = std::collections::BTreeMap::new();
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.map()?;
+            while match len { cbor_event::Len::Len(n) => table.len() < n as usize, cbor_event::Len::Indefinite => true, } {
+                if raw.cbor_type()? == CBORType::Special {
+                    assert_eq!(raw.special()?, CBORSpecial::Break);
+                    break;
+                }
+                let key = TransactionIndex::deserialize(raw)?;
+                let value = TransactionMetadata::deserialize(raw)?;
+                if table.insert(key.clone(), value).is_some() {
+                    return Err(DeserializeFailure::DuplicateKey(Key::Str(String::from("some complicated/unsupported type"))).into());
+                }
+            }
+            Ok(())
+        })().map_err(|e| e.annotate("MapTransactionIndexToTransactionMetadata"))?;
+        Ok(Self(table))
+    }
+}
+
+impl cbor_event::se::Serialize for Block {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(4))?;
+        self.header.serialize(serializer)?;
+        self.transaction_bodies.serialize(serializer)?;
+        self.transaction_witness_sets.serialize(serializer)?;
+        self.transaction_metadata_set.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for Block {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("Block"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for Block {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        let header = (|| -> Result<_, DeserializeError> {
+            Ok(Header::deserialize(raw)?)
+        })().map_err(|e| e.annotate("header"))?;
+        let transaction_bodies = (|| -> Result<_, DeserializeError> {
+            Ok(TransactionBodies::deserialize(raw)?)
+        })().map_err(|e| e.annotate("transaction_bodies"))?;
+        let transaction_witness_sets = (|| -> Result<_, DeserializeError> {
+            Ok(TransactionWitnessSets::deserialize(raw)?)
+        })().map_err(|e| e.annotate("transaction_witness_sets"))?;
+        let transaction_metadata_set = (|| -> Result<_, DeserializeError> {
+            Ok(MapTransactionIndexToTransactionMetadata::deserialize(raw)?)
+        })().map_err(|e| e.annotate("transaction_metadata_set"))?;
+        Ok(Block {
+            header,
+            transaction_bodies,
+            transaction_witness_sets,
+            transaction_metadata_set,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for Header {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(2))?;
+        self.header_body.serialize(serializer)?;
+        self.body_signature.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for Header {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("Header"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for Header {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        let header_body = (|| -> Result<_, DeserializeError> {
+            Ok(HeaderBody::deserialize(raw)?)
+        })().map_err(|e| e.annotate("header_body"))?;
+        let body_signature = (|| -> Result<_, DeserializeError> {
+            Ok(KESSignature::deserialize(raw)?)
+        })().map_err(|e| e.annotate("body_signature"))?;
+        Ok(Header {
+            header_body,
+            body_signature,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for OperationalCert {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(4))?;
+        self.serialize_as_embedded_group(serializer)
+    }
+}
+
+impl SerializeEmbeddedGroup for OperationalCert {
+    fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        self.hot_vkey.serialize(serializer)?;
+        self.sequence_number.serialize(serializer)?;
+        self.kes_period.serialize(serializer)?;
+        self.sigma.serialize(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for OperationalCert {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("OperationalCert"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for OperationalCert {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        let hot_vkey = (|| -> Result<_, DeserializeError> {
+            Ok(KESVKey::deserialize(raw)?)
+        })().map_err(|e| e.annotate("hot_vkey"))?;
+        let sequence_number = (|| -> Result<_, DeserializeError> {
+            Ok(u32::deserialize(raw)?)
+        })().map_err(|e| e.annotate("sequence_number"))?;
+        let kes_period = (|| -> Result<_, DeserializeError> {
+            Ok(u32::deserialize(raw)?)
+        })().map_err(|e| e.annotate("kes_period"))?;
+        let sigma = (|| -> Result<_, DeserializeError> {
+            Ok(Ed25519Signature::deserialize(raw)?)
+        })().map_err(|e| e.annotate("sigma"))?;
+        Ok(OperationalCert {
+            hot_vkey,
+            sequence_number,
+            kes_period,
+            sigma,
+        })
+    }
+}
+
+impl cbor_event::se::Serialize for HeaderBody {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(15))?;
+        self.block_number.serialize(serializer)?;
+        self.slot.serialize(serializer)?;
+        match &self.prev_hash {
+            Some(x) => {
+                x.serialize(serializer)
+            },
+            None => serializer.write_special(CBORSpecial::Null),
+        }?;
+        self.issuer_vkey.serialize(serializer)?;
+        self.vrf_vkey.serialize(serializer)?;
+        self.nonce_vrf.serialize(serializer)?;
+        self.leader_vrf.serialize(serializer)?;
+        self.block_body_size.serialize(serializer)?;
+        self.block_body_hash.serialize(serializer)?;
+        self.operational_cert.serialize_as_embedded_group(serializer)?;
+        self.protocol_version.serialize_as_embedded_group(serializer)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for HeaderBody {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        (|| -> Result<_, DeserializeError> {
+            let len = raw.array()?;
+            let ret = Self::deserialize_as_embedded_group(raw, len);
+            match len {
+                cbor_event::Len::Len(_) => /* TODO: check finite len somewhere */(),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => /* it's ok */(),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            ret
+        })().map_err(|e| e.annotate("HeaderBody"))
+    }
+}
+
+impl DeserializeEmbeddedGroup for HeaderBody {
+    fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
+        let block_number = (|| -> Result<_, DeserializeError> {
+            Ok(u32::deserialize(raw)?)
+        })().map_err(|e| e.annotate("block_number"))?;
+        let slot = (|| -> Result<_, DeserializeError> {
+            Ok(u32::deserialize(raw)?)
+        })().map_err(|e| e.annotate("slot"))?;
+        let prev_hash = (|| -> Result<_, DeserializeError> {
+            Ok(match raw.cbor_type()? != CBORType::Special {
+                true => {
+                    Some(BlockHash::deserialize(raw)?)
+                },
+                false => {
+                    if raw.special()? != CBORSpecial::Null {
+                        return Err(DeserializeFailure::ExpectedNull.into());
+                    }
+                    None
+                }
+            })
+        })().map_err(|e| e.annotate("prev_hash"))?;
+        let issuer_vkey = (|| -> Result<_, DeserializeError> {
+            Ok(Vkey::deserialize(raw)?)
+        })().map_err(|e| e.annotate("issuer_vkey"))?;
+        let vrf_vkey = (|| -> Result<_, DeserializeError> {
+            Ok(VRFVKey::deserialize(raw)?)
+        })().map_err(|e| e.annotate("vrf_vkey"))?;
+        let nonce_vrf = (|| -> Result<_, DeserializeError> {
+            Ok(VRFCert::deserialize(raw)?)
+        })().map_err(|e| e.annotate("nonce_vrf"))?;
+        let leader_vrf = (|| -> Result<_, DeserializeError> {
+            Ok(VRFCert::deserialize(raw)?)
+        })().map_err(|e| e.annotate("leader_vrf"))?;
+        let block_body_size = (|| -> Result<_, DeserializeError> {
+            Ok(u32::deserialize(raw)?)
+        })().map_err(|e| e.annotate("block_body_size"))?;
+        let block_body_hash = (|| -> Result<_, DeserializeError> {
+            Ok(BlockHash::deserialize(raw)?)
+        })().map_err(|e| e.annotate("block_body_hash"))?;
+        let operational_cert = (|| -> Result<_, DeserializeError> {
+            Ok(OperationalCert::deserialize_as_embedded_group(raw, len)?)
+        })().map_err(|e| e.annotate("operational_cert"))?;
+        let protocol_version = (|| -> Result<_, DeserializeError> {
+            Ok(ProtocolVersion::deserialize_as_embedded_group(raw, len)?)
+        })().map_err(|e| e.annotate("protocol_version"))?;
+        Ok(HeaderBody {
+            block_number,
+            slot,
+            prev_hash,
+            issuer_vkey,
+            vrf_vkey,
+            nonce_vrf,
+            leader_vrf,
+            block_body_size,
+            block_body_hash,
+            operational_cert,
+            protocol_version,
+        })
+    }
+}


### PR DESCRIPTION
This should now be all remaining structs in shelley.cddl generated.

The crypto relating to blocks are just raw byte structures and only perform
length validations and must be supplied to the library as raw bytes if
for some reason you must create a block.

closes #49 