### PR TITLE
Added PrivateKey::from_bech32()

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -3382,6 +3382,12 @@ declare export class PrivateKey {
   static generate_ed25519extended(): PrivateKey;
 
   /**
+   * @param {string} bech_str
+   * @returns {PrivateKey}
+   */
+  static from_bech32(bech_str: string): PrivateKey;
+
+  /**
    * @returns {string}
    */
   to_bech32(): string;

--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -229,6 +229,25 @@ impl PrivateKey {
             .map_err(|e| JsError::from_str(&format!("{}", e)))
     }
 
+    /// Get private key from its bech32 representation
+    /// ```javascript
+    /// PrivateKey.from_bech32(&#39;ed25519_sk1ahfetf02qwwg4dkq7mgp4a25lx5vh9920cr5wnxmpzz9906qvm8qwvlts0&#39;);
+    /// ```
+    /// For an extended 25519 key
+    /// ```javascript
+    /// PrivateKey.from_bech32(&#39;ed25519e_sk1gqwl4szuwwh6d0yk3nsqcc6xxc3fpvjlevgwvt60df59v8zd8f8prazt8ln3lmz096ux3xvhhvm3ca9wj2yctdh3pnw0szrma07rt5gl748fp&#39;);
+    /// ```
+    pub fn from_bech32(bech32_str: &str) -> Result<PrivateKey, JsError> {
+        crypto::SecretKey::try_from_bech32_str(&bech32_str)
+            .map(key::EitherEd25519SecretKey::Extended)
+            .or_else(|_| {
+                crypto::SecretKey::try_from_bech32_str(&bech32_str)
+                    .map(key::EitherEd25519SecretKey::Normal)
+            })
+            .map(PrivateKey)
+            .map_err(|_| JsError::from_str("Invalid secret key"))
+    }
+
     pub fn to_bech32(&self) -> String {
         match self.0 {
             key::EitherEd25519SecretKey::Normal(ref secret) => secret.to_bech32_str(),


### PR DESCRIPTION
This method existed already in js-chain-libs where we got this class
from to begin wtih. It also exists in the other 3 keys types:
PublicKey, Bip32PublicKey and Bip32PrivateKey so it makes sense to add here.

[taken from here](https://github.com/input-output-hk/js-chain-libs/blob/master/src/lib.rs#L47)

I'm not sure why it wasn't there to begin with. I didn't see it being removed in the git histories either yet it was in js-chain-libs.