### PR TITLE
fixed hash_script_data function

### DIFF
--- a/rust/src/plutus.rs
+++ b/rust/src/plutus.rs
@@ -51,6 +51,23 @@ impl PlutusScripts {
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct LanguageViews(Vec<u8>);
+
+to_from_bytes!(LanguageViews);
+
+#[wasm_bindgen]
+impl LanguageViews {
+    pub fn new(bytes: Vec<u8>) -> LanguageViews {
+        Self(bytes)
+    }
+
+    pub fn bytes(&self) -> Vec<u8> {
+        self.0.clone()
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ConstrPlutusData {
     tag: Int,
     data: PlutusList,
@@ -627,6 +644,18 @@ impl Deserialize for ConstrPlutusData {
                 data,
             })
         })().map_err(|e| e.annotate("ConstrPlutusData"))
+    }
+}
+
+impl cbor_event::se::Serialize for LanguageViews {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes(&self.0)
+    }
+}
+
+impl Deserialize for LanguageViews {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Ok(Self(raw.bytes()?))
     }
 }
 


### PR DESCRIPTION
I was finally able to reproduce the same script data hash in the serialization-lib as in the cardano-cli.
`language_views` is actually not the same as `costmdls` and the encoding is totally different. I was able to extract the encoded language_views from the cardano-node and then concatenated redemeers + datums + language_views, hashed it and received the correct hash.

Since I don't know exactly how to create the languague_views encoding, I created a struct LanguageViews, which takes the raw bytes, that fixes at least the hash_script_data function. Maybe someone could help here to build this encoding fully in Rust.

This is the language_views encoding based on current mainnet protocol parameters:
```
a141005901d59f1a000302590001011a00060bc719026d00011a000249f01903e800011a000249f018201a0025cea81971f70419744d186419744d186419744d186419744d186419744d186419744d18641864186419744d18641a000249f018201a000249f018201a000249f018201a000249f01903e800011a000249f018201a000249f01903e800081a000242201a00067e2318760001011a000249f01903e800081a000249f01a0001b79818f7011a000249f0192710011a0002155e19052e011903e81a000249f01903e8011a000249f018201a000249f018201a000249f0182001011a000249f0011a000249f0041a000194af18f8011a000194af18f8011a0002377c190556011a0002bdea1901f1011a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a000242201a00067e23187600010119f04c192bd200011a000249f018201a000242201a00067e2318760001011a000242201a00067e2318760001011a0025cea81971f704001a000141bb041a000249f019138800011a000249f018201a000302590001011a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a00330da70101ff
```
Links that could help with building this encoding:
https://github.com/input-output-hk/cardano-ledger-specs/blob/d37757e273d10fb251681faa1a2a0cc1ac018384/alonzo/test/test/Test/Cardano/Ledger/Alonzo/Serialisation/Canonical.hs#L36-L43
https://github.com/input-output-hk/cardano-ledger-specs/blob/37322df14d44d1370e8a72b677815d64a92baa00/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs#L268-L276
https://github.com/input-output-hk/cardano-ledger-specs/blob/37322df14d44d1370e8a72b677815d64a92baa00/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs#L511-L525
https://github.com/input-output-hk/cardano-ledger-specs/blob/ec51e4fb1b17461ab612cf427b79f1742942e8cb/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs#L172-L175