### PR TITLE
Alonzo: BigInt wrapper type

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -16,10 +16,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
-name = "bech32"
-version = "0.7.3"
+name = "autocfg"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "bech32"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcf67bb7ba7797a081cd19009948ab533af7c355d5caf1d08c777582d351e9c"
 
 [[package]]
 name = "bitflags"
@@ -65,6 +71,7 @@ dependencies = [
  "js-sys",
  "linked-hash-map",
  "noop_proc_macro",
+ "num-bigint",
  "quickcheck",
  "quickcheck_macros",
  "rand_chacha 0.1.1",
@@ -124,9 +131,9 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "cryptoxide"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46212f5d1792f89c3e866fb10636139464060110c568edd7f73ab5e9f736c26d"
+checksum = "b8c4fdc86023bc33b265f256ce8205329125b86c38a8a96e243a6a705b7230ec"
 
 [[package]]
 name = "curve25519-dalek"
@@ -280,6 +287,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg 1.0.1",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,9 +330,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
@@ -351,7 +388,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
- "autocfg",
+ "autocfg 0.1.7",
  "rand_core 0.3.1",
 ]
 
@@ -490,9 +527,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,6 +27,7 @@ hex = "0.4.0"
 cfg-if = "1"
 linked-hash-map = "0.5.3"
 serde_json = "1.0.57"
+num-bigint = "0.4.0"
 # The default can't be compiled to wasm, so it's necessary to use either the 'nightly'
 # feature or this one
 clear_on_drop = { version = "0.2", features = ["no_cc"] }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1918,7 +1918,7 @@ pub struct ProtocolParamUpdate {
     execution_costs: Option<ExUnitPrices>,
     max_tx_ex_units: Option<ExUnits>,
     max_block_ex_units: Option<ExUnits>,
-    max_value_size: Option<PreludeUnsigned>,
+    max_value_size: Option<u32>,
 }
 
 to_from_bytes!(ProtocolParamUpdate);
@@ -2093,11 +2093,11 @@ impl ProtocolParamUpdate {
         self.max_block_ex_units.clone()
     }
 
-    pub fn set_max_value_size(&mut self, max_value_size: &PreludeUnsigned) {
+    pub fn set_max_value_size(&mut self, max_value_size: u32) {
         self.max_value_size = Some(max_value_size.clone())
     }
 
-    pub fn max_value_size(&self) -> Option<PreludeUnsigned> {
+    pub fn max_value_size(&self) -> Option<u32> {
         self.max_value_size.clone()
     }
 
@@ -2675,57 +2675,6 @@ impl NetworkId {
 
     pub fn kind(&self) -> NetworkIdKind {
         self.0
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub enum PreludeUnsignedKind {
-    U64,
-    PreludeBiguint,
-}
-
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-enum PreludeUnsignedEnum {
-    U64(BigNum),
-    PreludeBiguint(PreludeBiguint),
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct PreludeUnsigned(PreludeUnsignedEnum);
-
-to_from_bytes!(PreludeUnsigned);
-
-#[wasm_bindgen]
-impl PreludeUnsigned {
-    pub fn new_u64(uint: BigNum) -> Self {
-        Self(PreludeUnsignedEnum::U64(uint))
-    }
-
-    pub fn new_prelude_biguint(prelude_biguint: &PreludeBiguint) -> Self {
-        Self(PreludeUnsignedEnum::PreludeBiguint(prelude_biguint.clone()))
-    }
-
-    pub fn kind(&self) -> PreludeUnsignedKind {
-        match &self.0 {
-            PreludeUnsignedEnum::U64(_) => PreludeUnsignedKind::U64,
-            PreludeUnsignedEnum::PreludeBiguint(_) => PreludeUnsignedKind::PreludeBiguint,
-        }
-    }
-
-    pub fn as_u64(&self) -> Option<BigNum> {
-        match &self.0 {
-            PreludeUnsignedEnum::U64(x) => Some(x.clone()),
-            _ => None,
-        }
-    }
-
-    pub fn as_prelude_biguint(&self) -> Option<PreludeBiguint> {
-        match &self.0 {
-            PreludeUnsignedEnum::PreludeBiguint(x) => Some(x.clone()),
-            _ => None,
-        }
     }
 }
 

--- a/rust/src/plutus.rs
+++ b/rust/src/plutus.rs
@@ -86,7 +86,7 @@ impl ConstrPlutusData {
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct CostModel(std::collections::BTreeMap<String, PreludeInteger>);
+pub struct CostModel(std::collections::BTreeMap<String, BigInt>);
 
 to_from_bytes!(CostModel);
 
@@ -100,11 +100,11 @@ impl CostModel {
         self.0.len()
     }
 
-    pub fn insert(&mut self, key: String, value: &PreludeInteger) -> Option<PreludeInteger> {
+    pub fn insert(&mut self, key: String, value: &BigInt) -> Option<BigInt> {
         self.0.insert(key, value.clone())
     }
 
-    pub fn get(&self, key: String) -> Option<PreludeInteger> {
+    pub fn get(&self, key: String) -> Option<BigInt> {
         self.0.get(&key).map(|v| v.clone())
     }
 
@@ -276,18 +276,18 @@ impl PlutusMap {
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum PlutusDataKind {
     ConstrPlutusData,
-    PlutusMap,
-    PlutusList,
-    PreludeInteger,
+    Map,
+    List,
+    Integer,
     Bytes,
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 enum PlutusDataEnum {
     ConstrPlutusData(ConstrPlutusData),
-    PlutusMap(PlutusMap),
-    PlutusList(PlutusList),
-    PreludeInteger(PreludeInteger),
+    Map(PlutusMap),
+    List(PlutusList),
+    Integer(BigInt),
     Bytes(Vec<u8>),
 }
 
@@ -306,15 +306,15 @@ impl PlutusData {
     }
 
     pub fn new_map(map: &PlutusMap) -> Self {
-        Self(PlutusDataEnum::PlutusMap(map.clone()))
+        Self(PlutusDataEnum::Map(map.clone()))
     }
 
     pub fn new_list(list: &PlutusList) -> Self {
-        Self(PlutusDataEnum::PlutusList(list.clone()))
+        Self(PlutusDataEnum::List(list.clone()))
     }
 
-    pub fn new_integer(integer: &PreludeInteger) -> Self {
-        Self(PlutusDataEnum::PreludeInteger(integer.clone()))
+    pub fn new_integer(integer: &BigInt) -> Self {
+        Self(PlutusDataEnum::Integer(integer.clone()))
     }
 
     pub fn new_bytes(bytes: Vec<u8>) -> Result<PlutusData, JsError> {
@@ -328,9 +328,9 @@ impl PlutusData {
     pub fn kind(&self) -> PlutusDataKind {
         match &self.0 {
             PlutusDataEnum::ConstrPlutusData(_) => PlutusDataKind::ConstrPlutusData,
-            PlutusDataEnum::PlutusMap(_) => PlutusDataKind::PlutusMap,
-            PlutusDataEnum::PlutusList(_) => PlutusDataKind::PlutusList,
-            PlutusDataEnum::PreludeInteger(_) => PlutusDataKind::PreludeInteger,
+            PlutusDataEnum::Map(_) => PlutusDataKind::Map,
+            PlutusDataEnum::List(_) => PlutusDataKind::List,
+            PlutusDataEnum::Integer(_) => PlutusDataKind::Integer,
             PlutusDataEnum::Bytes(_) => PlutusDataKind::Bytes,
         }
     }
@@ -344,21 +344,21 @@ impl PlutusData {
 
     pub fn as_map(&self) -> Option<PlutusMap> {
         match &self.0 {
-            PlutusDataEnum::PlutusMap(x) => Some(x.clone()),
+            PlutusDataEnum::Map(x) => Some(x.clone()),
             _ => None,
         }
     }
 
     pub fn as_list(&self) -> Option<PlutusList> {
         match &self.0 {
-            PlutusDataEnum::PlutusList(x) => Some(x.clone()),
+            PlutusDataEnum::List(x) => Some(x.clone()),
             _ => None,
         }
     }
 
-    pub fn as_integer(&self) -> Option<PreludeInteger> {
+    pub fn as_integer(&self) -> Option<BigInt> {
         match &self.0 {
-            PlutusDataEnum::PreludeInteger(x) => Some(x.clone()),
+            PlutusDataEnum::Integer(x) => Some(x.clone()),
             _ => None,
         }
     }
@@ -391,131 +391,6 @@ impl PlutusList {
 
     pub fn add(&mut self, elem: &PlutusData) {
         self.0.push(elem.clone());
-    }
-}
-
-// TODO: replace these prelude ints with a generalized Integer class
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub enum PreludeBigintKind {
-    PreludeBiguint,
-    PreludeBignint,
-}
-
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-enum PreludeBigintEnum {
-    PreludeBiguint(PreludeBiguint),
-    PreludeBignint(PreludeBignint),
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct PreludeBigint(PreludeBigintEnum);
-
-to_from_bytes!(PreludeBigint);
-
-#[wasm_bindgen]
-impl PreludeBigint {
-    pub fn new_prelude_biguint(prelude_biguint: &PreludeBiguint) -> Self {
-        Self(PreludeBigintEnum::PreludeBiguint(prelude_biguint.clone()))
-    }
-
-    pub fn new_prelude_bignint(prelude_bignint: &PreludeBignint) -> Self {
-        Self(PreludeBigintEnum::PreludeBignint(prelude_bignint.clone()))
-    }
-
-    pub fn kind(&self) -> PreludeBigintKind {
-        match &self.0 {
-            PreludeBigintEnum::PreludeBiguint(_) => PreludeBigintKind::PreludeBiguint,
-            PreludeBigintEnum::PreludeBignint(_) => PreludeBigintKind::PreludeBignint,
-        }
-    }
-
-    pub fn as_prelude_biguint(&self) -> Option<PreludeBiguint> {
-        match &self.0 {
-            PreludeBigintEnum::PreludeBiguint(x) => Some(x.clone()),
-            _ => None,
-        }
-    }
-
-    pub fn as_prelude_bignint(&self) -> Option<PreludeBignint> {
-        match &self.0 {
-            PreludeBigintEnum::PreludeBignint(x) => Some(x.clone()),
-            _ => None,
-        }
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct PreludeBignint(Vec<u8>);
-
-#[wasm_bindgen]
-impl PreludeBignint {
-    pub fn new(data: Vec<u8>) -> Self {
-        Self(data)
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct PreludeBiguint(Vec<u8>);
-
-#[wasm_bindgen]
-impl PreludeBiguint {
-    pub fn new(data: Vec<u8>) -> Self {
-        Self(data)
-    }
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub enum PreludeIntegerKind {
-    Int,
-    PreludeBigint,
-}
-
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-enum PreludeIntegerEnum {
-    Int(Int),
-    PreludeBigint(PreludeBigint),
-}
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct PreludeInteger(PreludeIntegerEnum);
-
-to_from_bytes!(PreludeInteger);
-
-#[wasm_bindgen]
-impl PreludeInteger {
-    pub fn new_int(int: &Int) -> Self {
-        Self(PreludeIntegerEnum::Int(int.clone()))
-    }
-
-    pub fn new_prelude_bigint(prelude_bigint: &PreludeBigint) -> Self {
-        Self(PreludeIntegerEnum::PreludeBigint(prelude_bigint.clone()))
-    }
-
-    pub fn kind(&self) -> PreludeIntegerKind {
-        match &self.0 {
-            PreludeIntegerEnum::Int(_) => PreludeIntegerKind::Int,
-            PreludeIntegerEnum::PreludeBigint(_) => PreludeIntegerKind::PreludeBigint,
-        }
-    }
-
-    pub fn as_int(&self) -> Option<Int> {
-        match &self.0 {
-            PreludeIntegerEnum::Int(x) => Some(x.clone()),
-            _ => None,
-        }
-    }
-
-    pub fn as_prelude_bigint(&self) -> Option<PreludeBigint> {
-        match &self.0 {
-            PreludeIntegerEnum::PreludeBigint(x) => Some(x.clone()),
-            _ => None,
-        }
     }
 }
 
@@ -787,7 +662,7 @@ impl Deserialize for CostModel {
                     break;
                 }
                 let key = String::deserialize(raw)?;
-                let value = PreludeInteger::deserialize(raw)?;
+                let value = BigInt::deserialize(raw)?;
                 if table.insert(key.clone(), value).is_some() {
                     return Err(DeserializeFailure::DuplicateKey(Key::Str(key)).into());
                 }
@@ -991,13 +866,13 @@ impl cbor_event::se::Serialize for PlutusDataEnum {
             PlutusDataEnum::ConstrPlutusData(x) => {
                 x.serialize(serializer)
             },
-            PlutusDataEnum::PlutusMap(x) => {
+            PlutusDataEnum::Map(x) => {
                 x.serialize(serializer)
             },
-            PlutusDataEnum::PlutusList(x) => {
+            PlutusDataEnum::List(x) => {
                 x.serialize(serializer)
             },
-            PlutusDataEnum::PreludeInteger(x) => {
+            PlutusDataEnum::Integer(x) => {
                 x.serialize(serializer)
             },
             PlutusDataEnum::Bytes(x) => {
@@ -1022,21 +897,21 @@ impl Deserialize for PlutusDataEnum {
                 Ok(PlutusMap::deserialize(raw)?)
             })(raw)
             {
-                Ok(variant) => return Ok(PlutusDataEnum::PlutusMap(variant)),
+                Ok(variant) => return Ok(PlutusDataEnum::Map(variant)),
                 Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
             };
             match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
                 Ok(PlutusList::deserialize(raw)?)
             })(raw)
             {
-                Ok(variant) => return Ok(PlutusDataEnum::PlutusList(variant)),
+                Ok(variant) => return Ok(PlutusDataEnum::List(variant)),
                 Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
             };
             match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-                Ok(PreludeInteger::deserialize(raw)?)
+                Ok(BigInt::deserialize(raw)?)
             })(raw)
             {
-                Ok(variant) => return Ok(PlutusDataEnum::PreludeInteger(variant)),
+                Ok(variant) => return Ok(PlutusDataEnum::Integer(variant)),
                 Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
             };
             match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
@@ -1096,136 +971,6 @@ impl Deserialize for PlutusList {
             Ok(())
         })().map_err(|e| e.annotate("PlutusList"))?;
         Ok(Self(arr))
-    }
-}
-
-impl cbor_event::se::Serialize for PreludeBigintEnum {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        match self {
-            PreludeBigintEnum::PreludeBiguint(x) => {
-                x.serialize(serializer)
-            },
-            PreludeBigintEnum::PreludeBignint(x) => {
-                x.serialize(serializer)
-            },
-        }
-    }
-}
-
-impl Deserialize for PreludeBigintEnum {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-                Ok(PreludeBiguint::deserialize(raw)?)
-            })(raw)
-            {
-                Ok(variant) => return Ok(PreludeBigintEnum::PreludeBiguint(variant)),
-                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-            };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-                Ok(PreludeBignint::deserialize(raw)?)
-            })(raw)
-            {
-                Ok(variant) => return Ok(PreludeBigintEnum::PreludeBignint(variant)),
-                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-            };
-            Err(DeserializeError::new("PreludeBigintEnum", DeserializeFailure::NoVariantMatched.into()))
-        })().map_err(|e| e.annotate("PreludeBigintEnum"))
-    }
-}
-
-impl cbor_event::se::Serialize for PreludeBigint {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        self.0.serialize(serializer)
-    }
-}
-
-impl Deserialize for PreludeBigint {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        Ok(Self(PreludeBigintEnum::deserialize(raw)?))
-    }
-}
-
-impl cbor_event::se::Serialize for PreludeBignint {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_tag(3u64)?;
-        serializer.write_bytes(&self.0)
-    }
-}
-
-impl Deserialize for PreludeBignint {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let tag = raw.tag().map_err(|e| DeserializeError::from(e).annotate("PreludeBignint"))?;
-        if tag != 3 {
-            return Err(DeserializeError::new("PreludeBignint", DeserializeFailure::TagMismatch{ found: tag, expected: 3 }));
-        }
-        Ok(Self(raw.bytes()?))
-    }
-}
-
-impl cbor_event::se::Serialize for PreludeBiguint {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        serializer.write_tag(2u64)?;
-        serializer.write_bytes(&self.0)
-    }
-}
-
-impl Deserialize for PreludeBiguint {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let tag = raw.tag().map_err(|e| DeserializeError::from(e).annotate("PreludeBiguint"))?;
-        if tag != 2 {
-            return Err(DeserializeError::new("PreludeBiguint", DeserializeFailure::TagMismatch{ found: tag, expected: 2 }));
-        }
-        Ok(Self(raw.bytes()?))
-    }
-}
-
-impl cbor_event::se::Serialize for PreludeIntegerEnum {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        match self {
-            PreludeIntegerEnum::Int(x) => {
-                x.serialize(serializer)
-            },
-            PreludeIntegerEnum::PreludeBigint(x) => {
-                x.serialize(serializer)
-            },
-        }
-    }
-}
-
-impl Deserialize for PreludeIntegerEnum {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-                Ok(Int::deserialize(raw)?)
-            })(raw)
-            {
-                Ok(variant) => return Ok(PreludeIntegerEnum::Int(variant)),
-                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-            };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-                Ok(PreludeBigint::deserialize(raw)?)
-            })(raw)
-            {
-                Ok(variant) => return Ok(PreludeIntegerEnum::PreludeBigint(variant)),
-                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-            };
-            Err(DeserializeError::new("PreludeIntegerEnum", DeserializeFailure::NoVariantMatched.into()))
-        })().map_err(|e| e.annotate("PreludeIntegerEnum"))
-    }
-}
-
-impl cbor_event::se::Serialize for PreludeInteger {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        self.0.serialize(serializer)
-    }
-}
-
-impl Deserialize for PreludeInteger {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        Ok(Self(PreludeIntegerEnum::deserialize(raw)?))
     }
 }
 

--- a/rust/src/serialization.rs
+++ b/rust/src/serialization.rs
@@ -2839,7 +2839,7 @@ impl Deserialize for ProtocolParamUpdate {
                             }
                             max_value_size = Some((|| -> Result<_, DeserializeError> {
                                 read_len.read_elems(1)?;
-                                Ok(PreludeUnsigned::deserialize(raw)?)
+                                Ok(u32::deserialize(raw)?)
                             })().map_err(|e| e.annotate("max_value_size"))?);
                         },
                         unknown_key => return Err(DeserializeFailure::UnknownKey(Key::Uint(unknown_key)).into()),
@@ -3432,54 +3432,6 @@ impl Deserialize for NetworkId {
                 _ => Err(DeserializeError::new("NetworkId", DeserializeFailure::NoVariantMatched.into())),
             }
         })().map_err(|e| e.annotate("NetworkId"))
-    }
-}
-
-impl cbor_event::se::Serialize for PreludeUnsignedEnum {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        match self {
-            PreludeUnsignedEnum::U64(x) => {
-                x.serialize(serializer)
-            },
-            PreludeUnsignedEnum::PreludeBiguint(x) => {
-                x.serialize(serializer)
-            },
-        }
-    }
-}
-
-impl Deserialize for PreludeUnsignedEnum {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        (|| -> Result<_, DeserializeError> {
-            let initial_position = raw.as_mut_ref().seek(SeekFrom::Current(0)).unwrap();
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-                Ok(BigNum::deserialize(raw)?)
-            })(raw)
-            {
-                Ok(variant) => return Ok(PreludeUnsignedEnum::U64(variant)),
-                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-            };
-            match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError> {
-                Ok(PreludeBiguint::deserialize(raw)?)
-            })(raw)
-            {
-                Ok(variant) => return Ok(PreludeUnsignedEnum::PreludeBiguint(variant)),
-                Err(_) => raw.as_mut_ref().seek(SeekFrom::Start(initial_position)).unwrap(),
-            };
-            Err(DeserializeError::new("PreludeUnsignedEnum", DeserializeFailure::NoVariantMatched.into()))
-        })().map_err(|e| e.annotate("PreludeUnsignedEnum"))
-    }
-}
-
-impl cbor_event::se::Serialize for PreludeUnsigned {
-    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
-        self.0.serialize(serializer)
-    }
-}
-
-impl Deserialize for PreludeUnsigned {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        Ok(Self(PreludeUnsignedEnum::deserialize(raw)?))
     }
 }
 


### PR DESCRIPTION
CDDL defines:
```
int = uint / nint
biguint = #6.2(bstr)
bignint = #6.3(bstr)
bigint = biguint / bignint
integer = int / bigint
unsigned = uint / biguint
```

which is very unwieldly to use and not to mention to have to interpret
the bytes correctly and everything so this commit introduces a single
wrapper type `BigInt` that covers all of these cases and tries to encode
the integer in the smallest possible type.