### PR TITLE
NativeScript::hash() return changed to ScriptHash

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -2587,7 +2587,7 @@ declare export class NativeScript {
    * @param {number} namespace
    * @returns {Ed25519KeyHash}
    */
-  hash(namespace: number): Ed25519KeyHash;
+  hash(namespace: number): ScriptHash;
 
   /**
    * @param {ScriptPubkey} script_pubkey

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2687,14 +2687,12 @@ mod tests {
 
     #[test]
     fn native_script_hash() {
-        let hash = Ed25519KeyHash::from_bytes(vec![143, 180, 186, 93, 223, 42, 243, 7, 81, 98, 86, 125, 97, 69, 110, 52, 130, 243, 244, 98, 246, 13, 33, 212, 128, 168, 136, 40]).unwrap();
-        assert_eq!(hex::encode(&hash.to_bytes()), "8fb4ba5ddf2af3075162567d61456e3482f3f462f60d21d480a88828");
+        let keyhash = Ed25519KeyHash::from_bytes(vec![143, 180, 186, 93, 223, 42, 243, 7, 81, 98, 86, 125, 97, 69, 110, 52, 130, 243, 244, 98, 246, 13, 33, 212, 128, 168, 136, 40]).unwrap();
+        assert_eq!(hex::encode(&keyhash.to_bytes()), "8fb4ba5ddf2af3075162567d61456e3482f3f462f60d21d480a88828");
 
-        let script = NativeScript::new_script_pubkey(&ScriptPubkey::new(&hash));
+        let script = NativeScript::new_script_pubkey(&ScriptPubkey::new(&keyhash));
 
-        let script_hash = ScriptHash::from_bytes(
-            script.hash(ScriptHashNamespace::NativeScript).to_bytes()
-        ).unwrap();
+        let script_hash = script.hash(ScriptHashNamespace::NativeScript);
 
         assert_eq!(hex::encode(&script_hash.to_bytes()), "187b8d3ddcb24013097c003da0b8d8f7ddcf937119d8f59dccd05a0f");
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1615,11 +1615,11 @@ pub enum ScriptHashNamespace {
 
 #[wasm_bindgen]
 impl NativeScript {
-    pub fn hash(&self, namespace: ScriptHashNamespace) -> Ed25519KeyHash {
+    pub fn hash(&self, namespace: ScriptHashNamespace) -> ScriptHash {
         let mut bytes = Vec::with_capacity(self.to_bytes().len() + 1);
         bytes.extend_from_slice(&vec![namespace as u8]);
         bytes.extend_from_slice(&self.to_bytes());
-        Ed25519KeyHash::from(blake2b224(bytes.as_ref()))
+        ScriptHash::from(blake2b224(bytes.as_ref()))
     }
 
     pub fn new_script_pubkey(script_pubkey: &ScriptPubkey) -> Self {


### PR DESCRIPTION
both Ed25519KeyHash and ScriptHash are 28-byte wrapper types with the
same API (both generated by `impl_hash_type!()`) around a blake2b224
hash and are CBOR-equivalent, but are different semantically.