### PR TITLE
TxBuilder: max output size + multiple change address support

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -385,7 +385,7 @@ impl TransactionInput {
 #[derive(Clone, Debug)]
 pub struct TransactionOutput {
     address: Address,
-    amount: Value,
+    pub (crate) amount: Value,
     data_hash: Option<DataHash>,
 }
 
@@ -2461,7 +2461,9 @@ pub type PolicyIDs = ScriptHashes;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Assets(std::collections::BTreeMap<AssetName, BigNum>);
+pub struct Assets(pub (crate) std::collections::BTreeMap<AssetName, BigNum>);
+
+to_from_bytes!(Assets);
 
 #[wasm_bindgen]
 impl Assets {
@@ -2488,7 +2490,7 @@ impl Assets {
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq)]
-pub struct MultiAsset(std::collections::BTreeMap<PolicyID, Assets>);
+pub struct MultiAsset(pub (crate) std::collections::BTreeMap<PolicyID, Assets>);
 
 to_from_bytes!(MultiAsset);
 

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -156,6 +156,10 @@ impl BigNum {
         format!("{}", self.0)
     }
 
+    pub fn zero() -> Self {
+        Self(0)
+    }
+
     pub fn checked_mul(&self, other: &BigNum) -> Result<BigNum, JsError> {
         match self.0.checked_mul(other.0) {
             Some(value) => Ok(BigNum(value)),
@@ -222,8 +226,8 @@ pub type Coin = BigNum;
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, /*Hash,*/ Ord, PartialEq)]
 pub struct Value {
-    coin: Coin,
-    multiasset: Option<MultiAsset>,
+    pub (crate) coin: Coin,
+    pub (crate) multiasset: Option<MultiAsset>,
 }
 
 to_from_bytes!(Value);


### PR DESCRIPTION
Users with many NFTs could run into problems creating certain txs that
returned many of them as a change output as it would surpass the maximum
output size limit in the ledger. The TxBuilder now takes this limit into
account and errors if it is passed, and during the change output
creation will attempt to spread out the assets over multiple outputs to
not surpass the ledger limit.

This is done as a greedy selection for now as the limit is currently 4kb
or so and each asset is at most 64 bytes each so this should suffice.