### PR TITLE
add fee_for_output to txbuilder

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -575,6 +575,13 @@ declare export class ByronAddress {
   static from_bytes(bytes: Uint8Array): ByronAddress;
 
   /**
+   * returns the byron protocol magic embedded in the address, or mainnet id if none is present
+   * note: for bech32 addresses, you need to use network_id instead
+   * @returns {number}
+   */
+  byron_protocol_magic(): number;
+
+  /**
    * @returns {number}
    */
   network_id(): number;
@@ -3040,6 +3047,13 @@ declare export class TransactionBuilder {
    * @param {TransactionOutput} output
    */
   add_output(output: TransactionOutput): void;
+
+  /**
+   * calculates how much the fee would increase if you added a given output
+   * @param {TransactionOutput} output
+   * @returns {BigNum}
+   */
+  fee_for_output(output: TransactionOutput): BigNum;
 
   /**
    * @param {BigNum} fee


### PR DESCRIPTION
This adds a new function called `fee_for_output` that calculates how much the fee would increase if you added a given output

When I was adding this feature, I also noticed some edge cases in the TransactionBuilder `build` function, so I fixed them and added tests for it.