### PR TITLE
Add size checks to pool registration cert objects

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -80,13 +80,6 @@ declare export function get_deposit(
 ): BigNum;
 
 /**
- * @param {Transaction} tx
- * @param {LinearFee} linear_fee
- * @returns {BigNum}
- */
-declare export function min_fee(tx: Transaction, linear_fee: LinearFee): BigNum;
-
-/**
  * @param {Uint8Array} bytes
  * @returns {TransactionMetadatum}
  */
@@ -121,6 +114,13 @@ declare export function decode_metadatum_to_json_str(
   metadatum: TransactionMetadatum,
   schema: number
 ): string;
+
+/**
+ * @param {Transaction} tx
+ * @param {LinearFee} linear_fee
+ * @returns {BigNum}
+ */
+declare export function min_fee(tx: Transaction, linear_fee: LinearFee): BigNum;
 
 /**
  */
@@ -834,6 +834,50 @@ declare export class Certificates {
    * @param {Certificate} elem
    */
   add(elem: Certificate): void;
+}
+/**
+ */
+declare export class DNSRecordAorAAAA {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {DNSRecordAorAAAA}
+   */
+  static from_bytes(bytes: Uint8Array): DNSRecordAorAAAA;
+
+  /**
+   * @param {string} dns_name
+   * @returns {DNSRecordAorAAAA}
+   */
+  static new(dns_name: string): DNSRecordAorAAAA;
+}
+/**
+ */
+declare export class DNSRecordSRV {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {DNSRecordSRV}
+   */
+  static from_bytes(bytes: Uint8Array): DNSRecordSRV;
+
+  /**
+   * @param {string} dns_name
+   * @returns {DNSRecordSRV}
+   */
+  static new(dns_name: string): DNSRecordSRV;
 }
 /**
  */
@@ -1796,15 +1840,15 @@ declare export class MultiHostName {
   static from_bytes(bytes: Uint8Array): MultiHostName;
 
   /**
-   * @returns {string}
+   * @returns {DNSRecordSRV}
    */
-  dns_name(): string;
+  dns_name(): DNSRecordSRV;
 
   /**
-   * @param {string} dns_name
+   * @param {DNSRecordSRV} dns_name
    * @returns {MultiHostName}
    */
-  static new(dns_name: string): MultiHostName;
+  static new(dns_name: DNSRecordSRV): MultiHostName;
 }
 /**
  */
@@ -2109,9 +2153,9 @@ declare export class PoolMetadata {
   static from_bytes(bytes: Uint8Array): PoolMetadata;
 
   /**
-   * @returns {string}
+   * @returns {URL}
    */
-  url(): string;
+  url(): URL;
 
   /**
    * @returns {MetadataHash}
@@ -2119,11 +2163,11 @@ declare export class PoolMetadata {
   metadata_hash(): MetadataHash;
 
   /**
-   * @param {string} url
+   * @param {URL} url
    * @param {MetadataHash} metadata_hash
    * @returns {PoolMetadata}
    */
-  static new(url: string, metadata_hash: MetadataHash): PoolMetadata;
+  static new(url: URL, metadata_hash: MetadataHash): PoolMetadata;
 }
 /**
  */
@@ -2931,16 +2975,16 @@ declare export class SingleHostName {
   port(): number | void;
 
   /**
-   * @returns {string}
+   * @returns {DNSRecordAorAAAA}
    */
-  dns_name(): string;
+  dns_name(): DNSRecordAorAAAA;
 
   /**
    * @param {number | void} port
-   * @param {string} dns_name
+   * @param {DNSRecordAorAAAA} dns_name
    * @returns {SingleHostName}
    */
-  static new(port: number | void, dns_name: string): SingleHostName;
+  static new(port: number | void, dns_name: DNSRecordAorAAAA): SingleHostName;
 }
 /**
  */
@@ -3851,6 +3895,28 @@ declare export class TransactionWitnessSets {
    * @param {TransactionWitnessSet} elem
    */
   add(elem: TransactionWitnessSet): void;
+}
+/**
+ */
+declare export class URL {
+  free(): void;
+
+  /**
+   * @returns {Uint8Array}
+   */
+  to_bytes(): Uint8Array;
+
+  /**
+   * @param {Uint8Array} bytes
+   * @returns {URL}
+   */
+  static from_bytes(bytes: Uint8Array): URL;
+
+  /**
+   * @param {string} url
+   * @returns {URL}
+   */
+  static new(url: string): URL;
 }
 /**
  */

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -36,6 +36,11 @@ pub enum DeserializeFailure {
     MandatoryFieldMissing(Key),
     Metadata(JsError),
     NoVariantMatched,
+    OutOfRange{
+        min: usize,
+        max: usize,
+        found: usize
+    },
     PublicKeyError(chain_crypto::PublicKeyError),
     SignatureError(chain_crypto::SignatureError),
     TagMismatch{
@@ -86,6 +91,7 @@ impl std::fmt::Display for DeserializeError {
             DeserializeFailure::MandatoryFieldMissing(key) => write!(f, "Mandatory field {} not found", key),
             DeserializeFailure::Metadata(e) => write!(f, "Metadata error: {:?}", e),
             DeserializeFailure::NoVariantMatched => write!(f, "No variant matched"),
+            DeserializeFailure::OutOfRange{ min, max, found } => write!(f, "Out of range: {} - must be in range {} - {}", found, min, max),
             DeserializeFailure::PublicKeyError(e) => write!(f, "PublicKeyError error: {}", e),
             DeserializeFailure::SignatureError(e) => write!(f, "Signature error: {}", e),
             DeserializeFailure::TagMismatch{ found, expected } => write!(f, "Expected tag {}, found {}", expected, found),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -827,31 +827,126 @@ type Port = u16;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Ipv4(Vec<u8>);
+pub struct Ipv4([u8; 4]);
 
 to_from_bytes!(Ipv4);
 
 #[wasm_bindgen]
 impl Ipv4 {
-    pub fn new(data: Vec<u8>) -> Self {
-        Self(data)
+    pub fn new(data: Vec<u8>) -> Result<Ipv4, JsError> {
+        Self::new_impl(data).map_err(|e| JsError::from_str(&e.to_string()))
+    }
+
+    pub (crate) fn new_impl(data: Vec<u8>) -> Result<Ipv4, DeserializeError> {
+        use std::convert::TryInto;
+        data[..4]
+            .try_into()
+            .map(Self)
+            .map_err(|_e| {
+                let cbor_error = cbor_event::Error::WrongLen(4, cbor_event::Len::Len(data.len() as u64), "Ipv4 address length");
+                DeserializeError::new("Ipv4", DeserializeFailure::CBOR(cbor_error))
+            })
     }
 }
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Ipv6(Vec<u8>);
+pub struct Ipv6([u8; 16]);
 
 to_from_bytes!(Ipv6);
 
 #[wasm_bindgen]
 impl Ipv6 {
-    pub fn new(data: Vec<u8>) -> Self {
-        Self(data)
+    pub fn new(data: Vec<u8>) -> Result<Ipv6, JsError> {
+        Self::new_impl(data).map_err(|e| JsError::from_str(&e.to_string()))
+    }
+
+    pub (crate) fn new_impl(data: Vec<u8>) -> Result<Ipv6, DeserializeError> {
+        use std::convert::TryInto;
+        data[..16]
+            .try_into()
+            .map(Self)
+            .map_err(|_e| {
+                let cbor_error = cbor_event::Error::WrongLen(16, cbor_event::Len::Len(data.len() as u64), "Ipv6 address length");
+                DeserializeError::new("Ipv6", DeserializeFailure::CBOR(cbor_error))
+            })
     }
 }
 
-type DnsName = String;
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct URL(String);
+
+to_from_bytes!(URL);
+
+#[wasm_bindgen]
+impl URL {
+    pub fn new(url: String) -> Result<URL, JsError> {
+        Self::new_impl(url).map_err(|e| JsError::from_str(&e.to_string()))
+    }
+
+    pub (crate) fn new_impl(url: String) -> Result<URL, DeserializeError> {
+        if url.len() <= 64 {
+            Ok(Self(url))
+        } else {
+            Err(DeserializeError::new("URL", DeserializeFailure::OutOfRange{
+                min: 0,
+                max: 64,
+                found: url.len(),
+            }))
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct DNSRecordAorAAAA(String);
+
+to_from_bytes!(DNSRecordAorAAAA);
+
+#[wasm_bindgen]
+impl DNSRecordAorAAAA {
+    pub fn new(dns_name: String) -> Result<DNSRecordAorAAAA, JsError> {
+        Self::new_impl(dns_name).map_err(|e| JsError::from_str(&e.to_string()))
+    }
+
+    pub (crate) fn new_impl(dns_name: String) -> Result<DNSRecordAorAAAA, DeserializeError> {
+        if dns_name.len() <= 64 {
+            Ok(Self(dns_name))
+        } else {
+            Err(DeserializeError::new("DNSRecordAorAAAA", DeserializeFailure::OutOfRange{
+                min: 0,
+                max: 64,
+                found: dns_name.len(),
+            }))
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct DNSRecordSRV(String);
+
+to_from_bytes!(DNSRecordSRV);
+
+#[wasm_bindgen]
+impl DNSRecordSRV {
+    pub fn new(dns_name: String) -> Result<DNSRecordSRV, JsError> {
+        Self::new_impl(dns_name).map_err(|e| JsError::from_str(&e.to_string()))
+    }
+
+    pub (crate) fn new_impl(dns_name: String) -> Result<DNSRecordSRV, DeserializeError> {
+        if dns_name.len() <= 64 {
+            Ok(Self(dns_name))
+        } else {
+            Err(DeserializeError::new("DNSRecordSRV", DeserializeFailure::OutOfRange{
+                min: 0,
+                max: 64,
+                found: dns_name.len(),
+            }))
+        }
+    }
+}
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -890,7 +985,7 @@ impl SingleHostAddr {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct SingleHostName {
     port: Option<Port>,
-    dns_name: DnsName,
+    dns_name: DNSRecordAorAAAA,
 }
 
 to_from_bytes!(SingleHostName);
@@ -901,14 +996,14 @@ impl SingleHostName {
         self.port.clone()
     }
 
-    pub fn dns_name(&self) -> DnsName {
+    pub fn dns_name(&self) -> DNSRecordAorAAAA {
         self.dns_name.clone()
     }
 
-    pub fn new(port: Option<Port>, dns_name: DnsName) -> Self {
+    pub fn new(port: Option<Port>, dns_name: &DNSRecordAorAAAA) -> Self {
         Self {
             port: port,
-            dns_name: dns_name,
+            dns_name: dns_name.clone(),
         }
     }
 }
@@ -916,19 +1011,19 @@ impl SingleHostName {
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct MultiHostName {
-    dns_name: DnsName,
+    dns_name: DNSRecordSRV,
 }
 
 to_from_bytes!(MultiHostName);
 
 #[wasm_bindgen]
 impl MultiHostName {
-    pub fn dns_name(&self) -> DnsName {
+    pub fn dns_name(&self) -> DNSRecordSRV {
         self.dns_name.clone()
     }
 
-    pub fn new(dns_name: DnsName) -> Self {
-        Self { dns_name: dns_name }
+    pub fn new(dns_name: &DNSRecordSRV) -> Self {
+        Self { dns_name: dns_name.clone() }
     }
 }
 
@@ -1000,7 +1095,7 @@ impl Relay {
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct PoolMetadata {
-    url: Url,
+    url: URL,
     metadata_hash: MetadataHash,
 }
 
@@ -1008,7 +1103,7 @@ to_from_bytes!(PoolMetadata);
 
 #[wasm_bindgen]
 impl PoolMetadata {
-    pub fn url(&self) -> Url {
+    pub fn url(&self) -> URL {
         self.url.clone()
     }
 
@@ -1016,16 +1111,13 @@ impl PoolMetadata {
         self.metadata_hash.clone()
     }
 
-    pub fn new(url: Url, metadata_hash: &MetadataHash) -> Self {
+    pub fn new(url: &URL, metadata_hash: &MetadataHash) -> Self {
         Self {
-            url: url,
+            url: url.clone(),
             metadata_hash: metadata_hash.clone(),
         }
     }
 }
-
-type Url = String;
-
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct StakeCredentials(Vec<StakeCredential>);

--- a/rust/src/serialization.rs
+++ b/rust/src/serialization.rs
@@ -1158,7 +1158,7 @@ impl cbor_event::se::Serialize for Ipv4 {
 
 impl Deserialize for Ipv4 {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        Ok(Self(raw.bytes()?))
+        Self::new_impl(raw.bytes()?)
     }
 }
 
@@ -1170,7 +1170,43 @@ impl cbor_event::se::Serialize for Ipv6 {
 
 impl Deserialize for Ipv6 {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        Ok(Self(raw.bytes()?))
+        Self::new_impl(raw.bytes()?)
+    }
+}
+
+impl cbor_event::se::Serialize for DNSRecordAorAAAA {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_text(&self.0)
+    }
+}
+
+impl Deserialize for DNSRecordAorAAAA {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Self::new_impl(raw.text()?)
+    }
+}
+
+impl cbor_event::se::Serialize for DNSRecordSRV {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_text(&self.0)
+    }
+}
+
+impl Deserialize for DNSRecordSRV {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Self::new_impl(raw.text()?)
+    }
+}
+
+impl cbor_event::se::Serialize for URL {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_text(&self.0)
+    }
+}
+
+impl Deserialize for URL {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Self::new_impl(raw.text()?)
     }
 }
 
@@ -1295,7 +1331,7 @@ impl SerializeEmbeddedGroup for SingleHostName {
             },
             None => serializer.write_special(CBORSpecial::Null),
         }?;
-        serializer.write_text(&self.dns_name)?;
+        self.dns_name.serialize(serializer)?;
         Ok(serializer)
     }
 }
@@ -1340,7 +1376,7 @@ impl DeserializeEmbeddedGroup for SingleHostName {
             })
         })().map_err(|e| e.annotate("port"))?;
         let dns_name = (|| -> Result<_, DeserializeError> {
-            Ok(String::deserialize(raw)?)
+            Ok(DNSRecordAorAAAA::deserialize(raw)?)
         })().map_err(|e| e.annotate("dns_name"))?;
         Ok(SingleHostName {
             port,
@@ -1359,7 +1395,7 @@ impl cbor_event::se::Serialize for MultiHostName {
 impl SerializeEmbeddedGroup for MultiHostName {
     fn serialize_as_embedded_group<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer.write_unsigned_integer(2u64)?;
-        serializer.write_text(&self.dns_name)?;
+        self.dns_name.serialize(serializer)?;
         Ok(serializer)
     }
 }
@@ -1391,7 +1427,7 @@ impl DeserializeEmbeddedGroup for MultiHostName {
             Ok(())
         })().map_err(|e| e.annotate("index_0"))?;
         let dns_name = (|| -> Result<_, DeserializeError> {
-            Ok(String::deserialize(raw)?)
+            Ok(DNSRecordSRV::deserialize(raw)?)
         })().map_err(|e| e.annotate("dns_name"))?;
         Ok(MultiHostName {
             dns_name,
@@ -1469,7 +1505,7 @@ impl Deserialize for Relay {
 impl cbor_event::se::Serialize for PoolMetadata {
     fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
         serializer.write_array(cbor_event::Len::Len(2))?;
-        serializer.write_text(&self.url)?;
+        self.url.serialize(serializer)?;
         self.metadata_hash.serialize(serializer)?;
         Ok(serializer)
     }
@@ -1495,7 +1531,7 @@ impl Deserialize for PoolMetadata {
 impl DeserializeEmbeddedGroup for PoolMetadata {
     fn deserialize_as_embedded_group<R: BufRead + Seek>(raw: &mut Deserializer<R>, len: cbor_event::Len) -> Result<Self, DeserializeError> {
         let url = (|| -> Result<_, DeserializeError> {
-            Ok(String::deserialize(raw)?)
+            Ok(URL::deserialize(raw)?)
         })().map_err(|e| e.annotate("url"))?;
         let metadata_hash = (|| -> Result<_, DeserializeError> {
             Ok(MetadataHash::deserialize(raw)?)


### PR DESCRIPTION
Add in checks for: Ipv4, Ipv6, Url (Moved to dedicated struct)

Split DnsName (string alias) into DNSRecordAorAAAA / DNSRecordSRV to be
more descriptive for the two use-cases and to allow us to potentially
add in types specific to each type of DNS record during creation.