### PR TITLE
Switch table-types from BTreeMap to LinkedHashMap

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "js-sys",
+ "linked-hash-map",
  "quickcheck",
  "quickcheck_macros",
  "rand_chacha 0.1.1",
@@ -306,6 +307,12 @@ name = "libc"
 version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "log"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,6 +21,7 @@ hex = "0.4.0"
 js-sys = "0.3.24"
 rand_os = { version = "0.1", features = ["wasm-bindgen"] }
 cfg-if = "0.1"
+linked-hash-map = "0.5.3"
 
 # The default can't be compiled to wasm, so it's necessary to use either the 'nightly'
 # feature or this one

--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -29,14 +29,14 @@ fn variable_nat_encode(mut num: u64) -> Vec<u8> {
     output
 }
 
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Hash, Eq, Ord, PartialEq, PartialOrd)]
 enum StakeCredType {
     Key(Ed25519KeyHash),
     Script(ScriptHash),
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct StakeCredential(StakeCredType);
 
 #[wasm_bindgen]
@@ -499,7 +499,7 @@ impl EnterpriseAddress {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct RewardAddress {
     network: u8,
     payment: StakeCredential,

--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -672,7 +672,7 @@ impl_signature!(Ed25519Signature, Vec<u8>, crypto::Ed25519);
 macro_rules! impl_hash_type {
     ($name:ident, $byte_count:expr) => {
         #[wasm_bindgen]
-        #[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+        #[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
         pub struct $name(pub (crate) [u8; $byte_count]);
 
         #[wasm_bindgen]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -781,7 +781,7 @@ pub enum MIRPot {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct MoveInstantaneousReward {
     pot: MIRPot,
-    rewards: std::collections::BTreeMap<StakeCredential, Coin>,
+    rewards: linked_hash_map::LinkedHashMap<StakeCredential, Coin>,
 }
 
 to_from_bytes!(MoveInstantaneousReward);
@@ -791,7 +791,7 @@ impl MoveInstantaneousReward {
     pub fn new(pot: MIRPot) -> Self {
         Self {
             pot,
-            rewards: std::collections::BTreeMap::new(),
+            rewards: linked_hash_map::LinkedHashMap::new(),
         }
     }
 
@@ -1072,14 +1072,14 @@ impl RewardAddresses {
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Withdrawals(std::collections::BTreeMap<RewardAddress, Coin>);
+pub struct Withdrawals(linked_hash_map::LinkedHashMap<RewardAddress, Coin>);
 
 to_from_bytes!(Withdrawals);
 
 #[wasm_bindgen]
 impl Withdrawals {
     pub fn new() -> Self {
-        Self(std::collections::BTreeMap::new())
+        Self(linked_hash_map::LinkedHashMap::new())
     }
 
     pub fn len(&self) -> usize {
@@ -1175,9 +1175,9 @@ impl TransactionWitnessSet {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct MapTransactionMetadatumToTransactionMetadatum(
-    std::collections::BTreeMap<TransactionMetadatum, TransactionMetadatum>,
+    linked_hash_map::LinkedHashMap<TransactionMetadatum, TransactionMetadatum>,
 );
 
 to_from_bytes!(MapTransactionMetadatumToTransactionMetadatum);
@@ -1185,7 +1185,7 @@ to_from_bytes!(MapTransactionMetadatumToTransactionMetadatum);
 #[wasm_bindgen]
 impl MapTransactionMetadatumToTransactionMetadatum {
     pub fn new() -> Self {
-        Self(std::collections::BTreeMap::new())
+        Self(linked_hash_map::LinkedHashMap::new())
     }
 
     pub fn len(&self) -> usize {
@@ -1215,7 +1215,7 @@ impl MapTransactionMetadatumToTransactionMetadatum {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct TransactionMetadatums(Vec<TransactionMetadatum>);
 
 to_from_bytes!(TransactionMetadatums);
@@ -1249,7 +1249,7 @@ pub enum TransactionMetadatumKind {
     Text,
 }
 
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 enum TransactionMetadatumEnum {
     MapTransactionMetadatumToTransactionMetadatum(MapTransactionMetadatumToTransactionMetadatum),
     ArrTransactionMetadatum(TransactionMetadatums),
@@ -1259,7 +1259,7 @@ enum TransactionMetadatumEnum {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct TransactionMetadatum(TransactionMetadatumEnum);
 
 to_from_bytes!(TransactionMetadatum);
@@ -1380,7 +1380,7 @@ impl TransactionMetadatumLabels {
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct TransactionMetadata(
-    std::collections::BTreeMap<TransactionMetadatumLabel, TransactionMetadatum>,
+    linked_hash_map::LinkedHashMap<TransactionMetadatumLabel, TransactionMetadatum>,
 );
 
 to_from_bytes!(TransactionMetadata);
@@ -1388,7 +1388,7 @@ to_from_bytes!(TransactionMetadata);
 #[wasm_bindgen]
 impl TransactionMetadata {
     pub fn new() -> Self {
-        Self(std::collections::BTreeMap::new())
+        Self(linked_hash_map::LinkedHashMap::new())
     }
 
     pub fn len(&self) -> usize {
@@ -1644,7 +1644,7 @@ impl GenesisHashes {
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ProposedProtocolParameterUpdates(
-    std::collections::BTreeMap<GenesisHash, ProtocolParamUpdate>,
+    linked_hash_map::LinkedHashMap<GenesisHash, ProtocolParamUpdate>,
 );
 
 to_from_bytes!(ProposedProtocolParameterUpdates);
@@ -1652,7 +1652,7 @@ to_from_bytes!(ProposedProtocolParameterUpdates);
 #[wasm_bindgen]
 impl ProposedProtocolParameterUpdates {
     pub fn new() -> Self {
-        Self(std::collections::BTreeMap::new())
+        Self(linked_hash_map::LinkedHashMap::new())
     }
 
     pub fn len(&self) -> usize {
@@ -1960,12 +1960,12 @@ pub type TransactionIndexes = Vec<TransactionIndex>;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct MapTransactionIndexToTransactionMetadata(std::collections::BTreeMap<TransactionIndex, TransactionMetadata>);
+pub struct MapTransactionIndexToTransactionMetadata(linked_hash_map::LinkedHashMap<TransactionIndex, TransactionMetadata>);
 
 #[wasm_bindgen]
 impl MapTransactionIndexToTransactionMetadata {
     pub fn new() -> Self {
-        Self(std::collections::BTreeMap::new())
+        Self(linked_hash_map::LinkedHashMap::new())
     }
 
     pub fn len(&self) -> usize {

--- a/rust/src/serialization.rs
+++ b/rust/src/serialization.rs
@@ -1112,7 +1112,7 @@ impl cbor_event::se::Serialize for MoveInstantaneousReward {
 
 impl Deserialize for MoveInstantaneousReward {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let mut table = std::collections::BTreeMap::new();
+        let mut table = linked_hash_map::LinkedHashMap::new();
         let pot = (|| -> Result<_, DeserializeError> {
             let outer_len = raw.array()?;
             let pot = match raw.unsigned_integer()? {
@@ -1549,7 +1549,7 @@ impl cbor_event::se::Serialize for Withdrawals {
 
 impl Deserialize for Withdrawals {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let mut table = std::collections::BTreeMap::new();
+        let mut table = linked_hash_map::LinkedHashMap::new();
         (|| -> Result<_, DeserializeError> {
             let len = raw.map()?;
             while match len { cbor_event::Len::Len(n) => table.len() < n as usize, cbor_event::Len::Indefinite => true, } {
@@ -1695,7 +1695,7 @@ impl cbor_event::se::Serialize for MapTransactionMetadatumToTransactionMetadatum
 
 impl Deserialize for MapTransactionMetadatumToTransactionMetadatum {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let mut table = std::collections::BTreeMap::new();
+        let mut table = linked_hash_map::LinkedHashMap::new();
         (|| -> Result<_, DeserializeError> {
             let len = raw.map()?;
             while match len { cbor_event::Len::Len(n) => table.len() < n as usize, cbor_event::Len::Indefinite => true, } {
@@ -1860,7 +1860,7 @@ impl cbor_event::se::Serialize for TransactionMetadata {
 
 impl Deserialize for TransactionMetadata {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let mut table = std::collections::BTreeMap::new();
+        let mut table = linked_hash_map::LinkedHashMap::new();
         (|| -> Result<_, DeserializeError> {
             let len = raw.map()?;
             while match len { cbor_event::Len::Len(n) => table.len() < n as usize, cbor_event::Len::Indefinite => true, } {
@@ -2242,7 +2242,7 @@ impl cbor_event::se::Serialize for ProposedProtocolParameterUpdates {
 
 impl Deserialize for ProposedProtocolParameterUpdates {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let mut table = std::collections::BTreeMap::new();
+        let mut table = linked_hash_map::LinkedHashMap::new();
         (|| -> Result<_, DeserializeError> {
             let len = raw.map()?;
             while match len { cbor_event::Len::Len(n) => table.len() < n as usize, cbor_event::Len::Indefinite => true, } {
@@ -2673,7 +2673,7 @@ impl cbor_event::se::Serialize for MapTransactionIndexToTransactionMetadata {
 
 impl Deserialize for MapTransactionIndexToTransactionMetadata {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let mut table = std::collections::BTreeMap::new();
+        let mut table = linked_hash_map::LinkedHashMap::new();
         (|| -> Result<_, DeserializeError> {
             let len = raw.map()?;
             while match len { cbor_event::Len::Len(n) => table.len() < n as usize, cbor_event::Len::Indefinite => true, } {

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -67,7 +67,7 @@ macro_rules! to_from_bytes {
 // This is an unsigned type - no negative numbers.
 // Can be converted to/from plain rust 
 #[wasm_bindgen]
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct BigNum(u64);
 
 to_from_bytes!(BigNum);
@@ -135,7 +135,7 @@ pub type Coin = BigNum;
 
 // CBOR has int = uint / nint
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Int(i128);
 
 #[wasm_bindgen]


### PR DESCRIPTION
To keep the order between serialization/deserialization consisetent
instead of storing in a BTreeMap which would ignore the
deserialize/insertion order and always serialize/iterate in lex order,
this is switched to linked_hash_map::LinkedHashMap which preserves this
order.

This issue still exists for non-iterable map types (e.g. map structs)
but that would be harder to fix (manually keeping track of the order)
and is less important since we don't iterate struct fields outside of
serialization.