### PR TITLE
[9.1.1] Implemented canonical ordering for `AssetName` and added a test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "(De)serialization functions for the Cardano blockchain along with related utility functions",
   "scripts": {
     "rust:build-nodejs": "rimraf ./rust/pkg && cd rust; wasm-pack build --target=nodejs; wasm-pack pack; cd .. && npm run js:flowgen",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "cardano-serialization-lib"
-version = "9.1.0"
+version = "9.1.1"
 dependencies = [
  "bech32",
  "cbor_event",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-serialization-lib"
-version = "9.1.0"
+version = "9.1.1"
 edition = "2018"
 authors = ["EMURGO"]
 license = "MIT"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2702,7 +2702,6 @@ impl NetworkId {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
 
     #[test]
     fn native_script_hash() {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2746,5 +2746,12 @@ mod tests {
         map.insert(&name3, &to_bignum(1));
 
         assert_eq!(map.keys(), AssetNames(vec![name3, name1, name2]));
+
+        let mut map2 = MintAssets::new();
+        map2.insert(&name11, Int::new_i32(1));
+        map2.insert(&name33, Int::new_i32(1));
+        map2.insert(&name22, Int::new_i32(1));
+
+        assert_eq!(map2.keys(), AssetNames(vec![name33, name11, name22]));
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -57,6 +57,7 @@ use error::*;
 use plutus::*;
 use metadata::*;
 use utils::*;
+use std::cmp::Ordering;
 
 type DeltaCoin = Int;
 
@@ -2403,8 +2404,25 @@ impl HeaderBody {
 
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AssetName(Vec<u8>);
+
+impl Ord for AssetName {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Implementing canonical CBOR order for asset names,
+        // as they might be of different length.
+        return match self.0.len().cmp(&other.0.len()) {
+            Ordering::Equal => self.0.cmp(&other.0),
+            x => x,
+        };
+    }
+}
+
+impl PartialOrd for AssetName {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
 
 to_from_bytes!(AssetName);
 
@@ -2684,6 +2702,7 @@ impl NetworkId {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     #[test]
     fn native_script_hash() {
@@ -2697,5 +2716,36 @@ mod tests {
         ).unwrap();
 
         assert_eq!(hex::encode(&script_hash.to_bytes()), "187b8d3ddcb24013097c003da0b8d8f7ddcf937119d8f59dccd05a0f");
+    }
+
+    #[test]
+    fn asset_name_ord() {
+
+        let name1 = AssetName::new(vec![0u8, 1, 2, 3]).unwrap();
+        let name11 = AssetName::new(vec![0u8, 1, 2, 3]).unwrap();
+
+        let name2 = AssetName::new(vec![0u8, 4, 5, 6]).unwrap();
+        let name22 = AssetName::new(vec![0u8, 4, 5, 6]).unwrap();
+
+        let name3 = AssetName::new(vec![0u8, 7, 8]).unwrap();
+        let name33 = AssetName::new(vec![0u8, 7, 8]).unwrap();
+
+        assert_eq!(name1.cmp(&name2), Ordering::Less);
+        assert_eq!(name2.cmp(&name1), Ordering::Greater);
+        assert_eq!(name1.cmp(&name3), Ordering::Greater);
+        assert_eq!(name2.cmp(&name3), Ordering::Greater);
+        assert_eq!(name3.cmp(&name1), Ordering::Less);
+        assert_eq!(name3.cmp(&name2), Ordering::Less);
+
+        assert_eq!(name1.cmp(&name11), Ordering::Equal);
+        assert_eq!(name2.cmp(&name22), Ordering::Equal);
+        assert_eq!(name3.cmp(&name33), Ordering::Equal);
+
+        let mut map = Assets::new();
+        map.insert(&name2, &to_bignum(1));
+        map.insert(&name1, &to_bignum(1));
+        map.insert(&name3, &to_bignum(1));
+
+        assert_eq!(map.keys(), AssetNames(vec![name3, name1, name2]));
     }
 }


### PR DESCRIPTION
As described in CIP21: https://cips.cardano.org/cips/cip21/

> **Multiassets**
>
> Since multiassets (policy_id and asset_name) are represented as maps, both need to be sorted in accordance with the specified canonical CBOR format. Also, an output or the mint field must not contain duplicate policy_ids and a policy must not contain duplicate asset_names.

Policy IDs are always same length, so default lexicographical ordering is correct, but asset names might be different length, so they require the sorting to be implemented explicitly.

Canonical CBOR is defined in section 3.9 here: https://www.rfc-editor.org/rfc/rfc7049.txt

> The keys in every map must be sorted lowest value to highest.
      Sorting is performed on the bytes of the representation of the key
      data items without paying attention to the 3/5 bit splitting for
      major types.  (Note that this rule allows maps that have keys of
      different types, even though that is probably a bad practice that
      could lead to errors in some canonicalization implementations.)
      The sorting rules are:
>
>      *  If two keys have different lengths,
>          the shorter one sorts earlier;
>
>      *  If two keys have the same length,
>          the one with the lower value in (byte-wise) lexical order sorts earlier.