### PR TITLE
CBOR tagged JSON schema for better metadata support + remove wasm-bindgen dependency for non-wasm builds

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "hex",
  "js-sys",
  "linked-hash-map",
+ "noop_proc_macro",
  "quickcheck",
  "quickcheck_macros",
  "rand_chacha 0.1.1",
@@ -329,6 +330,12 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "opaque-debug"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,10 +7,8 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-
 cryptoxide = "0.2.0"
 cbor_event = "2.1.3"
-wasm-bindgen = { version = "0.2", features=["serde-serialize"] }
 curve25519-dalek = "1"
 ed25519-dalek = "1.0.0-pre.1"
 ed25519-bip32 = "0.3.1"
@@ -19,14 +17,23 @@ digest = "^0.8"
 bech32 = "0.7.2"
 hex = "0.4.0"
 js-sys = "0.3.24"
-rand_os = { version = "0.1", features = ["wasm-bindgen"] }
 cfg-if = "0.1"
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
-
 # The default can't be compiled to wasm, so it's necessary to use either the 'nightly'
 # feature or this one
 clear_on_drop = { version = "0.2", features = ["no_cc"] }
+
+# non-wasm
+[target.'cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))'.dependencies]
+rand_os = "0.1"
+noop_proc_macro = "0.3.0"
+
+# wasm
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+rand_os = { version = "0.1", features = ["wasm-bindgen"] }
+wasm-bindgen = { version = "0.2", features=["serde-serialize"] }
+
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/rust/src/fees.rs
+++ b/rust/src/fees.rs
@@ -27,7 +27,7 @@ impl LinearFee {
 }
 
 #[wasm_bindgen]
-pub fn min_fee(tx: &Transaction, linear_fee: &LinearFee) -> Result<Coin, JsValue> {
+pub fn min_fee(tx: &Transaction, linear_fee: &LinearFee) -> Result<Coin, JsError> {
     to_bignum(tx.to_bytes().len() as u64)
         .checked_mul(&linear_fee.coefficient())?
         .checked_add(&linear_fee.constant())

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -14,8 +14,12 @@ extern crate quickcheck;
 extern crate quickcheck_macros;
 extern crate hex;
 
-
 use std::io::{BufRead, Seek, Write};
+
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+use noop_proc_macro::wasm_bindgen;
+
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
 use wasm_bindgen::prelude::*;
 
 // This file was code-generated using an experimental CDDL to rust tool:

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -45,17 +45,17 @@ impl MetadataMap {
         self.insert(&TransactionMetadatum::new_int(&Int::new_i32(key)), value)
     }
 
-    pub fn get(&self, key: &TransactionMetadatum) -> Result<TransactionMetadatum, JsValue> {
-        self.0.get(key).map(|v| v.clone()).ok_or_else(|| JsValue::from_str(&format!("key {:?} not found", key)))
+    pub fn get(&self, key: &TransactionMetadatum) -> Result<TransactionMetadatum, JsError> {
+        self.0.get(key).map(|v| v.clone()).ok_or_else(|| JsError::from_str(&format!("key {:?} not found", key)))
     }
 
     // convenience function for retrieving a string key
-    pub fn get_str(&self, key: &str) -> Result<TransactionMetadatum, JsValue> {
+    pub fn get_str(&self, key: &str) -> Result<TransactionMetadatum, JsError> {
         self.get(&TransactionMetadatum::new_text(key.to_owned()))
     }
 
     // convenience function for retrieving 32-bit integer keys - for higher-precision integers use get() with an Int struct
-    pub fn get_i32(&self, key: i32) -> Result<TransactionMetadatum, JsValue> {
+    pub fn get_i32(&self, key: i32) -> Result<TransactionMetadatum, JsError> {
         self.get(&TransactionMetadatum::new_int(&Int::new_i32(key)))
     }
 
@@ -171,40 +171,40 @@ impl TransactionMetadatum {
 
     pub fn as_map(
         &self,
-    ) -> Result<MetadataMap, JsValue> {
+    ) -> Result<MetadataMap, JsError> {
         match &self.0 {
             TransactionMetadatumEnum::MetadataMap(x) => {
                 Ok(x.clone())
             }
-            _ => Err(JsValue::from_str("not a map")),
+            _ => Err(JsError::from_str("not a map")),
         }
     }
 
-    pub fn as_list(&self) -> Result<MetadataList, JsValue> {
+    pub fn as_list(&self) -> Result<MetadataList, JsError> {
         match &self.0 {
             TransactionMetadatumEnum::MetadataList(x) => Ok(x.clone()),
-            _ => Err(JsValue::from_str("not a list")),
+            _ => Err(JsError::from_str("not a list")),
         }
     }
 
-    pub fn as_int(&self) -> Result<Int, JsValue> {
+    pub fn as_int(&self) -> Result<Int, JsError> {
         match &self.0 {
             TransactionMetadatumEnum::Int(x) => Ok(x.clone()),
-            _ => Err(JsValue::from_str("not an int")),
+            _ => Err(JsError::from_str("not an int")),
         }
     }
 
-    pub fn as_bytes(&self) -> Result<Vec<u8>, JsValue> {
+    pub fn as_bytes(&self) -> Result<Vec<u8>, JsError> {
         match &self.0 {
             TransactionMetadatumEnum::Bytes(x) => Ok(x.clone()),
-            _ => Err(JsValue::from_str("not bytes")),
+            _ => Err(JsError::from_str("not bytes")),
         }
     }
 
-    pub fn as_text(&self) -> Result<String, JsValue> {
+    pub fn as_text(&self) -> Result<String, JsError> {
         match &self.0 {
             TransactionMetadatumEnum::Text(x) => Ok(x.clone()),
-            _ => Err(JsValue::from_str("not text")),
+            _ => Err(JsError::from_str("not text")),
         }
     }
 }
@@ -288,7 +288,7 @@ pub fn encode_arbitrary_bytes_as_metadatum(bytes: &[u8]) -> TransactionMetadatum
 
 // decodes from chunks of bytes in a list to a byte vector if that is the metadata format, otherwise returns None
 #[wasm_bindgen]
-pub fn decode_arbitrary_bytes_from_metadatum(metadata: &TransactionMetadatum) -> Result<Vec<u8>, JsValue> {
+pub fn decode_arbitrary_bytes_from_metadatum(metadata: &TransactionMetadatum) -> Result<Vec<u8>, JsError> {
     let mut bytes = Vec::new();
     for elem in metadata.as_list()?.0 {
         bytes.append(&mut elem.as_bytes()?);
@@ -330,7 +330,7 @@ pub enum MetadataJsonSchema {
     // Maps are treated as an array of k-v pairs as such: [{"key1": {"int": 47}}, {"key2": {"list": [0, 1]}}, {"key3": {"bytes": "0xFFFF"}}]
     // From JSON:
     // * null/true/false NOT supported.
-    // * Strings parseable as bytes (0x starting hex) or integers converted.
+    // * Strings parseable as bytes (hex WITHOUT 0x prefix) or integers converted.
     // To JSON:
     // * Non-string keys are supported. Any key parseable as JSON is encoded as metadata instead of a string
     // Corresponds to TxMetadataJsonSchema's TxMetadataJsonDetailedSchema in cardano-node
@@ -357,26 +357,22 @@ fn bytes_to_hex_string(bytes: &[u8]) -> String {
     format!("0x{}", hex::encode(bytes))
 }
 
-// encodes a JSON object represented as a string into metadatum if possible.
-// Bytes are not supported due to ambiguity of representation in pure JSON
-// as representing as a byte array could be confused with a list, and using
-// a hex/b58etc string could be confused with a regular string
+// Converts JSON to Metadata according to MetadataJsonSchema
 #[wasm_bindgen]
-pub fn encode_json_str_to_metadatum(json: String, schema: MetadataJsonSchema) -> Result<TransactionMetadatum, JsValue> {
-    //let value = serde_json::from_str(&json).map_err(|e| JsValue::from_str(&e.to_string()))?;
-    let value = serde_json::from_str(&json).unwrap();
+pub fn encode_json_str_to_metadatum(json: String, schema: MetadataJsonSchema) -> Result<TransactionMetadatum, JsError> {
+    let value = serde_json::from_str(&json).map_err(|e| JsError::from_str(&e.to_string()))?;
     encode_json_value_to_metadatum(value, schema)
 }
 
-pub fn encode_json_value_to_metadatum(value: serde_json::Value, schema: MetadataJsonSchema) -> Result<TransactionMetadatum, JsValue> {
+pub fn encode_json_value_to_metadatum(value: serde_json::Value, schema: MetadataJsonSchema) -> Result<TransactionMetadatum, JsError> {
     use serde_json::Value;
-    fn encode_number(x: serde_json::Number) -> Result<TransactionMetadatum, JsValue> {
+    fn encode_number(x: serde_json::Number) -> Result<TransactionMetadatum, JsError> {
         if let Some(x) = x.as_u64() {
             Ok(TransactionMetadatum::new_int(&Int::new(utils::to_bignum(x))))
         } else if let Some(x) = x.as_i64() {
             Ok(TransactionMetadatum::new_int(&Int::new_negative(utils::to_bignum(-x as u64))))
         } else {
-            Err(JsValue::from_str("floats not allowed in metadata"))
+            Err(JsError::from_str("floats not allowed in metadata"))
         }
     }
     fn encode_string(s: String, schema: MetadataJsonSchema) -> TransactionMetadatum {
@@ -389,7 +385,7 @@ pub fn encode_json_value_to_metadatum(value: serde_json::Value, schema: Metadata
             TransactionMetadatum::new_text(s)
         }
     }
-    fn encode_array(json_arr: Vec<Value>, schema: MetadataJsonSchema) -> Result<TransactionMetadatum, JsValue> {
+    fn encode_array(json_arr: Vec<Value>, schema: MetadataJsonSchema) -> Result<TransactionMetadatum, JsError> {
         let mut arr = MetadataList::new();
         for value in json_arr {
             arr.add(&encode_json_value_to_metadatum(value, schema)?);
@@ -399,8 +395,8 @@ pub fn encode_json_value_to_metadatum(value: serde_json::Value, schema: Metadata
     match schema {
         MetadataJsonSchema::NoConversions |
         MetadataJsonSchema::BasicConversions => match value {
-            Value::Null => Err(JsValue::from_str("null not allowed in metadata")),
-            Value::Bool(_) => Err(JsValue::from_str("bools not allowed in metadata")),
+            Value::Null => Err(JsError::from_str("null not allowed in metadata")),
+            Value::Bool(_) => Err(JsError::from_str("bools not allowed in metadata")),
             Value::Number(x) => encode_number(x),
             Value::String(s) => Ok(encode_string(s, schema)),
             Value::Array(json_arr) => encode_array(json_arr, schema),
@@ -424,8 +420,8 @@ pub fn encode_json_value_to_metadatum(value: serde_json::Value, schema: Metadata
         MetadataJsonSchema::DetailedSchema => match value {
             Value::Object(obj) if obj.len() == 1 => {
                 let (k, v) = obj.into_iter().next().unwrap();
-                fn tag_mismatch() -> JsValue {
-                    JsValue::from_str("key does not match type")
+                fn tag_mismatch() -> JsError {
+                    JsError::from_str("key does not match type")
                 }
                 match k.as_str() {
                     "int" => match v {
@@ -433,43 +429,46 @@ pub fn encode_json_value_to_metadatum(value: serde_json::Value, schema: Metadata
                         _ => Err(tag_mismatch()),
                     },
                     "string" => Ok(encode_string(v.as_str().ok_or_else(tag_mismatch)?.to_owned(), schema)),
-                    "bytes" => match hex_string_to_bytes(v.as_str().ok_or_else(tag_mismatch)?) {
-                        Some(bytes) => Ok(TransactionMetadatum::new_bytes(bytes)),
-                        None => Err(JsValue::from_str("invalid hex string in tagged byte-object")),
+                    "bytes" => match hex::decode(v.as_str().ok_or_else(tag_mismatch)?) {
+                        Ok(bytes) => Ok(TransactionMetadatum::new_bytes(bytes)),
+                        Err(_) => Err(JsError::from_str("invalid hex string in tagged byte-object")),
                     },
                     "list" => encode_array(v.as_array().ok_or_else(tag_mismatch)?.clone(), schema),
                     "map" => {
                         let mut map = MetadataMap::new();
-                        for (raw_key, value) in v.as_object().ok_or_else(tag_mismatch)? {
-                            // this could potentially be a stringified JSON key
-                            let key = match encode_json_str_to_metadatum(raw_key.clone(), schema) {
-                                Ok(md)  => md,
-                                Err(_) => TransactionMetadatum::new_text(raw_key.clone()),
-                            };
+                        fn map_entry_err() -> JsError {
+                            JsError::from_str("entry format in detailed schema map object not correct. Needs to be of form {\"k\": \"key\", \"v\": value}")
+                        }
+                        for entry in v.as_array().ok_or_else(tag_mismatch)? {
+                            let entry_obj = entry.as_object().ok_or_else(map_entry_err)?;
+                            let raw_key = entry_obj
+                                .get("k")
+                                .ok_or_else(map_entry_err)?;
+                            let value = entry_obj.get("v").ok_or_else(map_entry_err)?;
+                            let key = encode_json_value_to_metadatum(raw_key.clone(), schema)?;
                             map.insert(&key, &encode_json_value_to_metadatum(value.clone(), schema)?);
                         }
                         Ok(TransactionMetadatum::new_map(&map))
                     },
-                    invalid_key => Err(JsValue::from_str(&format!("key '{}' in tagged object not valid", invalid_key))),
+                    invalid_key => Err(JsError::from_str(&format!("key '{}' in tagged object not valid", invalid_key))),
                 }
             },
-            _ => Err(JsValue::from_str("DetailedSchema requires types to be tagged objects")),
+            _ => Err(JsError::from_str("DetailedSchema requires types to be tagged objects")),
         },
     }
 }
 
-// decodes a metadatum into a JSON object string if possible
-// Bytes are not supported, see encoding comment.
+// Converts Metadata to JSON according to MetadataJsonSchema
 #[wasm_bindgen]
-pub fn decode_metadatum_to_json_str(metadatum: &TransactionMetadatum, schema: MetadataJsonSchema) -> Result<String, JsValue> {
+pub fn decode_metadatum_to_json_str(metadatum: &TransactionMetadatum, schema: MetadataJsonSchema) -> Result<String, JsError> {
     let value = decode_metadatum_to_json_value(metadatum, schema)?;
-    serde_json::to_string(&value).map_err(|e| JsValue::from_str(&e.to_string()))
+    serde_json::to_string(&value).map_err(|e| JsError::from_str(&e.to_string()))
 }
 
-pub fn decode_metadatum_to_json_value(metadatum: &TransactionMetadatum, schema: MetadataJsonSchema) -> Result<serde_json::Value, JsValue> {
+pub fn decode_metadatum_to_json_value(metadatum: &TransactionMetadatum, schema: MetadataJsonSchema) -> Result<serde_json::Value, JsError> {
     use serde_json::Value;
     use std::convert::TryFrom;
-    fn decode_key(key: &TransactionMetadatum, schema: MetadataJsonSchema) -> Result<String, JsValue> {
+    fn decode_key(key: &TransactionMetadatum, schema: MetadataJsonSchema) -> Result<String, JsError> {
         match &key.0 {
             TransactionMetadatumEnum::Text(s) => Ok(s.clone()),
             TransactionMetadatumEnum::Bytes(b) if schema != MetadataJsonSchema::NoConversions => Ok(bytes_to_hex_string(b.as_ref())),
@@ -479,11 +478,11 @@ pub fn decode_metadatum_to_json_value(metadatum: &TransactionMetadatum, schema: 
                 } else {
                     i64::try_from(i.0).map(|x| x.to_string())
                 };
-                int_str.map_err(|e| JsValue::from_str(&e.to_string()))
+                int_str.map_err(|e| JsError::from_str(&e.to_string()))
             },
             TransactionMetadatumEnum::MetadataList(list) if schema == MetadataJsonSchema::DetailedSchema => decode_metadatum_to_json_str(&TransactionMetadatum::new_list(&list), schema),
             TransactionMetadatumEnum::MetadataMap(map) if schema == MetadataJsonSchema::DetailedSchema => decode_metadatum_to_json_str(&TransactionMetadatum::new_map(&map), schema),
-            _ => Err(JsValue::from_str(&format!("key type {:?} not allowed in JSON under specified schema", key.0))),
+            _ => Err(JsError::from_str(&format!("key type {:?} not allowed in JSON under specified schema", key.0))),
         }
     }
     let (type_key, value) = match &metadatum.0 {
@@ -504,27 +503,30 @@ pub fn decode_metadatum_to_json_value(metadatum: &TransactionMetadatum, schema: 
             MetadataJsonSchema::DetailedSchema => ("map", Value::from(map.0.iter().map(|(key, value)| {
                 // must encode maps as JSON lists of objects with k/v keys
                 // also in these schemas we support more key types than strings
-                let k = decode_key(key, schema)?;
+                let k = decode_metadatum_to_json_value(key, schema)?;
                 let v = decode_metadatum_to_json_value(value, schema)?;
                 let mut kv_obj = serde_json::map::Map::with_capacity(2);
                 kv_obj.insert(String::from("k"), Value::from(k));
                 kv_obj.insert(String::from("v"), v);
                 Ok(Value::from(kv_obj))
-            }).collect::<Result<Vec<_>, JsValue>>()?))
+            }).collect::<Result<Vec<_>, JsError>>()?))
         },
         TransactionMetadatumEnum::MetadataList(arr) => {
             ("list", Value::from(arr.0.iter().map(|e| {
                 decode_metadatum_to_json_value(e, schema)
-            }).collect::<Result<Vec<_>, JsValue>>()?))
+            }).collect::<Result<Vec<_>, JsError>>()?))
         },
         TransactionMetadatumEnum::Int(x) => ("int", if x.0 >= 0 {
-            Value::from(u64::try_from(x.0).map_err(|e| JsValue::from_str(&e.to_string()))?)
+            Value::from(u64::try_from(x.0).map_err(|e| JsError::from_str(&e.to_string()))?)
         } else {
-            Value::from(i64::try_from(x.0).map_err(|e| JsValue::from_str(&e.to_string()))?)
+            Value::from(i64::try_from(x.0).map_err(|e| JsError::from_str(&e.to_string()))?)
         }),
         TransactionMetadatumEnum::Bytes(bytes) => ("bytes", match schema {
-            MetadataJsonSchema::NoConversions => Err(JsValue::from_str("bytes not allowed in JSON in specified schema")),
-            _ => Ok(Value::from(bytes_to_hex_string(bytes.as_ref()))),
+            MetadataJsonSchema::NoConversions => Err(JsError::from_str("bytes not allowed in JSON in specified schema")),
+            // 0x prefix
+            MetadataJsonSchema::BasicConversions => Ok(Value::from(bytes_to_hex_string(bytes.as_ref()))),
+            // no prefix
+            MetadataJsonSchema::DetailedSchema => Ok(Value::from(hex::encode(bytes))),
         }?),
         TransactionMetadatumEnum::Text(s) => ("string", Value::from(s.clone())),
     };
@@ -768,22 +770,104 @@ mod tests {
 
     #[test]
     fn json_encoding_basic() {
-        let input_str = String::from("{\"0x8badf00d\": \"0xdeadbeef\",\"9\": 5,\"map\": {\"a\":[{\"5\": 2},{}]}}");
+        let input_str = String::from("{\"0x8badf00d\": \"0xdeadbeef\",\"9\": 5,\"obj\": {\"a\":[{\"5\": 2},{}]}}");
         let metadata = encode_json_str_to_metadatum(input_str.clone(), MetadataJsonSchema::BasicConversions).expect("encode failed");
-        let map = metadata.as_map().unwrap();
-        assert_eq!(map.get(&TransactionMetadatum::new_bytes(hex::decode("8badf00d").unwrap())).unwrap().as_bytes().unwrap(), hex::decode("deadbeef").unwrap());
-        assert_eq!(map.get_i32(9).unwrap().as_int().unwrap().as_i32().unwrap(), 5);
-        let inner_map = map.get_str("map").unwrap().as_map().unwrap();
-        let a = inner_map.get_str("a").unwrap().as_list().unwrap();
-        let a1 = a.get(0).as_map().unwrap();
-        assert_eq!(a1.get_i32(5).unwrap().as_int().unwrap().as_i32().unwrap(), 2);
-        let a2 = a.get(1).as_map().unwrap();
-        assert_eq!(a2.keys().len(), 0);
+        json_encoding_check_example_metadatum(&metadata);
         let output_str = decode_metadatum_to_json_str(&metadata, MetadataJsonSchema::BasicConversions).expect("decode failed");
+        let input_json: serde_json::Value = serde_json::from_str(&input_str).unwrap();
+        let output_json: serde_json::Value= serde_json::from_str(&output_str).unwrap();
+        assert_eq!(input_json, output_json);
+        panic!(decode_metadatum_to_json_str(&metadata, MetadataJsonSchema::DetailedSchema).unwrap());
+    }
+
+    #[test]
+    fn json_encoding_detailed() {
+        let input_str = String::from(
+        "{\"map\":[
+            {
+                \"k\":{\"bytes\":\"8badf00d\"},
+                \"v\":{\"bytes\":\"deadbeef\"}
+            },
+            {
+                \"k\":{\"int\":9},
+                \"v\":{\"int\":5}
+            },
+            {
+                \"k\":{\"string\":\"obj\"},
+                \"v\":{\"map\":[
+                    {
+                        \"k\":{\"string\":\"a\"},
+                        \"v\":{\"list\":[
+                        {\"map\":[
+                            {
+                                \"k\":{\"int\":5},
+                                \"v\":{\"int\":2}
+                            }
+                            ]},
+                            {\"map\":[
+                            ]}
+                        ]}
+                    }
+                ]}
+            }
+        ]}");
+        let metadata = encode_json_str_to_metadatum(input_str.clone(), MetadataJsonSchema::DetailedSchema).expect("encode failed");
+        json_encoding_check_example_metadatum(&metadata);
+        let output_str = decode_metadatum_to_json_str(&metadata, MetadataJsonSchema::DetailedSchema).expect("decode failed");
         let input_json: serde_json::Value = serde_json::from_str(&input_str).unwrap();
         let output_json: serde_json::Value= serde_json::from_str(&output_str).unwrap();
         assert_eq!(input_json, output_json);
     }
 
-    // TODO: detailed encoding test
+    fn json_encoding_check_example_metadatum(metadata: &TransactionMetadatum) {
+        let map = metadata.as_map().unwrap();
+        assert_eq!(map.get(&TransactionMetadatum::new_bytes(hex::decode("8badf00d").unwrap())).unwrap().as_bytes().unwrap(), hex::decode("deadbeef").unwrap());
+        assert_eq!(map.get_i32(9).unwrap().as_int().unwrap().as_i32().unwrap(), 5);
+        let inner_map = map.get_str("obj").unwrap().as_map().unwrap();
+        let a = inner_map.get_str("a").unwrap().as_list().unwrap();
+        let a1 = a.get(0).as_map().unwrap();
+        assert_eq!(a1.get_i32(5).unwrap().as_int().unwrap().as_i32().unwrap(), 2);
+        let a2 = a.get(1).as_map().unwrap();
+        assert_eq!(a2.keys().len(), 0);
+    }
+
+    #[test]
+    fn json_encoding_detailed_complex_key() {
+        let input_str = String::from(
+        "{\"map\":[
+            {
+            \"k\":{\"list\":[
+                {\"map\": [
+                    {
+                        \"k\": {\"int\": 5},
+                        \"v\": {\"int\": 7}
+                    },
+                    {
+                        \"k\": {\"string\": \"hello\"},
+                        \"v\": {\"string\": \"world\"}
+                    }
+                ]},
+                {\"bytes\": \"ff00ff00\"}
+            ]},
+            \"v\":{\"int\":5}
+            }
+        ]}");
+        let metadata = encode_json_str_to_metadatum(input_str.clone(), MetadataJsonSchema::DetailedSchema).expect("encode failed");
+
+        let map = metadata.as_map().unwrap();
+        let key = map.keys().get(0);
+        assert_eq!(map.get(&key).unwrap().as_int().unwrap().as_i32().unwrap(), 5);
+        let key_list = key.as_list().unwrap();
+        assert_eq!(key_list.len(), 2);
+        let key_map = key_list.get(0).as_map().unwrap();
+        assert_eq!(key_map.get_i32(5).unwrap().as_int().unwrap().as_i32().unwrap(), 7);
+        assert_eq!(key_map.get_str("hello").unwrap().as_text().unwrap(), "world");
+        let key_bytes = key_list.get(1).as_bytes().unwrap();
+        assert_eq!(key_bytes, hex::decode("ff00ff00").unwrap());
+
+        let output_str = decode_metadatum_to_json_str(&metadata, MetadataJsonSchema::DetailedSchema).expect("decode failed");
+        let input_json: serde_json::Value = serde_json::from_str(&input_str).unwrap();
+        let output_json: serde_json::Value= serde_json::from_str(&output_str).unwrap();
+        assert_eq!(input_json, output_json);
+    }
 }

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -27,8 +27,36 @@ impl MetadataMap {
         self.0.insert(key.clone(), value.clone())
     }
 
+    // convenience function for inserting as a string key
+    pub fn insert_str(
+        &mut self,
+        key: &str,
+        value: &TransactionMetadatum,
+    ) -> Option<TransactionMetadatum> {
+        self.insert(&TransactionMetadatum::new_text(key.to_owned()), value)
+    }
+
+    // convenience function for inserting 32-bit integers - for higher-precision integers use insert() with an Int struct
+    pub fn insert_i32(
+        &mut self,
+        key: i32,
+        value: &TransactionMetadatum,
+    ) -> Option<TransactionMetadatum> {
+        self.insert(&TransactionMetadatum::new_int(&Int::new_i32(key)), value)
+    }
+
     pub fn get(&self, key: &TransactionMetadatum) -> Result<TransactionMetadatum, JsValue> {
         self.0.get(key).map(|v| v.clone()).ok_or_else(|| JsValue::from_str(&format!("key {:?} not found", key)))
+    }
+
+    // convenience function for retrieving a string key
+    pub fn get_str(&self, key: &str) -> Result<TransactionMetadatum, JsValue> {
+        self.get(&TransactionMetadatum::new_text(key.to_owned()))
+    }
+
+    // convenience function for retrieving 32-bit integer keys - for higher-precision integers use get() with an Int struct
+    pub fn get_i32(&self, key: i32) -> Result<TransactionMetadatum, JsValue> {
+        self.get(&TransactionMetadatum::new_int(&Int::new_i32(key)))
     }
 
     pub fn has(&self, key: &TransactionMetadatum) -> bool {
@@ -268,45 +296,164 @@ pub fn decode_arbitrary_bytes_from_metadatum(metadata: &TransactionMetadatum) ->
     Ok(bytes)
 }
 
+#[wasm_bindgen]
+#[derive(Copy, Clone, Eq, PartialEq)]
+// Different schema methods for mapping between JSON and the metadata CBOR.
+// This conversion should match TxMetadataJsonSchema in cardano-node defined (at time of writing) here:
+// https://github.com/input-output-hk/cardano-node/blob/master/cardano-api/src/Cardano/Api/MetaData.hs
+// but has 2 additional schemas for more or less conversions
+pub enum MetadataJsonSchema {
+    // Does zero implicit conversions.
+    // Round-trip conversions are 100% consistent
+    // Treats maps DIRECTLY as maps in JSON in a natural way e.g. {"key1": 47, "key2": [0, 1]]}
+    // From JSON:
+    // * null/true/false NOT supported.
+    // * keys treated as strings only
+    // To JSON
+    // * Bytes, non-string keys NOT supported.
+    // Stricter than any TxMetadataJsonSchema in cardano-node but more natural for JSON -> Metadata
+    NoConversions,
+    // Does some implicit conversions.
+    // Round-trip conversions MD -> JSON -> MD is NOT consistent, but JSON -> MD -> JSON is.
+    // Without using bytes
+    // Maps are treated as an array of k-v pairs as such: [{"key1": 47}, {"key2": [0, 1]}, {"key3": "0xFFFF"}]
+    // From JSON:
+    // * null/true/false NOT supported.
+    // * Strings parseable as bytes (0x starting hex) or integers are converted.
+    // To JSON:
+    // * Non-string keys partially supported (bytes as 0x starting hex string, integer converted to string).
+    // * Bytes are converted to hex strings starting with 0x for both values and keys.
+    // Corresponds to TxMetadataJsonSchema's TxMetadataJsonNoSchema in cardano-node
+    BasicConversions,
+    // Supports the annotated schema presented in cardano-node with tagged values e.g. {"int": 7}, {"list": [0, 1]}
+    // Round-trip conversions are 100% consistent
+    // Maps are treated as an array of k-v pairs as such: [{"key1": {"int": 47}}, {"key2": {"list": [0, 1]}}, {"key3": {"bytes": "0xFFFF"}}]
+    // From JSON:
+    // * null/true/false NOT supported.
+    // * Strings parseable as bytes (0x starting hex) or integers converted.
+    // To JSON:
+    // * Non-string keys are supported. Any key parseable as JSON is encoded as metadata instead of a string
+    // Corresponds to TxMetadataJsonSchema's TxMetadataJsonDetailedSchema in cardano-node
+    DetailedSchema,
+}
+
+fn supports_tagged_values(schema: MetadataJsonSchema) -> bool {
+    match schema {
+        MetadataJsonSchema::NoConversions |
+        MetadataJsonSchema::BasicConversions => false,
+        MetadataJsonSchema::DetailedSchema => true,
+    }
+}
+
+fn hex_string_to_bytes(hex: &str) -> Option<Vec<u8>> {
+    if hex.starts_with("0x") {
+        hex::decode(&hex[2..]).ok()
+    } else {
+        None
+    }
+}
+
+fn bytes_to_hex_string(bytes: &[u8]) -> String {
+    format!("0x{}", hex::encode(bytes))
+}
+
 // encodes a JSON object represented as a string into metadatum if possible.
 // Bytes are not supported due to ambiguity of representation in pure JSON
 // as representing as a byte array could be confused with a list, and using
 // a hex/b58etc string could be confused with a regular string
 #[wasm_bindgen]
-pub fn encode_json_str_to_metadatum(json: String) -> Result<TransactionMetadatum, JsValue> {
-    encode_json_value_to_metadatum(serde_json::from_str(&json).map_err(|e| JsValue::from_str(&e.to_string()))?)
+pub fn encode_json_str_to_metadatum(json: String, schema: MetadataJsonSchema) -> Result<TransactionMetadatum, JsValue> {
+    //let value = serde_json::from_str(&json).map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let value = serde_json::from_str(&json).unwrap();
+    encode_json_value_to_metadatum(value, schema)
 }
 
-pub fn encode_json_value_to_metadatum(value: serde_json::Value) -> Result<TransactionMetadatum, JsValue> {
+pub fn encode_json_value_to_metadatum(value: serde_json::Value, schema: MetadataJsonSchema) -> Result<TransactionMetadatum, JsValue> {
     use serde_json::Value;
-    match value {
-        Value::Null => Err(JsValue::from_str("null not allowed in metadata")),
-        Value::Bool(_) => Err(JsValue::from_str("bools not allowed in metadata")),
-        Value::Number(x) => {
-            if let Some(x) = x.as_u64() {
-                Ok(TransactionMetadatum::new_int(&Int::new(utils::to_bignum(x))))
-            } else if let Some(x) = x.as_i64() {
-                Ok(TransactionMetadatum::new_int(&Int::new_negative(utils::to_bignum(-x as u64))))
-            } else {
-                Err(JsValue::from_str("floats not allowed in metadata"))
+    fn encode_number(x: serde_json::Number) -> Result<TransactionMetadatum, JsValue> {
+        if let Some(x) = x.as_u64() {
+            Ok(TransactionMetadatum::new_int(&Int::new(utils::to_bignum(x))))
+        } else if let Some(x) = x.as_i64() {
+            Ok(TransactionMetadatum::new_int(&Int::new_negative(utils::to_bignum(-x as u64))))
+        } else {
+            Err(JsValue::from_str("floats not allowed in metadata"))
+        }
+    }
+    fn encode_string(s: String, schema: MetadataJsonSchema) -> TransactionMetadatum {
+        if schema == MetadataJsonSchema::BasicConversions {
+            match hex_string_to_bytes(&s) {
+                Some(bytes) => TransactionMetadatum::new_bytes(bytes),
+                None => TransactionMetadatum::new_text(s),
             }
+        } else {
+            TransactionMetadatum::new_text(s)
+        }
+    }
+    fn encode_array(json_arr: Vec<Value>, schema: MetadataJsonSchema) -> Result<TransactionMetadatum, JsValue> {
+        let mut arr = MetadataList::new();
+        for value in json_arr {
+            arr.add(&encode_json_value_to_metadatum(value, schema)?);
+        }
+        Ok(TransactionMetadatum::new_list(&arr))
+    }
+    match schema {
+        MetadataJsonSchema::NoConversions |
+        MetadataJsonSchema::BasicConversions => match value {
+            Value::Null => Err(JsValue::from_str("null not allowed in metadata")),
+            Value::Bool(_) => Err(JsValue::from_str("bools not allowed in metadata")),
+            Value::Number(x) => encode_number(x),
+            Value::String(s) => Ok(encode_string(s, schema)),
+            Value::Array(json_arr) => encode_array(json_arr, schema),
+            Value::Object(json_obj) => {
+                let mut map = MetadataMap::new();
+                for (raw_key, value) in json_obj {
+                    let key = if schema == MetadataJsonSchema::BasicConversions {
+                        match raw_key.parse::<i128>() {
+                            Ok(x) => TransactionMetadatum::new_int(&Int(x)),
+                            Err(_) => encode_string(raw_key, schema),
+                        }
+                    } else {
+                        TransactionMetadatum::new_text(raw_key)
+                    };
+                    map.insert(&key, &encode_json_value_to_metadatum(value, schema)?);
+                }
+                Ok(TransactionMetadatum::new_map(&map))
+            },
         },
-        Value::String(s) => Ok(TransactionMetadatum::new_text(s)),
-        Value::Array(json_arr) => {
-            let mut arr = MetadataList::new();
-            for value in json_arr {
-                arr.add(&encode_json_value_to_metadatum(value)?);
-            }
-            Ok(TransactionMetadatum::new_list(&arr))
-        },
-        Value::Object(json_obj) => {
-            let mut map = MetadataMap::new();
-            for (key, value) in json_obj {
-                map.insert(
-                    &TransactionMetadatum::new_text(key),
-                    &encode_json_value_to_metadatum(value)?);
-            }
-            Ok(TransactionMetadatum::new_map(&map))
+        // we rely on tagged objects to control parsing here instead
+        MetadataJsonSchema::DetailedSchema => match value {
+            Value::Object(obj) if obj.len() == 1 => {
+                let (k, v) = obj.into_iter().next().unwrap();
+                fn tag_mismatch() -> JsValue {
+                    JsValue::from_str("key does not match type")
+                }
+                match k.as_str() {
+                    "int" => match v {
+                        Value::Number(x) => encode_number(x),
+                        _ => Err(tag_mismatch()),
+                    },
+                    "string" => Ok(encode_string(v.as_str().ok_or_else(tag_mismatch)?.to_owned(), schema)),
+                    "bytes" => match hex_string_to_bytes(v.as_str().ok_or_else(tag_mismatch)?) {
+                        Some(bytes) => Ok(TransactionMetadatum::new_bytes(bytes)),
+                        None => Err(JsValue::from_str("invalid hex string in tagged byte-object")),
+                    },
+                    "list" => encode_array(v.as_array().ok_or_else(tag_mismatch)?.clone(), schema),
+                    "map" => {
+                        let mut map = MetadataMap::new();
+                        for (raw_key, value) in v.as_object().ok_or_else(tag_mismatch)? {
+                            // this could potentially be a stringified JSON key
+                            let key = match encode_json_str_to_metadatum(raw_key.clone(), schema) {
+                                Ok(md)  => md,
+                                Err(_) => TransactionMetadatum::new_text(raw_key.clone()),
+                            };
+                            map.insert(&key, &encode_json_value_to_metadatum(value.clone(), schema)?);
+                        }
+                        Ok(TransactionMetadatum::new_map(&map))
+                    },
+                    invalid_key => Err(JsValue::from_str(&format!("key '{}' in tagged object not valid", invalid_key))),
+                }
+            },
+            _ => Err(JsValue::from_str("DetailedSchema requires types to be tagged objects")),
         },
     }
 }
@@ -314,38 +461,80 @@ pub fn encode_json_value_to_metadatum(value: serde_json::Value) -> Result<Transa
 // decodes a metadatum into a JSON object string if possible
 // Bytes are not supported, see encoding comment.
 #[wasm_bindgen]
-pub fn decode_metadatum_to_json_str(metadatum: &TransactionMetadatum) -> Result<String, JsValue> {
-    let value = decode_metadatum_to_json_value(metadatum)?;
+pub fn decode_metadatum_to_json_str(metadatum: &TransactionMetadatum, schema: MetadataJsonSchema) -> Result<String, JsValue> {
+    let value = decode_metadatum_to_json_value(metadatum, schema)?;
     serde_json::to_string(&value).map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
-pub fn decode_metadatum_to_json_value(metadatum: &TransactionMetadatum) -> Result<serde_json::Value, JsValue> {
+pub fn decode_metadatum_to_json_value(metadatum: &TransactionMetadatum, schema: MetadataJsonSchema) -> Result<serde_json::Value, JsValue> {
     use serde_json::Value;
     use std::convert::TryFrom;
-    match &metadatum.0 {
-        TransactionMetadatumEnum::MetadataMap(map) => {
-            let mut json_map = serde_json::map::Map::with_capacity(map.len());
-            for (key, value) in map.0.iter() {
-                json_map.insert(
-                    match &key.0 {
-                        TransactionMetadatumEnum::Text(s) => s.clone(),
-                        _ => return Err(JsValue::from_str("non-string keys not allowed in JSON")),
-                    },
-                    decode_metadatum_to_json_value(value)?
-                );
-            }
-            Ok(Value::from(json_map))
+    fn decode_key(key: &TransactionMetadatum, schema: MetadataJsonSchema) -> Result<String, JsValue> {
+        match &key.0 {
+            TransactionMetadatumEnum::Text(s) => Ok(s.clone()),
+            TransactionMetadatumEnum::Bytes(b) if schema != MetadataJsonSchema::NoConversions => Ok(bytes_to_hex_string(b.as_ref())),
+            TransactionMetadatumEnum::Int(i) if schema != MetadataJsonSchema::NoConversions => {
+                let int_str = if i.0 >= 0 {
+                    u64::try_from(i.0).map(|x| x.to_string())
+                } else {
+                    i64::try_from(i.0).map(|x| x.to_string())
+                };
+                int_str.map_err(|e| JsValue::from_str(&e.to_string()))
+            },
+            TransactionMetadatumEnum::MetadataList(list) if schema == MetadataJsonSchema::DetailedSchema => decode_metadatum_to_json_str(&TransactionMetadatum::new_list(&list), schema),
+            TransactionMetadatumEnum::MetadataMap(map) if schema == MetadataJsonSchema::DetailedSchema => decode_metadatum_to_json_str(&TransactionMetadatum::new_map(&map), schema),
+            _ => Err(JsValue::from_str(&format!("key type {:?} not allowed in JSON under specified schema", key.0))),
+        }
+    }
+    let (type_key, value) = match &metadatum.0 {
+        TransactionMetadatumEnum::MetadataMap(map) => match schema {
+            MetadataJsonSchema::NoConversions |
+            MetadataJsonSchema::BasicConversions => {
+                // treats maps directly as JSON maps
+                let mut json_map = serde_json::map::Map::with_capacity(map.len());
+                for (key, value) in map.0.iter() {
+                    json_map.insert(
+                        decode_key(key, schema)?,
+                        decode_metadatum_to_json_value(value, schema)?
+                    );
+                }
+                ("map", Value::from(json_map))
+            },
+            
+            MetadataJsonSchema::DetailedSchema => ("map", Value::from(map.0.iter().map(|(key, value)| {
+                // must encode maps as JSON lists of objects with k/v keys
+                // also in these schemas we support more key types than strings
+                let k = decode_key(key, schema)?;
+                let v = decode_metadatum_to_json_value(value, schema)?;
+                let mut kv_obj = serde_json::map::Map::with_capacity(2);
+                kv_obj.insert(String::from("k"), Value::from(k));
+                kv_obj.insert(String::from("v"), v);
+                Ok(Value::from(kv_obj))
+            }).collect::<Result<Vec<_>, JsValue>>()?))
         },
         TransactionMetadatumEnum::MetadataList(arr) => {
-            Ok(Value::from(arr.0.iter().map(decode_metadatum_to_json_value).collect::<Result<Vec<_>, JsValue>>()?))
+            ("list", Value::from(arr.0.iter().map(|e| {
+                decode_metadatum_to_json_value(e, schema)
+            }).collect::<Result<Vec<_>, JsValue>>()?))
         },
-        TransactionMetadatumEnum::Int(x) => if x.0 >= 0 {
-            Ok(Value::from(u64::try_from(x.0).map_err(|e| JsValue::from_str(&e.to_string()))?))
+        TransactionMetadatumEnum::Int(x) => ("int", if x.0 >= 0 {
+            Value::from(u64::try_from(x.0).map_err(|e| JsValue::from_str(&e.to_string()))?)
         } else {
-            Ok(Value::from(i64::try_from(x.0).map_err(|e| JsValue::from_str(&e.to_string()))?))
-        },
-        TransactionMetadatumEnum::Bytes(_) => Err(JsValue::from_str("bytes not allowed in JSON")),
-        TransactionMetadatumEnum::Text(s) => Ok(Value::from(s.clone())),
+            Value::from(i64::try_from(x.0).map_err(|e| JsValue::from_str(&e.to_string()))?)
+        }),
+        TransactionMetadatumEnum::Bytes(bytes) => ("bytes", match schema {
+            MetadataJsonSchema::NoConversions => Err(JsValue::from_str("bytes not allowed in JSON in specified schema")),
+            _ => Ok(Value::from(bytes_to_hex_string(bytes.as_ref()))),
+        }?),
+        TransactionMetadatumEnum::Text(s) => ("string", Value::from(s.clone())),
+    };
+    // potentially wrap value in a keyed map to represent more types
+    if supports_tagged_values(schema) {
+        let mut wrapper = serde_json::map::Map::with_capacity(1);
+        wrapper.insert(String::from(type_key), value);
+        Ok(Value::from(wrapper))
+    } else {
+        Ok(value)
     }
 }
 
@@ -561,12 +750,40 @@ mod tests {
     }
 
     #[test]
-    fn json_encoding() {
+    fn json_encoding_no_conversions() {
         let input_str = String::from("{\"receiver_id\": \"SJKdj34k3jjKFDKfjFUDfdjkfd\",\"sender_id\": \"jkfdsufjdk34h3Sdfjdhfduf873\",\"comment\": \"happy birthday\",\"tags\": [0, 264, -1024, 32]}");
-        let metadata = encode_json_str_to_metadatum(input_str.clone()).expect("encode failed");
-        let output_str = decode_metadatum_to_json_str(&metadata).expect("decode failed");
+        let metadata = encode_json_str_to_metadatum(input_str.clone(), MetadataJsonSchema::NoConversions).expect("encode failed");
+        let map = metadata.as_map().unwrap();
+        assert_eq!(map.get_str("receiver_id").unwrap().as_text().unwrap(), "SJKdj34k3jjKFDKfjFUDfdjkfd");
+        assert_eq!(map.get_str("sender_id").unwrap().as_text().unwrap(), "jkfdsufjdk34h3Sdfjdhfduf873");
+        assert_eq!(map.get_str("comment").unwrap().as_text().unwrap(), "happy birthday");
+        let tags = map.get_str("tags").unwrap().as_list().unwrap();
+        let tags_i32 = tags.0.iter().map(|md| md.as_int().unwrap().as_i32().unwrap()).collect::<Vec<i32>>();
+        assert_eq!(tags_i32, vec![0, 264, -1024, 32]);
+        let output_str = decode_metadatum_to_json_str(&metadata, MetadataJsonSchema::NoConversions).expect("decode failed");
         let input_json: serde_json::Value = serde_json::from_str(&input_str).unwrap();
         let output_json: serde_json::Value= serde_json::from_str(&output_str).unwrap();
         assert_eq!(input_json, output_json);
     }
+
+    #[test]
+    fn json_encoding_basic() {
+        let input_str = String::from("{\"0x8badf00d\": \"0xdeadbeef\",\"9\": 5,\"map\": {\"a\":[{\"5\": 2},{}]}}");
+        let metadata = encode_json_str_to_metadatum(input_str.clone(), MetadataJsonSchema::BasicConversions).expect("encode failed");
+        let map = metadata.as_map().unwrap();
+        assert_eq!(map.get(&TransactionMetadatum::new_bytes(hex::decode("8badf00d").unwrap())).unwrap().as_bytes().unwrap(), hex::decode("deadbeef").unwrap());
+        assert_eq!(map.get_i32(9).unwrap().as_int().unwrap().as_i32().unwrap(), 5);
+        let inner_map = map.get_str("map").unwrap().as_map().unwrap();
+        let a = inner_map.get_str("a").unwrap().as_list().unwrap();
+        let a1 = a.get(0).as_map().unwrap();
+        assert_eq!(a1.get_i32(5).unwrap().as_int().unwrap().as_i32().unwrap(), 2);
+        let a2 = a.get(1).as_map().unwrap();
+        assert_eq!(a2.keys().len(), 0);
+        let output_str = decode_metadatum_to_json_str(&metadata, MetadataJsonSchema::BasicConversions).expect("decode failed");
+        let input_json: serde_json::Value = serde_json::from_str(&input_str).unwrap();
+        let output_json: serde_json::Value= serde_json::from_str(&output_str).unwrap();
+        assert_eq!(input_json, output_json);
+    }
+
+    // TODO: detailed encoding test
 }

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -777,7 +777,6 @@ mod tests {
         let input_json: serde_json::Value = serde_json::from_str(&input_str).unwrap();
         let output_json: serde_json::Value= serde_json::from_str(&output_str).unwrap();
         assert_eq!(input_json, output_json);
-        panic!(decode_metadatum_to_json_str(&metadata, MetadataJsonSchema::DetailedSchema).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Based on: https://github.com/input-output-hk/cardano-node/pull/1797/

Provides 3 options:

* our original format (slightly stricter but 100% bidirectional)
* partial conversions (ints/bytes for keys, bytes as values - metadata -> json -> metadata round-trippable but not the other way)
* full details (arbitrary keys, all types tagged - 100% bidirectional within the schema)

The latter two are what cardano-node uses.

detailed format not fully tested yet

still need to update the docs