### PR TITLE
Remove rust nightly requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,9 +76,8 @@ If you need to install Rust, do the following:
 
    curl https://sh.rustup.rs -sSf | sh -s -- -y
    echo 'export PATH=$HOME/.cargo/bin/:$PATH' >> $BASH_ENV
-   rustup default nightly
-   rustup update
-   rustup target add wasm32-unknown-unknown --toolchain nightly
+   rustup install stable
+   rustup target add wasm32-unknown-unknown --toolchain stable
    curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
 To build this repository, do the following:


### PR DESCRIPTION
Due to lack of support on some build targets we will remove the nightly
requirement by just temporarily, until >32 size auto-trait impls for
arrays are implemented by ~October, manually writing out the KESSignature
struct but using heap-allocation.