### PR TITLE
Fixed hash script function (updated)

### DIFF
--- a/rust/src/plutus.rs
+++ b/rust/src/plutus.rs
@@ -51,6 +51,23 @@ impl PlutusScripts {
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct LanguageViews(Vec<u8>);
+
+to_from_bytes!(LanguageViews);
+
+#[wasm_bindgen]
+impl LanguageViews {
+    pub fn new(bytes: Vec<u8>) -> LanguageViews {
+        Self(bytes)
+    }
+
+    pub fn bytes(&self) -> Vec<u8> {
+        self.0.clone()
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ConstrPlutusData {
     tag: Int,
     data: PlutusList,
@@ -627,6 +644,18 @@ impl Deserialize for ConstrPlutusData {
                 data,
             })
         })().map_err(|e| e.annotate("ConstrPlutusData"))
+    }
+}
+
+impl cbor_event::se::Serialize for LanguageViews {
+    fn serialize<'se, W: Write>(&self, serializer: &'se mut Serializer<W>) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_bytes(&self.0)
+    }
+}
+
+impl Deserialize for LanguageViews {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        Ok(Self(raw.bytes()?))
     }
 }
 

--- a/rust/src/plutus.rs
+++ b/rust/src/plutus.rs
@@ -159,7 +159,8 @@ impl Costmdls {
         for (key, key_bytes) in keys_bytes.iter() {
             serializer.write_bytes(key_bytes).unwrap();
             let cost_model = self.0.get(&key).unwrap();
-            // not sure why but the cardano node seems to use indefinite encoding despite this not being standard canonical CBOR
+            // Due to a bug in the cardano-node input-output-hk/cardano-ledger-specs/issues/2512
+            // we must use indefinite length serialization in this inner bytestring to match it
             let mut cost_model_serializer = Serializer::new_vec();
             cost_model_serializer.write_array(cbor_event::Len::Indefinite).unwrap();
             for cost in &cost_model.0 {

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -809,7 +809,7 @@ pub fn hash_plutus_data(plutus_data: &PlutusData) -> DataHash {
     DataHash::from(blake2b256(&plutus_data.to_bytes()))
 }
 #[wasm_bindgen]
-pub fn hash_script_data(redeemers: &Redeemers, cost_models: &Costmdls, datums: Option<PlutusList>) -> ScriptDataHash {
+pub fn hash_script_data(redeemers: &Redeemers, language_views: &LanguageViews, datums: Option<PlutusList>) -> ScriptDataHash {
     /*
     ; script data format:
     ; [ redeemers | datums | language views ]
@@ -819,13 +819,10 @@ pub fn hash_script_data(redeemers: &Redeemers, cost_models: &Costmdls, datums: O
     */
     let mut buf = Vec::new();
     buf.extend(redeemers.to_bytes());
-     if let Some(d) = &datums {
+    if let Some(d) = &datums {
         buf.extend(d.to_bytes());
-    } else {
-        let empty_string = "";
-        buf.extend(empty_string.as_bytes());
     }
-    buf.extend(cost_models.to_bytes());
+    buf.extend(language_views.bytes());
     ScriptDataHash::from(blake2b256(&buf))
 }
 
@@ -1003,6 +1000,23 @@ mod tests {
 
     // this is what is used in mainnet
     static MINIMUM_UTXO_VAL: u64 = 1_000_000;
+
+    #[test]
+    fn correct_script_data_hash() {
+        let mut datums = PlutusList::new();
+        datums.add(&PlutusData::new_integer(&BigInt::from_str("1000").unwrap()));
+        let mut redeemers = Redeemers::new();
+        redeemers.add(&Redeemer::new(&RedeemerTag::new_spend(), &BigNum::from_str("1").unwrap(), &PlutusData::new_integer(&BigInt::from_str("2000").unwrap()), &ExUnits::new(&BigNum::from_str("0").unwrap(), &BigNum::from_str("0").unwrap())));
+        let language_views = LanguageViews::new(hex::decode("a141005901d59f1a000302590001011a00060bc719026d00011a000249f01903e800011a000249f018201a0025cea81971f70419744d186419744d186419744d186419744d186419744d186419744d18641864186419744d18641a000249f018201a000249f018201a000249f018201a000249f01903e800011a000249f018201a000249f01903e800081a000242201a00067e2318760001011a000249f01903e800081a000249f01a0001b79818f7011a000249f0192710011a0002155e19052e011903e81a000249f01903e8011a000249f018201a000249f018201a000249f0182001011a000249f0011a000249f0041a000194af18f8011a000194af18f8011a0002377c190556011a0002bdea1901f1011a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a000242201a00067e23187600010119f04c192bd200011a000249f018201a000242201a00067e2318760001011a000242201a00067e2318760001011a0025cea81971f704001a000141bb041a000249f019138800011a000249f018201a000302590001011a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a00330da70101ff").unwrap());
+
+        let script_data_hash = hash_script_data(&redeemers,&language_views, Some(datums));
+
+        assert_eq!(
+            hex::encode(script_data_hash.to_bytes()),
+            "57240d358f8ab6128c4a66340271e4fec39b4971232add308f01a5809313adcf"
+        );
+    }
+
 
     #[test]
     fn no_token_minimum() {

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -809,7 +809,7 @@ pub fn hash_plutus_data(plutus_data: &PlutusData) -> DataHash {
     DataHash::from(blake2b256(&plutus_data.to_bytes()))
 }
 #[wasm_bindgen]
-pub fn hash_script_data(redeemers: &Redeemers, language_views: &LanguageViews, datums: Option<PlutusList>) -> ScriptDataHash {
+pub fn hash_script_data(redeemers: &Redeemers, cost_models: &Costmdls, datums: Option<PlutusList>) -> ScriptDataHash {
     /*
     ; script data format:
     ; [ redeemers | datums | language views ]
@@ -822,7 +822,7 @@ pub fn hash_script_data(redeemers: &Redeemers, language_views: &LanguageViews, d
     if let Some(d) = &datums {
         buf.extend(d.to_bytes());
     }
-    buf.extend(language_views.bytes());
+    buf.extend(cost_models.language_views_encoding());
     ScriptDataHash::from(blake2b256(&buf))
 }
 
@@ -1007,9 +1007,27 @@ mod tests {
         datums.add(&PlutusData::new_integer(&BigInt::from_str("1000").unwrap()));
         let mut redeemers = Redeemers::new();
         redeemers.add(&Redeemer::new(&RedeemerTag::new_spend(), &BigNum::from_str("1").unwrap(), &PlutusData::new_integer(&BigInt::from_str("2000").unwrap()), &ExUnits::new(&BigNum::from_str("0").unwrap(), &BigNum::from_str("0").unwrap())));
-        let language_views = LanguageViews::new(hex::decode("a141005901d59f1a000302590001011a00060bc719026d00011a000249f01903e800011a000249f018201a0025cea81971f70419744d186419744d186419744d186419744d186419744d186419744d18641864186419744d18641a000249f018201a000249f018201a000249f018201a000249f01903e800011a000249f018201a000249f01903e800081a000242201a00067e2318760001011a000249f01903e800081a000249f01a0001b79818f7011a000249f0192710011a0002155e19052e011903e81a000249f01903e8011a000249f018201a000249f018201a000249f0182001011a000249f0011a000249f0041a000194af18f8011a000194af18f8011a0002377c190556011a0002bdea1901f1011a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a000242201a00067e23187600010119f04c192bd200011a000249f018201a000242201a00067e2318760001011a000242201a00067e2318760001011a0025cea81971f704001a000141bb041a000249f019138800011a000249f018201a000302590001011a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a000249f018201a00330da70101ff").unwrap());
-
-        let script_data_hash = hash_script_data(&redeemers,&language_views, Some(datums));
+        let plutus_cost_model = CostModel::from_bytes(vec![
+            159, 26, 0, 3, 2, 89, 0, 1, 1, 26, 0, 6, 11, 199, 25, 2, 109, 0, 1, 26, 0, 2, 73, 240, 25, 3, 232, 0, 1, 26, 0,
+            2, 73, 240, 24, 32, 26, 0, 37, 206, 168, 25, 113, 247, 4, 25, 116, 77, 24, 100, 25, 116, 77, 24, 100, 25, 116, 77,
+            24, 100, 25, 116, 77, 24, 100, 25, 116, 77, 24, 100, 25, 116, 77, 24, 100, 24, 100, 24, 100, 25, 116, 77, 24, 100,
+            26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 73, 240, 25, 3, 232, 0,
+            1, 26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 73, 240, 25, 3, 232, 0, 8, 26, 0, 2, 66, 32, 26, 0, 6, 126, 35, 24, 118, 0,
+            1, 1, 26, 0, 2, 73, 240, 25, 3, 232, 0, 8, 26, 0, 2, 73, 240, 26, 0, 1, 183, 152, 24, 247, 1, 26, 0, 2, 73, 240, 25,
+            39, 16, 1, 26, 0, 2, 21, 94, 25, 5, 46, 1, 25, 3, 232, 26, 0, 2, 73, 240, 25, 3, 232, 1, 26, 0, 2, 73, 240, 24, 32,
+            26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 73, 240, 24, 32, 1, 1, 26, 0, 2, 73, 240, 1, 26, 0, 2, 73, 240, 4, 26, 0, 1, 148,
+            175, 24, 248, 1, 26, 0, 1, 148, 175, 24, 248, 1, 26, 0, 2, 55, 124, 25, 5, 86, 1, 26, 0, 2, 189, 234, 25, 1, 241, 1,
+            26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 73, 240, 24, 32, 26, 0, 2,
+            73, 240, 24, 32, 26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 66, 32, 26, 0, 6, 126, 35, 24, 118, 0, 1, 1, 25, 240, 76, 25, 43,
+            210, 0, 1, 26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 66, 32, 26, 0, 6, 126, 35, 24, 118, 0, 1, 1, 26, 0, 2, 66, 32, 26, 0, 6,
+            126, 35, 24, 118, 0, 1, 1, 26, 0, 37, 206, 168, 25, 113, 247, 4, 0, 26, 0, 1, 65, 187, 4, 26, 0, 2, 73, 240, 25, 19,
+            136, 0, 1, 26, 0, 2, 73, 240, 24, 32, 26, 0, 3, 2, 89, 0, 1, 1, 26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 73, 240, 24, 32,
+            26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 73, 240, 24, 32, 26, 0, 2, 73,
+            240, 24, 32, 26, 0, 51, 13, 167, 1, 1, 255
+        ]).unwrap();
+        let mut cost_models = Costmdls::new();
+        cost_models.insert(&Language::new_plutus_v1(), &plutus_cost_model);
+        let script_data_hash = hash_script_data(&redeemers, &cost_models, Some(datums));
 
         assert_eq!(
             hex::encode(script_data_hash.to_bytes()),


### PR DESCRIPTION
continues with #209 to fix `utils::hash_script_data()` which in the Haskell node instead of using `cost_mdls` directly seems to construct some kind of canonical `LangViewDep` structure to hash instead.