### PR TITLE
Fix for certainn rust (non-wasm) builds

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,6 @@ exclude = [
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-wasm-bindgen = "=0.2.65"
 cryptoxide = "0.2.0"
 cbor_event = "2.1.3"
 curve25519-dalek = "1"
@@ -25,7 +24,6 @@ sha2 = "^0.8"
 digest = "^0.8"
 bech32 = "0.7.2"
 hex = "0.4.0"
-js-sys = "=0.3.24"
 cfg-if = "0.1"
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
@@ -40,7 +38,9 @@ noop_proc_macro = "0.3.0"
 
 # wasm
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+wasm-bindgen = "=0.2.65"
 rand_os = { version = "0.1", features = ["wasm-bindgen"] }
+js-sys = "=0.3.24"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.


### PR DESCRIPTION
While I seem to have been able to do rust builds before, when I tried
using it in another rust project I ran into some build errors inside of
js-sys. I am not entirely sure as to the root causes of these, but
we shouldn't need js-sys/wasm-bindgen for non-wasm builds either way so
it should be fine to just entirely omit them for non-wasm rust builds.