### PR TITLE
Improved binary/string types

### DIFF
--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -677,6 +677,8 @@ macro_rules! impl_hash_type {
 
         #[wasm_bindgen]
         impl $name {
+            // hash types are the only types in this library to not give the entire CBOR structure.
+            // There is no CBOR binary tag here just the raw hash bytes.
             pub fn to_bytes(&self) -> Vec<u8> {
                 self.0.to_vec()
             }
@@ -693,6 +695,8 @@ macro_rules! impl_hash_type {
             }
         }
 
+        // hash types are the only types in this library to not expect the entire CBOR structure.
+        // There is no CBOR binary tag here just the raw hash bytes.
         from_bytes!($name, bytes, {
             use std::convert::TryInto;
             match bytes.len() {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -867,6 +867,10 @@ impl Ipv4 {
                 DeserializeError::new("Ipv4", DeserializeFailure::CBOR(cbor_error))
             })
     }
+
+    pub fn ip(&self) -> Vec<u8> {
+        self.0.clone()
+    }
 }
 
 #[wasm_bindgen]
@@ -890,6 +894,10 @@ impl Ipv6 {
                 let cbor_error = cbor_event::Error::WrongLen(16, cbor_event::Len::Len(data.len() as u64), "Ipv6 address length");
                 DeserializeError::new("Ipv6", DeserializeFailure::CBOR(cbor_error))
             })
+    }
+
+    pub fn ip(&self) -> Vec<u8> {
+        self.0.clone()
     }
 }
 
@@ -918,6 +926,10 @@ impl URL {
             }))
         }
     }
+
+    pub fn url(&self) -> String {
+        self.0.clone()
+    }
 }
 
 static DNS_NAME_MAX_LEN: usize = 64;
@@ -945,6 +957,10 @@ impl DNSRecordAorAAAA {
             }))
         }
     }
+
+    pub fn record(&self) -> String {
+        self.0.clone()
+    }
 }
 
 #[wasm_bindgen]
@@ -969,6 +985,10 @@ impl DNSRecordSRV {
                 found: dns_name.len(),
             }))
         }
+    }
+
+    pub fn record(&self) -> String {
+        self.0.clone()
     }
 }
 
@@ -2168,6 +2188,10 @@ impl AssetName {
                 found: name.len(),
             }))
         }
+    }
+
+    pub fn name(&self) -> Vec<u8> {
+        self.0.clone()
     }
 }
 


### PR DESCRIPTION
Add in checks for: Ipv4, Ipv6, Url (Moved to dedicated struct)

Split DnsName (string alias) into DNSRecordAorAAAA / DNSRecordSRV to be
more descriptive for the two use-cases and to allow us to potentially
add in types specific to each type of DNS record during creation.

Also adds in getters for all of these types + AssetName, as to_bytes() includes wrapping cbor tags making it unsuitable/confusing.

This PR replaces #97 