### PR TITLE
Fix for negative integer (de)serialization

### DIFF
--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -822,7 +822,7 @@ mod tests {
                 {\"map\": [
                     {
                         \"k\": {\"int\": 5},
-                        \"v\": {\"int\": 7}
+                        \"v\": {\"int\": -7}
                     },
                     {
                         \"k\": {\"string\": \"hello\"},
@@ -842,7 +842,7 @@ mod tests {
         let key_list = key.as_list().unwrap();
         assert_eq!(key_list.len(), 2);
         let key_map = key_list.get(0).as_map().unwrap();
-        assert_eq!(key_map.get_i32(5).unwrap().as_int().unwrap().as_i32().unwrap(), 7);
+        assert_eq!(key_map.get_i32(5).unwrap().as_int().unwrap().as_i32().unwrap(), -7);
         assert_eq!(key_map.get_str("hello").unwrap().as_text().unwrap(), "world");
         let key_bytes = key_list.get(1).as_bytes().unwrap();
         assert_eq!(key_bytes, hex::decode("ff00ff00").unwrap());

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -180,7 +180,7 @@ impl Int {
 impl cbor_event::se::Serialize for Int {
     fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
         if self.0 < 0 {
-            serializer.write_negative_integer((-self.0) as i64)
+            serializer.write_negative_integer(self.0 as i64)
         } else {
             serializer.write_unsigned_integer(self.0 as u64)
         }
@@ -192,7 +192,7 @@ impl Deserialize for Int {
         (|| -> Result<_, DeserializeError> {
             match raw.cbor_type()? {
                 cbor_event::Type::UnsignedInteger => Ok(Self(raw.unsigned_integer()? as i128)),
-                cbor_event::Type::NegativeInteger => Ok(Self(-raw.negative_integer()? as i128)),
+                cbor_event::Type::NegativeInteger => Ok(Self(raw.negative_integer()? as i128)),
                 _ => Err(DeserializeFailure::NoVariantMatched.into()),
             }
         })().map_err(|e| e.annotate("Int"))


### PR DESCRIPTION
This impacts anyone using `Int` directly, and also anyone using negative
integers via metadata, whether directly or via the JSON conversions.

Non-negative integers are not impacted at all.