### PR TITLE
Add generic add input & input fee calc

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -3192,6 +3192,26 @@ declare export class TransactionBuilder {
   ): void;
 
   /**
+   * @param {Address} address
+   * @param {TransactionInput} input
+   * @param {BigNum} amount
+   */
+  add_input(address: Address, input: TransactionInput, amount: BigNum): void;
+
+  /**
+   * calculates how much the fee would increase if you added a given output
+   * @param {Address} address
+   * @param {TransactionInput} input
+   * @param {BigNum} amount
+   * @returns {BigNum}
+   */
+  fee_for_input(
+    address: Address,
+    input: TransactionInput,
+    amount: BigNum
+  ): BigNum;
+
+  /**
    * @param {TransactionOutput} output
    */
   add_output(output: TransactionOutput): void;


### PR DESCRIPTION
This PR contains two related features:

- added a  `add_input` function that takes an address and figures out how to handle it internally instead of having the user do it
- added a `fee_for_input` that says how much the fee would increase by adding an input. This is useful for input selection since you can avoid adding inputs where the value of the input is less than the fee to add it.