### PR TITLE
Token input selection helper function

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -408,6 +408,13 @@ declare export class BigNum {
   checked_sub(other: BigNum): BigNum;
 
   /**
+   * returns 0 if it would otherwise underflow
+   * @param {BigNum} other
+   * @returns {BigNum}
+   */
+  clamped_sub(other: BigNum): BigNum;
+
+  /**
    * @param {BigNum} rhs_value
    * @returns {number}
    */
@@ -2008,6 +2015,13 @@ declare export class MultiAsset {
    * @returns {ScriptHashes}
    */
   keys(): ScriptHashes;
+
+  /**
+   * removes an asset from the list if the result is 0 or less
+   * @param {MultiAsset} rhs_ma
+   * @returns {MultiAsset}
+   */
+  sub(rhs_ma: MultiAsset): MultiAsset;
 }
 /**
  */
@@ -4539,6 +4553,12 @@ declare export class Value {
    * @returns {Value}
    */
   checked_sub(rhs_value: Value): Value;
+
+  /**
+   * @param {Value} rhs_value
+   * @returns {Value}
+   */
+  clamped_sub(rhs_value: Value): Value;
 
   /**
    * note: values are only partially comparable

--- a/rust/src/fees.rs
+++ b/rust/src/fees.rs
@@ -59,7 +59,7 @@ mod tests {
                 hex::decode("611c616f1acb460668a9b2f123c80372c2adad3583b9c6cd2b1deeed1c").unwrap(),
             )
             .unwrap(),
-            &Value::new(to_bignum(1)),
+            &Value::new(&to_bignum(1)),
         ));
         let body = TransactionBody::new(&inputs, &outputs, &to_bignum(94002), Some(10));
 
@@ -104,7 +104,7 @@ mod tests {
                 hex::decode("611c616f1acb460668a9b2f123c80372c2adad3583b9c6cd2b1deeed1c").unwrap(),
             )
             .unwrap(),
-            &Value::new(to_bignum(1)),
+            &Value::new(&to_bignum(1)),
         ));
         let body = TransactionBody::new(&inputs, &outputs, &to_bignum(112002), Some(10));
 
@@ -162,14 +162,14 @@ mod tests {
                 hex::decode("611c616f1acb460668a9b2f123c80372c2adad3583b9c6cd2b1deeed1c").unwrap(),
             )
             .unwrap(),
-            &Value::new(to_bignum(289)),
+            &Value::new(&to_bignum(289)),
         ));
         outputs.add(&TransactionOutput::new(
             &Address::from_bytes(
                 hex::decode("61bcd18fcffa797c16c007014e2b8553b8b9b1e94c507688726243d611").unwrap(),
             )
             .unwrap(),
-            &Value::new(to_bignum(874551452)),
+            &Value::new(&to_bignum(874551452)),
         ));
         let body = TransactionBody::new(&inputs, &outputs, &to_bignum(183502), Some(999));
 
@@ -220,7 +220,7 @@ mod tests {
             &Address::from_bytes(
                 hex::decode("611c616f1acb460668a9b2f123c80372c2adad3583b9c6cd2b1deeed1c").unwrap()
             ).unwrap(),
-            &Value::new(to_bignum(1))
+            &Value::new(&to_bignum(1))
         ));
         let mut body = TransactionBody::new(&inputs, &outputs, &to_bignum(266002), Some(10));
 
@@ -449,7 +449,7 @@ mod tests {
             &Address::from_bytes(
                 hex::decode("611c616f1acb460668a9b2f123c80372c2adad3583b9c6cd2b1deeed1c").unwrap()
             ).unwrap(),
-            &Value::new(to_bignum(1))
+            &Value::new(&to_bignum(1))
         ));
         let mut body = TransactionBody::new(&inputs, &outputs, &to_bignum(162502), Some(10));
         let mut withdrawals = Withdrawals::new();

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -409,13 +409,14 @@ impl TransactionBuilder {
                     builder: &mut TransactionBuilder,
                     burn_amount: &BigNum
                 | {
-                    match &change_estimator.multiasset() {
-                        None => {
+                    let has_assets = change_estimator.multiasset().map(|assets| assets.len() > 0).unwrap_or(false);
+                    match has_assets {
+                        false => {
                             // recall: min_fee assumed the fee was the maximum possible so we definitely have enough input to cover whatever fee it ends up being
                             builder.set_fee(burn_amount);
                             Ok(false) // not enough input to covert the extra fee from adding an output so we just burn whatever is left
                         },
-                        Some(_assets) => Err(JsError::from_str("Not enough ADA leftover to include non-ADA assets in a change address")),
+                        true => Err(JsError::from_str("Not enough ADA leftover to include non-ADA assets in a change address")),
                     }
                 };
 
@@ -1134,6 +1135,44 @@ mod tests {
         assert_eq!(
             tx_builder.get_explicit_input().unwrap().checked_add(&tx_builder.get_implicit_input().unwrap()).unwrap(),
             tx_builder.get_explicit_output().unwrap().checked_add(&Value::new(&tx_builder.get_fee_if_set().unwrap())).unwrap()
+        );
+        let _final_tx = tx_builder.build(); // just test that it doesn't throw
+    }
+
+    #[test]
+    fn build_tx_burn_empty_assets() {
+        let linear_fee = LinearFee::new(&to_bignum(44), &to_bignum(155381));
+        let mut tx_builder =
+            TransactionBuilder::new(&linear_fee, &to_bignum(1000000), &to_bignum(500000000), &to_bignum(2000000));
+
+        let output_addr = ByronAddress::from_base58("Ae2tdPwUPEZD9QQf2ZrcYV34pYJwxK4vqXaF8EXkup1eYH73zUScHReM42b").unwrap();
+        tx_builder.add_output(&TransactionOutput::new(
+            &output_addr.to_address(),
+            &Value::new(&to_bignum(2_000_000))
+        )).unwrap();
+
+        let mut input_value = Value::new(&to_bignum(2_400_000));
+        input_value.set_multiasset(&MultiAsset::new());
+        tx_builder.add_input(
+            &ByronAddress::from_base58("Ae2tdPwUPEZ5uzkzh1o2DHECiUi3iugvnnKHRisPgRRP3CTF4KCMvy54Xd3").unwrap().to_address(),
+            &TransactionInput::new(
+                &genesis_id(),
+                0
+            ),
+            &input_value
+        );
+        
+        tx_builder.set_ttl(1);
+
+        let change_addr = ByronAddress::from_base58("Ae2tdPwUPEZGUEsuMAhvDcy94LKsZxDjCbgaiBBMgYpR8sKf96xJmit7Eho").unwrap();
+        let added_change = tx_builder.add_change_if_needed(
+            &change_addr.to_address()
+        );
+        assert!(!added_change.unwrap());
+        assert_eq!(tx_builder.outputs.len(), 1);
+        assert_eq!(
+            tx_builder.get_explicit_input().unwrap().checked_add(&tx_builder.get_implicit_input().unwrap()).unwrap().coin(),
+            tx_builder.get_explicit_output().unwrap().checked_add(&Value::new(&tx_builder.get_fee_if_set().unwrap())).unwrap().coin()
         );
         let _final_tx = tx_builder.build(); // just test that it doesn't throw
     }

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -314,7 +314,7 @@ impl TransactionBuilder {
     pub fn get_explicit_input(&self) -> Result<Value, JsError> {
         self.inputs
             .iter()
-            .try_fold(Value::new(to_bignum(0)), |acc, ref tx_builder_input| {
+            .try_fold(Value::new(&to_bignum(0)), |acc, ref tx_builder_input| {
                 acc.checked_add(&tx_builder_input.amount)
             })
     }
@@ -333,7 +333,7 @@ impl TransactionBuilder {
         self.outputs
             .0
             .iter()
-            .try_fold(Value::new(to_bignum(0)), |acc, ref output| {
+            .try_fold(Value::new(&to_bignum(0)), |acc, ref output| {
                 acc.checked_add(&output.amount())
             })
     }
@@ -368,10 +368,10 @@ impl TransactionBuilder {
 
         let output_total = self
             .get_explicit_output()?
-            .checked_add(&Value::new(self.get_deposit()?))?;
+            .checked_add(&Value::new(&self.get_deposit()?))?;
 
         use std::cmp::Ordering;
-        match &input_total.partial_cmp(&output_total.checked_add(&Value::new(fee))?) {
+        match &input_total.partial_cmp(&output_total.checked_add(&Value::new(&fee))?) {
             Some(Ordering::Equal) => {
                 // recall: min_fee assumed the fee was the maximum possible so we definitely have enough input to cover whatever fee it ends up being
                 self.set_fee(&input_total.checked_sub(&output_total)?.coin());
@@ -397,7 +397,7 @@ impl TransactionBuilder {
                             })?;
 
                             let new_fee = fee.checked_add(&fee_for_change)?;
-                            match change_estimator.coin() >= min_ada.checked_add(&Value::new(new_fee).coin())? {
+                            match change_estimator.coin() >= min_ada.checked_add(&Value::new(&new_fee).coin())? {
                                 false => burn_fee(builder, &change_estimator.coin()),
                                 true => add_change(builder, &new_fee)
                             }
@@ -428,7 +428,7 @@ impl TransactionBuilder {
 
                     builder.add_output(&TransactionOutput {
                         address: address.clone(),
-                        amount: change_estimator.checked_sub(&Value::new(new_fee.clone()))?,
+                        amount: change_estimator.checked_sub(&Value::new(&new_fee.clone()))?,
                     })?;
 
                     Ok(true)
@@ -525,11 +525,11 @@ mod tests {
         tx_builder.add_key_input(
             &spend.to_raw_key().hash(),
             &TransactionInput::new(&genesis_id(), 0),
-            &Value::new(to_bignum(1_000_000))
+            &Value::new(&to_bignum(1_000_000))
         );
         tx_builder.add_output(&TransactionOutput::new(
             &addr_net_0,
-            &Value::new(to_bignum(10))
+            &Value::new(&to_bignum(10))
         )).unwrap();
         tx_builder.set_ttl(1000);
 
@@ -542,7 +542,7 @@ mod tests {
         assert_eq!(tx_builder.outputs.len(), 2);
         assert_eq!(
             tx_builder.get_explicit_input().unwrap().checked_add(&tx_builder.get_implicit_input().unwrap()).unwrap(),
-            tx_builder.get_explicit_output().unwrap().checked_add(&Value::new(tx_builder.get_fee_if_set().unwrap())).unwrap()
+            tx_builder.get_explicit_output().unwrap().checked_add(&Value::new(&tx_builder.get_fee_if_set().unwrap())).unwrap()
         );
         let _final_tx = tx_builder.build(); // just test that it doesn't throw
     }
@@ -580,11 +580,11 @@ mod tests {
         tx_builder.add_key_input(
             &spend.to_raw_key().hash(),
             &TransactionInput::new(&genesis_id(), 0),
-            &Value::new(to_bignum(1_000_000))
+            &Value::new(&to_bignum(1_000_000))
         );
         tx_builder.add_output(&TransactionOutput::new(
             &addr_net_0,
-            &Value::new(to_bignum(880_000))
+            &Value::new(&to_bignum(880_000))
         )).unwrap();
         tx_builder.set_ttl(1000);
 
@@ -597,7 +597,7 @@ mod tests {
         assert_eq!(tx_builder.outputs.len(), 1);
         assert_eq!(
             tx_builder.get_explicit_input().unwrap().checked_add(&tx_builder.get_implicit_input().unwrap()).unwrap(),
-            tx_builder.get_explicit_output().unwrap().checked_add(&Value::new(tx_builder.get_fee_if_set().unwrap())).unwrap()
+            tx_builder.get_explicit_output().unwrap().checked_add(&Value::new(&tx_builder.get_fee_if_set().unwrap())).unwrap()
         );
         let _final_tx = tx_builder.build(); // just test that it doesn't throw
     }
@@ -637,7 +637,7 @@ mod tests {
         tx_builder.add_key_input(
             &spend.to_raw_key().hash(),
             &TransactionInput::new(&genesis_id(), 0),
-            &Value::new(to_bignum(5_000_000))
+            &Value::new(&to_bignum(5_000_000))
         );
         tx_builder.set_ttl(1000);
 
@@ -662,8 +662,8 @@ mod tests {
             tx_builder.get_explicit_input().unwrap().checked_add(&tx_builder.get_implicit_input().unwrap()).unwrap(),
             tx_builder
                 .get_explicit_output().unwrap()
-                .checked_add(&Value::new(tx_builder.get_fee_if_set().unwrap())).unwrap()
-                .checked_add(&Value::new(tx_builder.get_deposit().unwrap())).unwrap()
+                .checked_add(&Value::new(&tx_builder.get_fee_if_set().unwrap())).unwrap()
+                .checked_add(&Value::new(&tx_builder.get_deposit().unwrap())).unwrap()
         );
         let _final_tx = tx_builder.build(); // just test that it doesn't throw
     }
@@ -698,14 +698,14 @@ mod tests {
         tx_builder.add_key_input(
             &&spend.to_raw_key().hash(),
             &TransactionInput::new(&genesis_id(), 0),
-            &Value::new(to_bignum(5))
+            &Value::new(&to_bignum(5))
         );
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
         let stake_cred = StakeCredential::from_keyhash(&stake.to_raw_key().hash());
         let addr_net_0 = BaseAddress::new(NetworkInfo::testnet().network_id(), &spend_cred, &stake_cred).to_address();
         tx_builder.add_output(&TransactionOutput::new(
             &addr_net_0,
-            &Value::new(to_bignum(5))
+            &Value::new(&to_bignum(5))
         )).unwrap();
         tx_builder.set_ttl(0);
 
@@ -749,7 +749,7 @@ mod tests {
         tx_builder.add_key_input(
             &&spend.to_raw_key().hash(),
             &TransactionInput::new(&genesis_id(), 0),
-            &Value::new(to_bignum(6))
+            &Value::new(&to_bignum(6))
         );
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
         let stake_cred = StakeCredential::from_keyhash(&stake.to_raw_key().hash());
@@ -762,7 +762,7 @@ mod tests {
         tx_builder
             .add_output(&TransactionOutput::new(
                 &addr_net_0,
-                &Value::new(to_bignum(5)),
+                &Value::new(&to_bignum(5)),
             ))
             .unwrap();
         tx_builder.set_ttl(0);
@@ -809,7 +809,7 @@ mod tests {
         tx_builder.add_key_input(
             &&spend.to_raw_key().hash(),
             &TransactionInput::new(&genesis_id(), 0),
-            &Value::new(to_bignum(5)),
+            &Value::new(&to_bignum(5)),
         );
         let spend_cred = StakeCredential::from_keyhash(&spend.to_raw_key().hash());
         let stake_cred = StakeCredential::from_keyhash(&stake.to_raw_key().hash());
@@ -822,7 +822,7 @@ mod tests {
         tx_builder
             .add_output(&TransactionOutput::new(
                 &addr_net_0,
-                &Value::new(to_bignum(5)),
+                &Value::new(&to_bignum(5)),
             ))
             .unwrap();
         tx_builder.set_ttl(0);
@@ -875,7 +875,7 @@ mod tests {
                     &spend_cred
                 ).to_address(),
                 &TransactionInput::new(&genesis_id(), 0),
-                &Value::new(to_bignum(1_000_000))
+                &Value::new(&to_bignum(1_000_000))
             ).unwrap().to_str(), "69500");
             tx_builder.add_input(
                 &EnterpriseAddress::new(
@@ -883,7 +883,7 @@ mod tests {
                     &spend_cred
                 ).to_address(),
                 &TransactionInput::new(&genesis_id(), 0),
-                &Value::new(to_bignum(1_000_000))
+                &Value::new(&to_bignum(1_000_000))
             );
         }
         tx_builder.add_input(
@@ -893,7 +893,7 @@ mod tests {
                 &stake_cred
             ).to_address(),
             &TransactionInput::new(&genesis_id(), 0),
-            &Value::new(to_bignum(1_000_000))
+            &Value::new(&to_bignum(1_000_000))
         );
         tx_builder.add_input(
             &PointerAddress::new(
@@ -906,14 +906,14 @@ mod tests {
                 )
             ).to_address(),
             &TransactionInput::new(&genesis_id(), 0),
-            &Value::new(to_bignum(1_000_000))
+            &Value::new(&to_bignum(1_000_000))
         );
         tx_builder.add_input(
             &ByronAddress::icarus_from_key(
                 &spend, NetworkInfo::testnet().protocol_magic()
             ).to_address(),
             &TransactionInput::new(&genesis_id(), 0),
-            &Value::new(to_bignum(1_000_000))
+            &Value::new(&to_bignum(1_000_000))
         );
 
         assert_eq!(tx_builder.inputs.len(), 4);
@@ -975,7 +975,7 @@ mod tests {
             .iter()
             .zip([10u64, 10].iter().cloned().map(to_bignum))
         {
-            let mut input_amount = Value::new(ada);
+            let mut input_amount = Value::new(&ada);
             input_amount.set_multiasset(multiasset);
 
             tx_builder.add_key_input(
@@ -995,7 +995,7 @@ mod tests {
         )
         .to_address();
 
-        let mut output_amount = Value::new(to_bignum(1));
+        let mut output_amount = Value::new(&to_bignum(1));
         output_amount.set_multiasset(&multiassets[2]);
 
         tx_builder
@@ -1068,7 +1068,7 @@ mod tests {
         // add an input that contains an asset not present in the output
         let policy_id = &PolicyID::from([0u8; 28]);
         let name = AssetName::new(vec![0u8, 1, 2, 3]).unwrap();
-        let mut input_amount = Value::new(to_bignum(1_000_000));
+        let mut input_amount = Value::new(&to_bignum(1_000_000));
         let mut input_multiasset = MultiAsset::new();
         input_multiasset.insert(policy_id, &{
             let mut assets = Assets::new();
@@ -1084,7 +1084,7 @@ mod tests {
 
         tx_builder.add_output(&TransactionOutput::new(
             &addr_net_0,
-            &Value::new(to_bignum(880_000))
+            &Value::new(&to_bignum(880_000))
         )).unwrap();
         tx_builder.set_ttl(1000);
 
@@ -1097,7 +1097,7 @@ mod tests {
         assert_eq!(tx_builder.outputs.len(), 1);
         assert_eq!(
             tx_builder.get_explicit_input().unwrap().checked_add(&tx_builder.get_implicit_input().unwrap()).unwrap(),
-            tx_builder.get_explicit_output().unwrap().checked_add(&Value::new(tx_builder.get_fee_if_set().unwrap())).unwrap()
+            tx_builder.get_explicit_output().unwrap().checked_add(&Value::new(&tx_builder.get_fee_if_set().unwrap())).unwrap()
         );
         let _final_tx = tx_builder.build(); // just test that it doesn't throw
     }
@@ -1111,7 +1111,7 @@ mod tests {
         let output_addr = ByronAddress::from_base58("Ae2tdPwUPEZD9QQf2ZrcYV34pYJwxK4vqXaF8EXkup1eYH73zUScHReM42b").unwrap();
         tx_builder.add_output(&TransactionOutput::new(
             &output_addr.to_address(),
-            &Value::new(to_bignum(2_000_000))
+            &Value::new(&to_bignum(2_000_000))
         )).unwrap();
 
         tx_builder.add_input(
@@ -1120,7 +1120,7 @@ mod tests {
                 &genesis_id(),
                 0
             ),
-            &Value::new(to_bignum(2_400_000))
+            &Value::new(&to_bignum(2_400_000))
         );
         
         tx_builder.set_ttl(1);
@@ -1133,7 +1133,7 @@ mod tests {
         assert_eq!(tx_builder.outputs.len(), 1);
         assert_eq!(
             tx_builder.get_explicit_input().unwrap().checked_add(&tx_builder.get_implicit_input().unwrap()).unwrap(),
-            tx_builder.get_explicit_output().unwrap().checked_add(&Value::new(tx_builder.get_fee_if_set().unwrap())).unwrap()
+            tx_builder.get_explicit_output().unwrap().checked_add(&Value::new(&tx_builder.get_fee_if_set().unwrap())).unwrap()
         );
         let _final_tx = tx_builder.build(); // just test that it doesn't throw
     }

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -716,364 +716,250 @@ mod tests {
     // this is what is used in mainnet
     static MINIMUM_UTXO_VAL: u64 = 1_000_000;
 
-    // #[test]
-    // fn no_token_minimum() {
+    #[test]
+    fn no_token_minimum() {
         
-    //     let assets = Value {
-    //         coin: BigNum(0),
-    //         multiasset: None,
-    //     };
+        let assets = Value {
+            coin: BigNum(0),
+            multiasset: None,
+        };
         
-    //     assert_eq!(
-    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-    //         MINIMUM_UTXO_VAL
-    //     );
-    // }
-
-    // #[test]
-    // fn one_policy_one_smallest_name() {
-        
-    //     let mut token_bundle = MultiAsset::new();
-    //     let mut asset_list = Assets::new();
-    //     asset_list.insert(
-    //         &AssetName(vec![]),
-    //         &BigNum(1)
-    //     );
-    //     token_bundle.insert(
-    //         &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
-    //         &asset_list
-    //     );
-    //     let assets = Value {
-    //         coin: BigNum(1407406),
-    //         multiasset: Some(token_bundle),
-    //     };
-        
-    //     assert_eq!(
-    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-    //         1407406
-    //     );
-    // }
-
-    // #[test]
-    // fn one_policy_one_small_name() {
-        
-    //     let mut token_bundle = MultiAsset::new();
-    //     let mut asset_list = Assets::new();
-    //     asset_list.insert(
-    //         &AssetName(vec![1]),
-    //         &BigNum(1)
-    //     );
-    //     token_bundle.insert(
-    //         &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
-    //         &asset_list
-    //     );
-    //     let assets = Value {
-    //         coin: BigNum(1444443),
-    //         multiasset: Some(token_bundle),
-    //     };
-        
-    //     assert_eq!(
-    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-    //         1444443
-    //     );
-    // }
-
-    // #[test]
-    // fn one_policy_one_largest_name() {
-        
-    //     let mut token_bundle = MultiAsset::new();
-    //     let mut asset_list = Assets::new();
-    //     asset_list.insert(
-    //         // The largest asset names have length thirty-two
-    //         &AssetName([1; 32].to_vec()),
-    //         &BigNum(1)
-    //     );
-    //     token_bundle.insert(
-    //         &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
-    //         &asset_list
-    //     );
-    //     let assets = Value {
-    //         coin: BigNum(1555554),
-    //         multiasset: Some(token_bundle),
-    //     };
-        
-    //     assert_eq!(
-    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-    //         1555554
-    //     );
-    // }
-
-    // #[test]
-    // fn one_policy_three_small_names() {
-        
-    //     let mut token_bundle = MultiAsset::new();
-    //     let mut asset_list = Assets::new();
-    //     asset_list.insert(
-    //         &AssetName(vec![1]),
-    //         &BigNum(1)
-    //     );
-    //     asset_list.insert(
-    //         &AssetName(vec![2]),
-    //         &BigNum(1)
-    //     );
-    //     asset_list.insert(
-    //         &AssetName(vec![3]),
-    //         &BigNum(1)
-    //     );
-    //     token_bundle.insert(
-    //         &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
-    //         &asset_list
-    //     );
-    //     let assets = Value {
-    //         coin: BigNum(1555554),
-    //         multiasset: Some(token_bundle),
-    //     };
-        
-    //     assert_eq!(
-    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-    //         1555554
-    //     );
-    // }
-
-    // #[test]
-    // fn one_policy_three_largest_names() {
-        
-    //     let mut token_bundle = MultiAsset::new();
-    //     let mut asset_list = Assets::new();
-    //     asset_list.insert(
-    //         // The largest asset names have length thirty-two
-    //         &AssetName([1; 32].to_vec()),
-    //         &BigNum(1)
-    //     );
-    //     asset_list.insert(
-    //         // The largest asset names have length thirty-two
-    //         &AssetName([2; 32].to_vec()),
-    //         &BigNum(1)
-    //     );
-    //     asset_list.insert(
-    //         // The largest asset names have length thirty-two
-    //         &AssetName([3; 32].to_vec()),
-    //         &BigNum(1)
-    //     );
-    //     token_bundle.insert(
-    //         &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
-    //         &asset_list
-    //     );
-    //     let assets = Value {
-    //         coin: BigNum(1962961),
-    //         multiasset: Some(token_bundle),
-    //     };
-        
-    //     assert_eq!(
-    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-    //         1962961
-    //     );
-    // }
-
-    // #[test]
-    // fn two_policies_one_smallest_name() {
-        
-    //     let mut token_bundle = MultiAsset::new();
-    //     let mut asset_list = Assets::new();
-    //     asset_list.insert(
-    //         &AssetName(vec![]),
-    //         &BigNum(1)
-    //     );
-    //     token_bundle.insert(
-    //         &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
-    //         &asset_list
-    //     );
-    //     token_bundle.insert(
-    //         &PolicyID::from([1; ScriptHash::BYTE_COUNT]),
-    //         &asset_list
-    //     );
-    //     let assets = Value {
-    //         coin: BigNum(1592591),
-    //         multiasset: Some(token_bundle),
-    //     };
-        
-    //     assert_eq!(
-    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-    //         1592591
-    //     );
-    // }
-
-    // #[test]
-    // fn two_policies_two_small_names() {
-        
-    //     let mut token_bundle = MultiAsset::new();
-    //     let mut asset_list = Assets::new();
-    //     asset_list.insert(
-    //         &AssetName(vec![]),
-    //         &BigNum(1)
-    //     );
-    //     token_bundle.insert(
-    //         &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
-    //         &asset_list
-    //     );
-    //     token_bundle.insert(
-    //         &PolicyID::from([1; ScriptHash::BYTE_COUNT]),
-    //         &asset_list
-    //     );
-    //     let assets = Value {
-    //         coin: BigNum(1592591),
-    //         multiasset: Some(token_bundle),
-    //     };
-        
-    //     assert_eq!(
-    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-    //         1592591
-    //     );
-    // }
-
-    // #[test]
-    // fn three_policies_99_small_names() {
-        
-    //     let mut token_bundle = MultiAsset::new();
-    //     fn add_policy(token_bundle: &mut MultiAsset, index: u8) -> () {
-    //         let mut asset_list = Assets::new();
-
-    //         for i in 0..33 {
-    //             asset_list.insert(
-    //                 &AssetName(vec![i]),
-    //                 &BigNum(1)
-    //             );
-    //         }
-    //         token_bundle.insert(
-    //             &PolicyID::from([index; ScriptHash::BYTE_COUNT]),
-    //             &asset_list
-    //         );
-    //     }
-    //     add_policy(&mut token_bundle, 1);
-    //     add_policy(&mut token_bundle, 2);
-    //     add_policy(&mut token_bundle, 3);
-    //     let assets = Value {
-    //         coin: BigNum(7592585),
-    //         multiasset: Some(token_bundle),
-    //     };
-        
-    //     assert_eq!(
-    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-    //         7592585
-    //     );
-    // }
-
-    // #[test]
-    // fn subtract_values() {
-    //     let policy1 = PolicyID::from([0; ScriptHash::BYTE_COUNT]);
-    //     let policy2 = PolicyID::from([1; ScriptHash::BYTE_COUNT]);
-
-    //     let asset1 = AssetName(vec![1]);
-    //     let asset2 = AssetName(vec![2]);
-    //     let asset3 = AssetName(vec![3]);
-    //     let asset4 = AssetName(vec![4]);
-
-    //     let mut token_bundle1 = MultiAsset::new();
-    //     {
-    //         let mut asset_list1 = Assets::new();
-    //         asset_list1.insert(
-    //             &asset1,
-    //             &BigNum(1)
-    //         );
-    //         asset_list1.insert(
-    //             &asset2,
-    //             &BigNum(1)
-    //         );
-    //         asset_list1.insert(
-    //             &asset3,
-    //             &BigNum(1)
-    //         );
-    //         asset_list1.insert(
-    //             &asset4,
-    //             &BigNum(2)
-    //         );
-    //         token_bundle1.insert(
-    //             &policy1,
-    //             &asset_list1
-    //         );
-
-    //         let mut asset_list2 = Assets::new();
-    //         asset_list2.insert(
-    //             &asset1,
-    //             &BigNum(1)
-    //         );
-    //         token_bundle1.insert(
-    //             &policy2,
-    //             &asset_list2
-    //         );
-    //     }
-    //     let assets1 = Value {
-    //         coin: BigNum(1555554),
-    //         multiasset: Some(token_bundle1),
-    //     };
-
-    //     let mut token_bundle2 = MultiAsset::new();
-    //     {
-    //         let mut asset_list2 = Assets::new();
-    //         // more than asset1 bundle
-    //         asset_list2.insert(
-    //             &asset1,
-    //             &BigNum(2)
-    //         );
-    //         // exactly equal to asset1 bundle
-    //         asset_list2.insert(
-    //             &asset2,
-    //             &BigNum(1)
-    //         );
-    //         // skip asset 3
-    //         // less than in asset1 bundle
-    //         asset_list2.insert(
-    //             &asset4,
-    //             &BigNum(1)
-    //         );
-    //         token_bundle2.insert(
-    //             &policy1,
-    //             &asset_list2
-    //         );
-
-    //         // this policy should be removed entirely
-    //         let mut asset_list2 = Assets::new();
-    //         asset_list2.insert(
-    //             &asset1,
-    //             &BigNum(1)
-    //         );
-    //         token_bundle2.insert(
-    //             &policy2,
-    //             &asset_list2
-    //         );
-    //     }
-
-    //     let assets2 = Value {
-    //         coin: BigNum(2555554),
-    //         multiasset: Some(token_bundle2),
-    //     };
-
-    //     let result = assets1.clamped_sub(&assets2);
-    //     assert_eq!(
-    //         result.coin().to_str(),
-    //         "0"
-    //     );
-    //     assert_eq!(
-    //         result.multiasset().unwrap().len(),
-    //         1 // policy 2 was deleted successfully
-    //     );
-    //     let policy1_content = result.multiasset().unwrap().get(&policy1).unwrap();
-    //     assert_eq!(
-    //         policy1_content.len(),
-    //         2
-    //     );
-    //     assert_eq!(
-    //         policy1_content.get(&asset3).unwrap().to_str(),
-    //         "1"
-    //     );
-    //     assert_eq!(
-    //         policy1_content.get(&asset4).unwrap().to_str(),
-    //         "1"
-    //     );
-    // }
+        assert_eq!(
+            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+            MINIMUM_UTXO_VAL
+        );
+    }
 
     #[test]
-    fn compare_values() {
+    fn one_policy_one_smallest_name() {
+        
+        let mut token_bundle = MultiAsset::new();
+        let mut asset_list = Assets::new();
+        asset_list.insert(
+            &AssetName(vec![]),
+            &BigNum(1)
+        );
+        token_bundle.insert(
+            &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
+            &asset_list
+        );
+        let assets = Value {
+            coin: BigNum(1407406),
+            multiasset: Some(token_bundle),
+        };
+        
+        assert_eq!(
+            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+            1407406
+        );
+    }
+
+    #[test]
+    fn one_policy_one_small_name() {
+        
+        let mut token_bundle = MultiAsset::new();
+        let mut asset_list = Assets::new();
+        asset_list.insert(
+            &AssetName(vec![1]),
+            &BigNum(1)
+        );
+        token_bundle.insert(
+            &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
+            &asset_list
+        );
+        let assets = Value {
+            coin: BigNum(1444443),
+            multiasset: Some(token_bundle),
+        };
+        
+        assert_eq!(
+            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+            1444443
+        );
+    }
+
+    #[test]
+    fn one_policy_one_largest_name() {
+        
+        let mut token_bundle = MultiAsset::new();
+        let mut asset_list = Assets::new();
+        asset_list.insert(
+            // The largest asset names have length thirty-two
+            &AssetName([1; 32].to_vec()),
+            &BigNum(1)
+        );
+        token_bundle.insert(
+            &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
+            &asset_list
+        );
+        let assets = Value {
+            coin: BigNum(1555554),
+            multiasset: Some(token_bundle),
+        };
+        
+        assert_eq!(
+            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+            1555554
+        );
+    }
+
+    #[test]
+    fn one_policy_three_small_names() {
+        
+        let mut token_bundle = MultiAsset::new();
+        let mut asset_list = Assets::new();
+        asset_list.insert(
+            &AssetName(vec![1]),
+            &BigNum(1)
+        );
+        asset_list.insert(
+            &AssetName(vec![2]),
+            &BigNum(1)
+        );
+        asset_list.insert(
+            &AssetName(vec![3]),
+            &BigNum(1)
+        );
+        token_bundle.insert(
+            &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
+            &asset_list
+        );
+        let assets = Value {
+            coin: BigNum(1555554),
+            multiasset: Some(token_bundle),
+        };
+        
+        assert_eq!(
+            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+            1555554
+        );
+    }
+
+    #[test]
+    fn one_policy_three_largest_names() {
+        
+        let mut token_bundle = MultiAsset::new();
+        let mut asset_list = Assets::new();
+        asset_list.insert(
+            // The largest asset names have length thirty-two
+            &AssetName([1; 32].to_vec()),
+            &BigNum(1)
+        );
+        asset_list.insert(
+            // The largest asset names have length thirty-two
+            &AssetName([2; 32].to_vec()),
+            &BigNum(1)
+        );
+        asset_list.insert(
+            // The largest asset names have length thirty-two
+            &AssetName([3; 32].to_vec()),
+            &BigNum(1)
+        );
+        token_bundle.insert(
+            &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
+            &asset_list
+        );
+        let assets = Value {
+            coin: BigNum(1962961),
+            multiasset: Some(token_bundle),
+        };
+        
+        assert_eq!(
+            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+            1962961
+        );
+    }
+
+    #[test]
+    fn two_policies_one_smallest_name() {
+        
+        let mut token_bundle = MultiAsset::new();
+        let mut asset_list = Assets::new();
+        asset_list.insert(
+            &AssetName(vec![]),
+            &BigNum(1)
+        );
+        token_bundle.insert(
+            &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
+            &asset_list
+        );
+        token_bundle.insert(
+            &PolicyID::from([1; ScriptHash::BYTE_COUNT]),
+            &asset_list
+        );
+        let assets = Value {
+            coin: BigNum(1592591),
+            multiasset: Some(token_bundle),
+        };
+        
+        assert_eq!(
+            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+            1592591
+        );
+    }
+
+    #[test]
+    fn two_policies_two_small_names() {
+        
+        let mut token_bundle = MultiAsset::new();
+        let mut asset_list = Assets::new();
+        asset_list.insert(
+            &AssetName(vec![]),
+            &BigNum(1)
+        );
+        token_bundle.insert(
+            &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
+            &asset_list
+        );
+        token_bundle.insert(
+            &PolicyID::from([1; ScriptHash::BYTE_COUNT]),
+            &asset_list
+        );
+        let assets = Value {
+            coin: BigNum(1592591),
+            multiasset: Some(token_bundle),
+        };
+        
+        assert_eq!(
+            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+            1592591
+        );
+    }
+
+    #[test]
+    fn three_policies_99_small_names() {
+        
+        let mut token_bundle = MultiAsset::new();
+        fn add_policy(token_bundle: &mut MultiAsset, index: u8) -> () {
+            let mut asset_list = Assets::new();
+
+            for i in 0..33 {
+                asset_list.insert(
+                    &AssetName(vec![i]),
+                    &BigNum(1)
+                );
+            }
+            token_bundle.insert(
+                &PolicyID::from([index; ScriptHash::BYTE_COUNT]),
+                &asset_list
+            );
+        }
+        add_policy(&mut token_bundle, 1);
+        add_policy(&mut token_bundle, 2);
+        add_policy(&mut token_bundle, 3);
+        let assets = Value {
+            coin: BigNum(7592585),
+            multiasset: Some(token_bundle),
+        };
+        
+        assert_eq!(
+            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+            7592585
+        );
+    }
+
+    #[test]
+    fn subtract_values() {
         let policy1 = PolicyID::from([0; ScriptHash::BYTE_COUNT]);
         let policy2 = PolicyID::from([1; ScriptHash::BYTE_COUNT]);
 
@@ -1081,6 +967,117 @@ mod tests {
         let asset2 = AssetName(vec![2]);
         let asset3 = AssetName(vec![3]);
         let asset4 = AssetName(vec![4]);
+
+        let mut token_bundle1 = MultiAsset::new();
+        {
+            let mut asset_list1 = Assets::new();
+            asset_list1.insert(
+                &asset1,
+                &BigNum(1)
+            );
+            asset_list1.insert(
+                &asset2,
+                &BigNum(1)
+            );
+            asset_list1.insert(
+                &asset3,
+                &BigNum(1)
+            );
+            asset_list1.insert(
+                &asset4,
+                &BigNum(2)
+            );
+            token_bundle1.insert(
+                &policy1,
+                &asset_list1
+            );
+
+            let mut asset_list2 = Assets::new();
+            asset_list2.insert(
+                &asset1,
+                &BigNum(1)
+            );
+            token_bundle1.insert(
+                &policy2,
+                &asset_list2
+            );
+        }
+        let assets1 = Value {
+            coin: BigNum(1555554),
+            multiasset: Some(token_bundle1),
+        };
+
+        let mut token_bundle2 = MultiAsset::new();
+        {
+            let mut asset_list2 = Assets::new();
+            // more than asset1 bundle
+            asset_list2.insert(
+                &asset1,
+                &BigNum(2)
+            );
+            // exactly equal to asset1 bundle
+            asset_list2.insert(
+                &asset2,
+                &BigNum(1)
+            );
+            // skip asset 3
+            // less than in asset1 bundle
+            asset_list2.insert(
+                &asset4,
+                &BigNum(1)
+            );
+            token_bundle2.insert(
+                &policy1,
+                &asset_list2
+            );
+
+            // this policy should be removed entirely
+            let mut asset_list2 = Assets::new();
+            asset_list2.insert(
+                &asset1,
+                &BigNum(1)
+            );
+            token_bundle2.insert(
+                &policy2,
+                &asset_list2
+            );
+        }
+
+        let assets2 = Value {
+            coin: BigNum(2555554),
+            multiasset: Some(token_bundle2),
+        };
+
+        let result = assets1.clamped_sub(&assets2);
+        assert_eq!(
+            result.coin().to_str(),
+            "0"
+        );
+        assert_eq!(
+            result.multiasset().unwrap().len(),
+            1 // policy 2 was deleted successfully
+        );
+        let policy1_content = result.multiasset().unwrap().get(&policy1).unwrap();
+        assert_eq!(
+            policy1_content.len(),
+            2
+        );
+        assert_eq!(
+            policy1_content.get(&asset3).unwrap().to_str(),
+            "1"
+        );
+        assert_eq!(
+            policy1_content.get(&asset4).unwrap().to_str(),
+            "1"
+        );
+    }
+
+    #[test]
+    fn compare_values() {
+        let policy1 = PolicyID::from([0; ScriptHash::BYTE_COUNT]);
+
+        let asset1 = AssetName(vec![1]);
+        let asset2 = AssetName(vec![2]);
 
         // testing cases with no assets
         {

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -267,57 +267,32 @@ impl Value {
     }
 }
 
-// deriving PartialOrd doesn't work in a way that's useful , as the
-// implementation of PartialOrd for BTreeMap compares keys by their order,
-// i.e, is equivalent to comparing the iterators of (pid, Assets).
-// that would mean that: v1 < v2 if the min_pid(v1) < min_pid(v2)
-// this function instead compares amounts, assuming that if a pair (pid, aname)
-// is not in the Value then it has an amount of 0
 impl PartialOrd for Value {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         use std::cmp::Ordering::*;
 
-        fn for_all(ma: &MultiAsset, f: impl Fn(&PolicyID, &AssetName, &Coin) -> bool) -> bool {
-            ma.0.iter()
-                .all(|(pid, assets)| assets.0.iter().all(|(aname, amount)| f(pid, aname, amount)))
-        }
-
-        fn rhs_amount(rhs_ma: &Option<MultiAsset>, pid: &PolicyID, aname: &AssetName) -> Coin {
-            rhs_ma
-                .as_ref()
-                .and_then(|rhs_ma| rhs_ma.get(&pid).and_then(|assets| assets.get(aname)))
-                .unwrap_or(to_bignum(0u64))
-        }
-
-        match self.coin.cmp(&other.coin) {
-            Less => {
-                let le = self.multiasset.iter().all(|ma| {
-                    for_all(&ma, |pid, aname, amount| {
-                        amount < &rhs_amount(&other.multiasset, pid, aname)
-                    })
-                });
-
-                Some(Less).filter(|_| le)
-            }
-            Equal => {
-                let eq = self.multiasset.iter().all(|ma| {
-                    for_all(&ma, |pid, aname, amount| {
-                        amount == &rhs_amount(&other.multiasset, pid, aname)
-                    })
-                });
-
-                Some(Equal).filter(|_| eq)
-            }
-            Greater => {
-                let ge = self.multiasset.iter().all(|ma| {
-                    for_all(&ma, |pid, aname, amount| {
-                        amount > &rhs_amount(&other.multiasset, pid, aname)
-                    })
-                });
-
-                Some(Greater).filter(|_| ge)
+        fn compare_assets(lhs: &Option<MultiAsset>, rhs: &Option<MultiAsset>) -> Option<std::cmp::Ordering> {
+            match (lhs, rhs) {
+                (None, None) => Some(Equal),
+                (None, Some(rhs_assets)) => MultiAsset::new().partial_cmp(&rhs_assets),
+                (Some(lhs_assets), None) => lhs_assets.partial_cmp(&MultiAsset::new()),
+                (Some(lhs_assets), Some(rhs_assets)) => lhs_assets.partial_cmp(&rhs_assets),
             }
         }
+
+        compare_assets(&self.multiasset(), &other.multiasset())
+            .and_then(|assets_match| {
+                let coin_cmp = self.coin.cmp(&other.coin);
+
+                match (coin_cmp, assets_match) {
+                    (coin_order, Equal) => Some(coin_order),
+                    (Equal, Less) => Some(Less),
+                    (Less, Less) => Some(Less),
+                    (Equal, Greater) => Some(Greater),
+                    (Greater, Greater) => Some(Greater),
+                    (_, _) => None
+                }
+            })
     }
 }
 
@@ -741,250 +716,364 @@ mod tests {
     // this is what is used in mainnet
     static MINIMUM_UTXO_VAL: u64 = 1_000_000;
 
-    #[test]
-    fn no_token_minimum() {
+    // #[test]
+    // fn no_token_minimum() {
         
-        let assets = Value {
-            coin: BigNum(0),
-            multiasset: None,
-        };
+    //     let assets = Value {
+    //         coin: BigNum(0),
+    //         multiasset: None,
+    //     };
         
-        assert_eq!(
-            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-            MINIMUM_UTXO_VAL
-        );
-    }
+    //     assert_eq!(
+    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+    //         MINIMUM_UTXO_VAL
+    //     );
+    // }
+
+    // #[test]
+    // fn one_policy_one_smallest_name() {
+        
+    //     let mut token_bundle = MultiAsset::new();
+    //     let mut asset_list = Assets::new();
+    //     asset_list.insert(
+    //         &AssetName(vec![]),
+    //         &BigNum(1)
+    //     );
+    //     token_bundle.insert(
+    //         &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
+    //         &asset_list
+    //     );
+    //     let assets = Value {
+    //         coin: BigNum(1407406),
+    //         multiasset: Some(token_bundle),
+    //     };
+        
+    //     assert_eq!(
+    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+    //         1407406
+    //     );
+    // }
+
+    // #[test]
+    // fn one_policy_one_small_name() {
+        
+    //     let mut token_bundle = MultiAsset::new();
+    //     let mut asset_list = Assets::new();
+    //     asset_list.insert(
+    //         &AssetName(vec![1]),
+    //         &BigNum(1)
+    //     );
+    //     token_bundle.insert(
+    //         &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
+    //         &asset_list
+    //     );
+    //     let assets = Value {
+    //         coin: BigNum(1444443),
+    //         multiasset: Some(token_bundle),
+    //     };
+        
+    //     assert_eq!(
+    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+    //         1444443
+    //     );
+    // }
+
+    // #[test]
+    // fn one_policy_one_largest_name() {
+        
+    //     let mut token_bundle = MultiAsset::new();
+    //     let mut asset_list = Assets::new();
+    //     asset_list.insert(
+    //         // The largest asset names have length thirty-two
+    //         &AssetName([1; 32].to_vec()),
+    //         &BigNum(1)
+    //     );
+    //     token_bundle.insert(
+    //         &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
+    //         &asset_list
+    //     );
+    //     let assets = Value {
+    //         coin: BigNum(1555554),
+    //         multiasset: Some(token_bundle),
+    //     };
+        
+    //     assert_eq!(
+    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+    //         1555554
+    //     );
+    // }
+
+    // #[test]
+    // fn one_policy_three_small_names() {
+        
+    //     let mut token_bundle = MultiAsset::new();
+    //     let mut asset_list = Assets::new();
+    //     asset_list.insert(
+    //         &AssetName(vec![1]),
+    //         &BigNum(1)
+    //     );
+    //     asset_list.insert(
+    //         &AssetName(vec![2]),
+    //         &BigNum(1)
+    //     );
+    //     asset_list.insert(
+    //         &AssetName(vec![3]),
+    //         &BigNum(1)
+    //     );
+    //     token_bundle.insert(
+    //         &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
+    //         &asset_list
+    //     );
+    //     let assets = Value {
+    //         coin: BigNum(1555554),
+    //         multiasset: Some(token_bundle),
+    //     };
+        
+    //     assert_eq!(
+    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+    //         1555554
+    //     );
+    // }
+
+    // #[test]
+    // fn one_policy_three_largest_names() {
+        
+    //     let mut token_bundle = MultiAsset::new();
+    //     let mut asset_list = Assets::new();
+    //     asset_list.insert(
+    //         // The largest asset names have length thirty-two
+    //         &AssetName([1; 32].to_vec()),
+    //         &BigNum(1)
+    //     );
+    //     asset_list.insert(
+    //         // The largest asset names have length thirty-two
+    //         &AssetName([2; 32].to_vec()),
+    //         &BigNum(1)
+    //     );
+    //     asset_list.insert(
+    //         // The largest asset names have length thirty-two
+    //         &AssetName([3; 32].to_vec()),
+    //         &BigNum(1)
+    //     );
+    //     token_bundle.insert(
+    //         &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
+    //         &asset_list
+    //     );
+    //     let assets = Value {
+    //         coin: BigNum(1962961),
+    //         multiasset: Some(token_bundle),
+    //     };
+        
+    //     assert_eq!(
+    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+    //         1962961
+    //     );
+    // }
+
+    // #[test]
+    // fn two_policies_one_smallest_name() {
+        
+    //     let mut token_bundle = MultiAsset::new();
+    //     let mut asset_list = Assets::new();
+    //     asset_list.insert(
+    //         &AssetName(vec![]),
+    //         &BigNum(1)
+    //     );
+    //     token_bundle.insert(
+    //         &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
+    //         &asset_list
+    //     );
+    //     token_bundle.insert(
+    //         &PolicyID::from([1; ScriptHash::BYTE_COUNT]),
+    //         &asset_list
+    //     );
+    //     let assets = Value {
+    //         coin: BigNum(1592591),
+    //         multiasset: Some(token_bundle),
+    //     };
+        
+    //     assert_eq!(
+    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+    //         1592591
+    //     );
+    // }
+
+    // #[test]
+    // fn two_policies_two_small_names() {
+        
+    //     let mut token_bundle = MultiAsset::new();
+    //     let mut asset_list = Assets::new();
+    //     asset_list.insert(
+    //         &AssetName(vec![]),
+    //         &BigNum(1)
+    //     );
+    //     token_bundle.insert(
+    //         &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
+    //         &asset_list
+    //     );
+    //     token_bundle.insert(
+    //         &PolicyID::from([1; ScriptHash::BYTE_COUNT]),
+    //         &asset_list
+    //     );
+    //     let assets = Value {
+    //         coin: BigNum(1592591),
+    //         multiasset: Some(token_bundle),
+    //     };
+        
+    //     assert_eq!(
+    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+    //         1592591
+    //     );
+    // }
+
+    // #[test]
+    // fn three_policies_99_small_names() {
+        
+    //     let mut token_bundle = MultiAsset::new();
+    //     fn add_policy(token_bundle: &mut MultiAsset, index: u8) -> () {
+    //         let mut asset_list = Assets::new();
+
+    //         for i in 0..33 {
+    //             asset_list.insert(
+    //                 &AssetName(vec![i]),
+    //                 &BigNum(1)
+    //             );
+    //         }
+    //         token_bundle.insert(
+    //             &PolicyID::from([index; ScriptHash::BYTE_COUNT]),
+    //             &asset_list
+    //         );
+    //     }
+    //     add_policy(&mut token_bundle, 1);
+    //     add_policy(&mut token_bundle, 2);
+    //     add_policy(&mut token_bundle, 3);
+    //     let assets = Value {
+    //         coin: BigNum(7592585),
+    //         multiasset: Some(token_bundle),
+    //     };
+        
+    //     assert_eq!(
+    //         min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
+    //         7592585
+    //     );
+    // }
+
+    // #[test]
+    // fn subtract_values() {
+    //     let policy1 = PolicyID::from([0; ScriptHash::BYTE_COUNT]);
+    //     let policy2 = PolicyID::from([1; ScriptHash::BYTE_COUNT]);
+
+    //     let asset1 = AssetName(vec![1]);
+    //     let asset2 = AssetName(vec![2]);
+    //     let asset3 = AssetName(vec![3]);
+    //     let asset4 = AssetName(vec![4]);
+
+    //     let mut token_bundle1 = MultiAsset::new();
+    //     {
+    //         let mut asset_list1 = Assets::new();
+    //         asset_list1.insert(
+    //             &asset1,
+    //             &BigNum(1)
+    //         );
+    //         asset_list1.insert(
+    //             &asset2,
+    //             &BigNum(1)
+    //         );
+    //         asset_list1.insert(
+    //             &asset3,
+    //             &BigNum(1)
+    //         );
+    //         asset_list1.insert(
+    //             &asset4,
+    //             &BigNum(2)
+    //         );
+    //         token_bundle1.insert(
+    //             &policy1,
+    //             &asset_list1
+    //         );
+
+    //         let mut asset_list2 = Assets::new();
+    //         asset_list2.insert(
+    //             &asset1,
+    //             &BigNum(1)
+    //         );
+    //         token_bundle1.insert(
+    //             &policy2,
+    //             &asset_list2
+    //         );
+    //     }
+    //     let assets1 = Value {
+    //         coin: BigNum(1555554),
+    //         multiasset: Some(token_bundle1),
+    //     };
+
+    //     let mut token_bundle2 = MultiAsset::new();
+    //     {
+    //         let mut asset_list2 = Assets::new();
+    //         // more than asset1 bundle
+    //         asset_list2.insert(
+    //             &asset1,
+    //             &BigNum(2)
+    //         );
+    //         // exactly equal to asset1 bundle
+    //         asset_list2.insert(
+    //             &asset2,
+    //             &BigNum(1)
+    //         );
+    //         // skip asset 3
+    //         // less than in asset1 bundle
+    //         asset_list2.insert(
+    //             &asset4,
+    //             &BigNum(1)
+    //         );
+    //         token_bundle2.insert(
+    //             &policy1,
+    //             &asset_list2
+    //         );
+
+    //         // this policy should be removed entirely
+    //         let mut asset_list2 = Assets::new();
+    //         asset_list2.insert(
+    //             &asset1,
+    //             &BigNum(1)
+    //         );
+    //         token_bundle2.insert(
+    //             &policy2,
+    //             &asset_list2
+    //         );
+    //     }
+
+    //     let assets2 = Value {
+    //         coin: BigNum(2555554),
+    //         multiasset: Some(token_bundle2),
+    //     };
+
+    //     let result = assets1.clamped_sub(&assets2);
+    //     assert_eq!(
+    //         result.coin().to_str(),
+    //         "0"
+    //     );
+    //     assert_eq!(
+    //         result.multiasset().unwrap().len(),
+    //         1 // policy 2 was deleted successfully
+    //     );
+    //     let policy1_content = result.multiasset().unwrap().get(&policy1).unwrap();
+    //     assert_eq!(
+    //         policy1_content.len(),
+    //         2
+    //     );
+    //     assert_eq!(
+    //         policy1_content.get(&asset3).unwrap().to_str(),
+    //         "1"
+    //     );
+    //     assert_eq!(
+    //         policy1_content.get(&asset4).unwrap().to_str(),
+    //         "1"
+    //     );
+    // }
 
     #[test]
-    fn one_policy_one_smallest_name() {
-        
-        let mut token_bundle = MultiAsset::new();
-        let mut asset_list = Assets::new();
-        asset_list.insert(
-            &AssetName(vec![]),
-            &BigNum(1)
-        );
-        token_bundle.insert(
-            &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
-            &asset_list
-        );
-        let assets = Value {
-            coin: BigNum(1407406),
-            multiasset: Some(token_bundle),
-        };
-        
-        assert_eq!(
-            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-            1407406
-        );
-    }
-
-    #[test]
-    fn one_policy_one_small_name() {
-        
-        let mut token_bundle = MultiAsset::new();
-        let mut asset_list = Assets::new();
-        asset_list.insert(
-            &AssetName(vec![1]),
-            &BigNum(1)
-        );
-        token_bundle.insert(
-            &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
-            &asset_list
-        );
-        let assets = Value {
-            coin: BigNum(1444443),
-            multiasset: Some(token_bundle),
-        };
-        
-        assert_eq!(
-            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-            1444443
-        );
-    }
-
-    #[test]
-    fn one_policy_one_largest_name() {
-        
-        let mut token_bundle = MultiAsset::new();
-        let mut asset_list = Assets::new();
-        asset_list.insert(
-            // The largest asset names have length thirty-two
-            &AssetName([1; 32].to_vec()),
-            &BigNum(1)
-        );
-        token_bundle.insert(
-            &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
-            &asset_list
-        );
-        let assets = Value {
-            coin: BigNum(1555554),
-            multiasset: Some(token_bundle),
-        };
-        
-        assert_eq!(
-            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-            1555554
-        );
-    }
-
-    #[test]
-    fn one_policy_three_small_names() {
-        
-        let mut token_bundle = MultiAsset::new();
-        let mut asset_list = Assets::new();
-        asset_list.insert(
-            &AssetName(vec![1]),
-            &BigNum(1)
-        );
-        asset_list.insert(
-            &AssetName(vec![2]),
-            &BigNum(1)
-        );
-        asset_list.insert(
-            &AssetName(vec![3]),
-            &BigNum(1)
-        );
-        token_bundle.insert(
-            &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
-            &asset_list
-        );
-        let assets = Value {
-            coin: BigNum(1555554),
-            multiasset: Some(token_bundle),
-        };
-        
-        assert_eq!(
-            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-            1555554
-        );
-    }
-
-    #[test]
-    fn one_policy_three_largest_names() {
-        
-        let mut token_bundle = MultiAsset::new();
-        let mut asset_list = Assets::new();
-        asset_list.insert(
-            // The largest asset names have length thirty-two
-            &AssetName([1; 32].to_vec()),
-            &BigNum(1)
-        );
-        asset_list.insert(
-            // The largest asset names have length thirty-two
-            &AssetName([2; 32].to_vec()),
-            &BigNum(1)
-        );
-        asset_list.insert(
-            // The largest asset names have length thirty-two
-            &AssetName([3; 32].to_vec()),
-            &BigNum(1)
-        );
-        token_bundle.insert(
-            &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
-            &asset_list
-        );
-        let assets = Value {
-            coin: BigNum(1962961),
-            multiasset: Some(token_bundle),
-        };
-        
-        assert_eq!(
-            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-            1962961
-        );
-    }
-
-    #[test]
-    fn two_policies_one_smallest_name() {
-        
-        let mut token_bundle = MultiAsset::new();
-        let mut asset_list = Assets::new();
-        asset_list.insert(
-            &AssetName(vec![]),
-            &BigNum(1)
-        );
-        token_bundle.insert(
-            &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
-            &asset_list
-        );
-        token_bundle.insert(
-            &PolicyID::from([1; ScriptHash::BYTE_COUNT]),
-            &asset_list
-        );
-        let assets = Value {
-            coin: BigNum(1592591),
-            multiasset: Some(token_bundle),
-        };
-        
-        assert_eq!(
-            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-            1592591
-        );
-    }
-
-    #[test]
-    fn two_policies_two_small_names() {
-        
-        let mut token_bundle = MultiAsset::new();
-        let mut asset_list = Assets::new();
-        asset_list.insert(
-            &AssetName(vec![]),
-            &BigNum(1)
-        );
-        token_bundle.insert(
-            &PolicyID::from([0; ScriptHash::BYTE_COUNT]),
-            &asset_list
-        );
-        token_bundle.insert(
-            &PolicyID::from([1; ScriptHash::BYTE_COUNT]),
-            &asset_list
-        );
-        let assets = Value {
-            coin: BigNum(1592591),
-            multiasset: Some(token_bundle),
-        };
-        
-        assert_eq!(
-            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-            1592591
-        );
-    }
-
-    #[test]
-    fn three_policies_99_small_names() {
-        
-        let mut token_bundle = MultiAsset::new();
-        fn add_policy(token_bundle: &mut MultiAsset, index: u8) -> () {
-            let mut asset_list = Assets::new();
-
-            for i in 0..33 {
-                asset_list.insert(
-                    &AssetName(vec![i]),
-                    &BigNum(1)
-                );
-            }
-            token_bundle.insert(
-                &PolicyID::from([index; ScriptHash::BYTE_COUNT]),
-                &asset_list
-            );
-        }
-        add_policy(&mut token_bundle, 1);
-        add_policy(&mut token_bundle, 2);
-        add_policy(&mut token_bundle, 3);
-        let assets = Value {
-            coin: BigNum(7592585),
-            multiasset: Some(token_bundle),
-        };
-        
-        assert_eq!(
-            min_ada_required(&assets, &BigNum(MINIMUM_UTXO_VAL)).0,
-            7592585
-        );
-    }
-
-    #[test]
-    fn subtract_values() {
+    fn compare_values() {
         let policy1 = PolicyID::from([0; ScriptHash::BYTE_COUNT]);
         let policy2 = PolicyID::from([1; ScriptHash::BYTE_COUNT]);
 
@@ -993,107 +1082,379 @@ mod tests {
         let asset3 = AssetName(vec![3]);
         let asset4 = AssetName(vec![4]);
 
-        let mut token_bundle1 = MultiAsset::new();
+        // testing cases with no assets
         {
+            let a = Value::new(&to_bignum(1));
+            let b = Value::new(&to_bignum(1));
+            assert_eq!(a.partial_cmp(&b).unwrap(), std::cmp::Ordering::Equal);
+        }
+        {
+            let a = Value::new(&to_bignum(2));
+            let b = Value::new(&to_bignum(1));
+            assert_eq!(a.partial_cmp(&b).unwrap(), std::cmp::Ordering::Greater);
+        }
+        {
+            let a = Value::new(&to_bignum(1));
+            let b = Value::new(&to_bignum(2));
+            assert_eq!(a.partial_cmp(&b).unwrap(), std::cmp::Ordering::Less);
+        }
+        // testing case where one side has assets
+        {
+            let mut token_bundle1 = MultiAsset::new();
             let mut asset_list1 = Assets::new();
             asset_list1.insert(
                 &asset1,
                 &BigNum(1)
             );
+            token_bundle1.insert(
+                &policy1,
+                &asset_list1
+            );
+            let a = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle1),
+            };
+            let b = Value::new(&to_bignum(1));
+            assert_eq!(a.partial_cmp(&b).unwrap(), std::cmp::Ordering::Greater);
+        }
+        {
+            let mut token_bundle1 = MultiAsset::new();
+            let mut asset_list1 = Assets::new();
             asset_list1.insert(
-                &asset2,
+                &asset1,
                 &BigNum(1)
             );
+            token_bundle1.insert(
+                &policy1,
+                &asset_list1
+            );
+            let a = Value::new(&to_bignum(1));
+            let b = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle1),
+            };
+            assert_eq!(a.partial_cmp(&b).unwrap(), std::cmp::Ordering::Less);
+        }
+        // testing case where both sides has assets
+        {
+            let mut token_bundle1 = MultiAsset::new();
+            let mut asset_list1 = Assets::new();
             asset_list1.insert(
-                &asset3,
+                &asset1,
                 &BigNum(1)
             );
+            token_bundle1.insert(
+                &policy1,
+                &asset_list1
+            );
+            let a = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle1),
+            };
+
+            let mut token_bundle2 = MultiAsset::new();
+            let mut asset_list2 = Assets::new();
+            asset_list2.insert(
+                &asset1,
+                &BigNum(1)
+            );
+            token_bundle2.insert(
+                &policy1,
+                &asset_list2
+            );
+            let b = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle2),
+            };
+            assert_eq!(a.partial_cmp(&b).unwrap(), std::cmp::Ordering::Equal);
+        }
+        {
+            let mut token_bundle1 = MultiAsset::new();
+            let mut asset_list1 = Assets::new();
             asset_list1.insert(
-                &asset4,
+                &asset1,
+                &BigNum(1)
+            );
+            token_bundle1.insert(
+                &policy1,
+                &asset_list1
+            );
+            let a = Value {
+                coin: BigNum(2),
+                multiasset: Some(token_bundle1),
+            };
+
+            let mut token_bundle2 = MultiAsset::new();
+            let mut asset_list2 = Assets::new();
+            asset_list2.insert(
+                &asset1,
+                &BigNum(1)
+            );
+            token_bundle2.insert(
+                &policy1,
+                &asset_list2
+            );
+            let b = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle2),
+            };
+            assert_eq!(a.partial_cmp(&b).unwrap(), std::cmp::Ordering::Greater);
+        }
+        {
+            let mut token_bundle1 = MultiAsset::new();
+            let mut asset_list1 = Assets::new();
+            asset_list1.insert(
+                &asset1,
+                &BigNum(1)
+            );
+            token_bundle1.insert(
+                &policy1,
+                &asset_list1
+            );
+            let a = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle1),
+            };
+
+            let mut token_bundle2 = MultiAsset::new();
+            let mut asset_list2 = Assets::new();
+            asset_list2.insert(
+                &asset1,
+                &BigNum(1)
+            );
+            token_bundle2.insert(
+                &policy1,
+                &asset_list2
+            );
+            let b = Value {
+                coin: BigNum(2),
+                multiasset: Some(token_bundle2),
+            };
+            assert_eq!(a.partial_cmp(&b).unwrap(), std::cmp::Ordering::Less);
+        }
+        {
+            let mut token_bundle1 = MultiAsset::new();
+            let mut asset_list1 = Assets::new();
+            asset_list1.insert(
+                &asset1,
                 &BigNum(2)
             );
             token_bundle1.insert(
                 &policy1,
                 &asset_list1
             );
+            let a = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle1),
+            };
 
+            let mut token_bundle2 = MultiAsset::new();
             let mut asset_list2 = Assets::new();
             asset_list2.insert(
                 &asset1,
-                &BigNum(1)
-            );
-            token_bundle1.insert(
-                &policy2,
-                &asset_list2
-            );
-        }
-        let assets1 = Value {
-            coin: BigNum(1555554),
-            multiasset: Some(token_bundle1),
-        };
-
-        let mut token_bundle2 = MultiAsset::new();
-        {
-            let mut asset_list2 = Assets::new();
-            // more than asset1 bundle
-            asset_list2.insert(
-                &asset1,
-                &BigNum(2)
-            );
-            // exactly equal to asset1 bundle
-            asset_list2.insert(
-                &asset2,
-                &BigNum(1)
-            );
-            // skip asset 3
-            // less than in asset1 bundle
-            asset_list2.insert(
-                &asset4,
                 &BigNum(1)
             );
             token_bundle2.insert(
                 &policy1,
                 &asset_list2
             );
+            let b = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle2),
+            };
+            assert_eq!(a.partial_cmp(&b).unwrap(), std::cmp::Ordering::Greater);
+        }
+        {
+            let mut token_bundle1 = MultiAsset::new();
+            let mut asset_list1 = Assets::new();
+            asset_list1.insert(
+                &asset1,
+                &BigNum(2)
+            );
+            token_bundle1.insert(
+                &policy1,
+                &asset_list1
+            );
+            let a = Value {
+                coin: BigNum(2),
+                multiasset: Some(token_bundle1),
+            };
 
-            // this policy should be removed entirely
+            let mut token_bundle2 = MultiAsset::new();
             let mut asset_list2 = Assets::new();
             asset_list2.insert(
                 &asset1,
                 &BigNum(1)
             );
             token_bundle2.insert(
-                &policy2,
+                &policy1,
                 &asset_list2
             );
+            let b = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle2),
+            };
+            assert_eq!(a.partial_cmp(&b).unwrap(), std::cmp::Ordering::Greater);
         }
+        {
+            let mut token_bundle1 = MultiAsset::new();
+            let mut asset_list1 = Assets::new();
+            asset_list1.insert(
+                &asset1,
+                &BigNum(2)
+            );
+            token_bundle1.insert(
+                &policy1,
+                &asset_list1
+            );
+            let a = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle1),
+            };
 
-        let assets2 = Value {
-            coin: BigNum(2555554),
-            multiasset: Some(token_bundle2),
-        };
+            let mut token_bundle2 = MultiAsset::new();
+            let mut asset_list2 = Assets::new();
+            asset_list2.insert(
+                &asset1,
+                &BigNum(1)
+            );
+            token_bundle2.insert(
+                &policy1,
+                &asset_list2
+            );
+            let b = Value {
+                coin: BigNum(2),
+                multiasset: Some(token_bundle2),
+            };
+            assert_eq!(a.partial_cmp(&b), None);
+        }
+        {
+            let mut token_bundle1 = MultiAsset::new();
+            let mut asset_list1 = Assets::new();
+            asset_list1.insert(
+                &asset1,
+                &BigNum(1)
+            );
+            token_bundle1.insert(
+                &policy1,
+                &asset_list1
+            );
+            let a = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle1),
+            };
 
-        let result = assets1.clamped_sub(&assets2);
-        assert_eq!(
-            result.coin().to_str(),
-            "0"
-        );
-        assert_eq!(
-            result.multiasset().unwrap().len(),
-            1 // policy 2 was deleted successfully
-        );
-        let policy1_content = result.multiasset().unwrap().get(&policy1).unwrap();
-        assert_eq!(
-            policy1_content.len(),
-            2
-        );
-        assert_eq!(
-            policy1_content.get(&asset3).unwrap().to_str(),
-            "1"
-        );
-        assert_eq!(
-            policy1_content.get(&asset4).unwrap().to_str(),
-            "1"
-        );
+            let mut token_bundle2 = MultiAsset::new();
+            let mut asset_list2 = Assets::new();
+            asset_list2.insert(
+                &asset1,
+                &BigNum(2)
+            );
+            token_bundle2.insert(
+                &policy1,
+                &asset_list2
+            );
+            let b = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle2),
+            };
+            assert_eq!(a.partial_cmp(&b).unwrap(), std::cmp::Ordering::Less);
+        }
+        {
+            let mut token_bundle1 = MultiAsset::new();
+            let mut asset_list1 = Assets::new();
+            asset_list1.insert(
+                &asset1,
+                &BigNum(1)
+            );
+            token_bundle1.insert(
+                &policy1,
+                &asset_list1
+            );
+            let a = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle1),
+            };
+
+            let mut token_bundle2 = MultiAsset::new();
+            let mut asset_list2 = Assets::new();
+            asset_list2.insert(
+                &asset1,
+                &BigNum(2)
+            );
+            token_bundle2.insert(
+                &policy1,
+                &asset_list2
+            );
+            let b = Value {
+                coin: BigNum(2),
+                multiasset: Some(token_bundle2),
+            };
+            assert_eq!(a.partial_cmp(&b).unwrap(), std::cmp::Ordering::Less);
+        }
+        {
+            let mut token_bundle1 = MultiAsset::new();
+            let mut asset_list1 = Assets::new();
+            asset_list1.insert(
+                &asset1,
+                &BigNum(1)
+            );
+            token_bundle1.insert(
+                &policy1,
+                &asset_list1
+            );
+            let a = Value {
+                coin: BigNum(2),
+                multiasset: Some(token_bundle1),
+            };
+
+            let mut token_bundle2 = MultiAsset::new();
+            let mut asset_list2 = Assets::new();
+            asset_list2.insert(
+                &asset1,
+                &BigNum(2)
+            );
+            token_bundle2.insert(
+                &policy1,
+                &asset_list2
+            );
+            let b = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle2),
+            };
+            assert_eq!(a.partial_cmp(&b), None);
+        }
+        {
+            let mut token_bundle1 = MultiAsset::new();
+            let mut asset_list1 = Assets::new();
+            asset_list1.insert(
+                &asset1,
+                &BigNum(1)
+            );
+            token_bundle1.insert(
+                &policy1,
+                &asset_list1
+            );
+            let a = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle1),
+            };
+
+            let mut token_bundle2 = MultiAsset::new();
+            let mut asset_list2 = Assets::new();
+            asset_list2.insert(
+                &asset2,
+                &BigNum(1)
+            );
+            token_bundle2.insert(
+                &policy1,
+                &asset_list2
+            );
+            let b = Value {
+                coin: BigNum(1),
+                multiasset: Some(token_bundle2),
+            };
+            assert_eq!(a.partial_cmp(&b), None);
+        }
     }
 }


### PR DESCRIPTION
This adds a utility function `clamped_sub` to the `Value` type

This is useful for input selection since you can do something like `output.clamped_sub(inputs_added)` to get how much of each token type is left to be added during input selection

Additional bugfix:
- `checked_sub` returned the wrong value when the lhs had no tokens but the rhs did (I added a test to make sure we catch this)
- `Value` constructor was missing a `clone`
- `Value` definition of `partial_ord` was incorrect
- Change calculation would crash on a multiasset list of size 0

Notably, here are some cases of `partial_ord` that failed:

```rust
let mut token_bundle1 = MultiAsset::new();
let mut asset_list1 = Assets::new();
asset_list1.insert(
	&asset1,
	&BigNum(1)
);
token_bundle1.insert(
	&policy1,
	&asset_list1
);
let a = Value {
	coin: BigNum(1),
	multiasset: Some(token_bundle1),
};
let b = Value::new(&to_bignum(1));
// incorrectly returned None
assert_eq!(a.partial_cmp(&b).unwrap(), std::cmp::Ordering::Greater);
```

```rust
let mut token_bundle1 = MultiAsset::new();
let mut asset_list1 = Assets::new();
asset_list1.insert(
	&asset1,
	&BigNum(1)
);
token_bundle1.insert(
	&policy1,
	&asset_list1
);
let a = Value::new(&to_bignum(1));
let b = Value {
	coin: BigNum(1),
	multiasset: Some(token_bundle1),
};
// incorrectly returned Equal
assert_eq!(a.partial_cmp(&b).unwrap(), std::cmp::Ordering::Less);
```

There are more cases, but hopefully this should be enough to show the previous results were wrong