### PR TITLE
to_from_bytes macro to Value type

### DIFF
--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -157,6 +157,8 @@ pub struct Value {
     multiasset: Option<MultiAsset>,
 }
 
+to_from_bytes!(Value);
+
 #[wasm_bindgen]
 impl Value {
     pub fn new(coin: &Coin) -> Value {


### PR DESCRIPTION
Added the macro in order to convert Value to bytes and parse it from bytes.