### PR TITLE
Switched `Assets` and `MultiAsset` to use `LinkedHashMap`

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -57,6 +57,7 @@ use error::*;
 use plutus::*;
 use metadata::*;
 use utils::*;
+use linked_hash_map::LinkedHashMap;
 
 type DeltaCoin = Int;
 
@@ -2403,7 +2404,7 @@ impl HeaderBody {
 
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct AssetName(Vec<u8>);
 
 to_from_bytes!(AssetName);
@@ -2461,14 +2462,14 @@ pub type PolicyIDs = ScriptHashes;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Assets(pub (crate) std::collections::BTreeMap<AssetName, BigNum>);
+pub struct Assets(pub (crate) LinkedHashMap<AssetName, BigNum>);
 
 to_from_bytes!(Assets);
 
 #[wasm_bindgen]
 impl Assets {
     pub fn new() -> Self {
-        Self(std::collections::BTreeMap::new())
+        Self(LinkedHashMap::new())
     }
 
     pub fn len(&self) -> usize {
@@ -2490,14 +2491,14 @@ impl Assets {
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq)]
-pub struct MultiAsset(pub (crate) std::collections::BTreeMap<PolicyID, Assets>);
+pub struct MultiAsset(pub (crate) LinkedHashMap<PolicyID, Assets>);
 
 to_from_bytes!(MultiAsset);
 
 #[wasm_bindgen]
 impl MultiAsset {
     pub fn new() -> Self {
-        Self(std::collections::BTreeMap::new())
+        Self(LinkedHashMap::new())
     }
 
     pub fn len(&self) -> usize {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -58,7 +58,6 @@ use plutus::*;
 use metadata::*;
 use utils::*;
 use linked_hash_map::LinkedHashMap;
-use itertools::Itertools;
 
 type DeltaCoin = Int;
 
@@ -1792,10 +1791,6 @@ impl ScriptHashes {
         Self(Vec::new())
     }
 
-    fn from_vec(vec: Vec<&ScriptHash>) -> Self {
-        Self(vec.iter().map(|h| { h.clone().clone() }).collect_vec())
-    }
-
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -2449,10 +2444,6 @@ impl AssetNames {
         Self(Vec::new())
     }
 
-    fn from_vec(vec: Vec<&AssetName>) -> Self {
-        Self(vec.iter().map(|h| { h.clone().clone() }).collect_vec())
-    }
-
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -2742,10 +2733,10 @@ mod tests {
         assert_eq!(asset1.len(), 2);
         assert_eq!(asset2.len(), 2);
 
-        assert_eq!(masset1.keys(), PolicyIDs::from_vec([&policy_id1, &policy_id2].to_vec()));
-        assert_eq!(masset2.keys(), PolicyIDs::from_vec([&policy_id2, &policy_id1].to_vec()));
+        assert_eq!(masset1.keys(), ScriptHashes([policy_id1.clone(), policy_id2.clone()].to_vec()));
+        assert_eq!(masset2.keys(), ScriptHashes([policy_id2.clone(), policy_id1.clone()].to_vec()));
 
-        assert_eq!(asset1.keys(), AssetNames::from_vec([&name1, &name2].to_vec()));
-        assert_eq!(asset2.keys(), AssetNames::from_vec([&name2, &name1].to_vec()));
+        assert_eq!(asset1.keys(), AssetNames([name1.clone(), name2.clone()].to_vec()));
+        assert_eq!(asset2.keys(), AssetNames([name2.clone(), name1.clone()].to_vec()));
     }
 }

--- a/rust/src/serialization.rs
+++ b/rust/src/serialization.rs
@@ -3291,7 +3291,7 @@ impl cbor_event::se::Serialize for Assets {
 
 impl Deserialize for Assets {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let mut table = std::collections::BTreeMap::new();
+        let mut table = LinkedHashMap::new();
         (|| -> Result<_, DeserializeError> {
             let len = raw.map()?;
             while match len { cbor_event::Len::Len(n) => table.len() < n as usize, cbor_event::Len::Indefinite => true, } {
@@ -3324,7 +3324,7 @@ impl cbor_event::se::Serialize for MultiAsset {
 
 impl Deserialize for MultiAsset {
     fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
-        let mut table = std::collections::BTreeMap::new();
+        let mut table = LinkedHashMap::new();
         (|| -> Result<_, DeserializeError> {
             let len = raw.map()?;
             while match len { cbor_event::Len::Len(n) => table.len() < n as usize, cbor_event::Len::Indefinite => true, } {

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -271,7 +271,7 @@ impl Value {
     }
 
     pub fn checked_add(&self, rhs: &Value) -> Result<Value, JsError> {
-        use std::collections::btree_map::Entry;
+        use linked_hash_map::Entry;
         let coin = self.coin.checked_add(&rhs.coin)?;
 
         let multiasset = match (&self.multiasset, &rhs.multiasset) {


### PR DESCRIPTION
For compatibility with new Ledger requirements the client apps must be able to preserve a certain insertion order for asset policies and asset names.

See: https://github.com/Emurgo/cardano-serialization-lib/issues/240