### PR TITLE
Deprecated `Int::as_i32`

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -6,73 +6,6 @@
  */
 
 /**
- * @param {Uint8Array} bytes
- * @returns {TransactionMetadatum}
- */
-declare export function encode_arbitrary_bytes_as_metadatum(
-  bytes: Uint8Array
-): TransactionMetadatum;
-
-/**
- * @param {TransactionMetadatum} metadata
- * @returns {Uint8Array}
- */
-declare export function decode_arbitrary_bytes_from_metadatum(
-  metadata: TransactionMetadatum
-): Uint8Array;
-
-/**
- * @param {string} json
- * @param {number} schema
- * @returns {TransactionMetadatum}
- */
-declare export function encode_json_str_to_metadatum(
-  json: string,
-  schema: number
-): TransactionMetadatum;
-
-/**
- * @param {TransactionMetadatum} metadatum
- * @param {number} schema
- * @returns {string}
- */
-declare export function decode_metadatum_to_json_str(
-  metadatum: TransactionMetadatum,
-  schema: number
-): string;
-
-/**
- * @param {string} password
- * @param {string} salt
- * @param {string} nonce
- * @param {string} data
- * @returns {string}
- */
-declare export function encrypt_with_password(
-  password: string,
-  salt: string,
-  nonce: string,
-  data: string
-): string;
-
-/**
- * @param {string} password
- * @param {string} data
- * @returns {string}
- */
-declare export function decrypt_with_password(
-  password: string,
-  data: string
-): string;
-
-/**
- * @param {Transaction} tx
- * @param {LinearFee} linear_fee
- * @returns {BigNum}
- */
-declare export function min_fee(tx: Transaction, linear_fee: LinearFee): BigNum;
-
-/**
  * @param {TransactionHash} tx_body_hash
  * @param {ByronAddress} addr
  * @param {LegacyDaedalusPrivateKey} key
@@ -166,12 +99,14 @@ declare export function get_deposit(
 
 /**
  * @param {Value} assets
- * @param {BigNum} minimum_utxo_val
+ * @param {boolean} has_data_hash
+ * @param {BigNum} coins_per_utxo_word
  * @returns {BigNum}
  */
 declare export function min_ada_required(
   assets: Value,
-  minimum_utxo_val: BigNum
+  has_data_hash: boolean,
+  coins_per_utxo_word: BigNum
 ): BigNum;
 
 /**
@@ -179,21 +114,87 @@ declare export function min_ada_required(
  * and returns a NativeScript.
  * Cardano Wallet and Node styles are supported.
  *
- * * wallet: https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/listSharedWallets
- *    * payment_script_template is the schema
+ * * wallet: https://github.com/input-output-hk/cardano-wallet/blob/master/specifications/api/swagger.yaml
  * * node: https://github.com/input-output-hk/cardano-node/blob/master/doc/reference/simple-scripts.md
  *
- * self_address is expected to be a Bip32PublicKey as hex-encoded bytes
+ * self_xpub is expected to be a Bip32PublicKey as hex-encoded bytes
  * @param {string} json
- * @param {string} self_address
+ * @param {string} self_xpub
  * @param {number} schema
  * @returns {NativeScript}
  */
 declare export function encode_json_str_to_native_script(
   json: string,
-  self_address: string,
+  self_xpub: string,
   schema: number
 ): NativeScript;
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {TransactionMetadatum}
+ */
+declare export function encode_arbitrary_bytes_as_metadatum(
+  bytes: Uint8Array
+): TransactionMetadatum;
+
+/**
+ * @param {TransactionMetadatum} metadata
+ * @returns {Uint8Array}
+ */
+declare export function decode_arbitrary_bytes_from_metadatum(
+  metadata: TransactionMetadatum
+): Uint8Array;
+
+/**
+ * @param {string} json
+ * @param {number} schema
+ * @returns {TransactionMetadatum}
+ */
+declare export function encode_json_str_to_metadatum(
+  json: string,
+  schema: number
+): TransactionMetadatum;
+
+/**
+ * @param {TransactionMetadatum} metadatum
+ * @param {number} schema
+ * @returns {string}
+ */
+declare export function decode_metadatum_to_json_str(
+  metadatum: TransactionMetadatum,
+  schema: number
+): string;
+
+/**
+ * @param {string} password
+ * @param {string} salt
+ * @param {string} nonce
+ * @param {string} data
+ * @returns {string}
+ */
+declare export function encrypt_with_password(
+  password: string,
+  salt: string,
+  nonce: string,
+  data: string
+): string;
+
+/**
+ * @param {string} password
+ * @param {string} data
+ * @returns {string}
+ */
+declare export function decrypt_with_password(
+  password: string,
+  data: string
+): string;
+
+/**
+ * @param {Transaction} tx
+ * @param {LinearFee} linear_fee
+ * @returns {BigNum}
+ */
+declare export function min_fee(tx: Transaction, linear_fee: LinearFee): BigNum;
 
 /**
  */
@@ -267,40 +268,6 @@ declare export var NetworkIdKind: {|
 /**
  */
 
-declare export var TransactionMetadatumKind: {|
-  +MetadataMap: 0, // 0
-  +MetadataList: 1, // 1
-  +Int: 2, // 2
-  +Bytes: 3, // 3
-  +Text: 4, // 4
-|};
-
-/**
- */
-
-declare export var MetadataJsonSchema: {|
-  +NoConversions: 0, // 0
-  +BasicConversions: 1, // 1
-  +DetailedSchema: 2, // 2
-|};
-
-/**
- * Used to choosed the schema for a script JSON string
- */
-
-declare export var ScriptSchema: {|
-  +Wallet: 0, // 0
-  +Node: 1, // 1
-|};
-
-/**
- */
-
-declare export var StakeCredKind: {|
-  +Key: 0, // 0
-  +Script: 1, // 1
-|};
-
 declare export var LanguageKind: {|
   +PlutusV1: 0, // 0
 |};
@@ -324,6 +291,51 @@ declare export var RedeemerTagKind: {|
   +Mint: 1, // 1
   +Cert: 2, // 2
   +Reward: 3, // 3
+|};
+
+/**
+ * Used to choosed the schema for a script JSON string
+ */
+
+declare export var ScriptSchema: {|
+  +Wallet: 0, // 0
+  +Node: 1, // 1
+|};
+
+/**
+ */
+
+declare export var TransactionMetadatumKind: {|
+  +MetadataMap: 0, // 0
+  +MetadataList: 1, // 1
+  +Int: 2, // 2
+  +Bytes: 3, // 3
+  +Text: 4, // 4
+|};
+
+/**
+ */
+
+declare export var MetadataJsonSchema: {|
+  +NoConversions: 0, // 0
+  +BasicConversions: 1, // 1
+  +DetailedSchema: 2, // 2
+|};
+
+/**
+ */
+
+declare export var CoinSelectionStrategyCIP2: {|
+  +LargestFirst: 0, // 0
+  +RandomImprove: 1, // 1
+|};
+
+/**
+ */
+
+declare export var StakeCredKind: {|
+  +Key: 0, // 0
+  +Script: 1, // 1
 |};
 
 /**
@@ -1278,9 +1290,9 @@ declare export class ConstrPlutusData {
   static from_bytes(bytes: Uint8Array): ConstrPlutusData;
 
   /**
-   * @returns {Int}
+   * @returns {BigNum}
    */
-  tag(): Int;
+  alternative(): BigNum;
 
   /**
    * @returns {PlutusList}
@@ -1288,11 +1300,11 @@ declare export class ConstrPlutusData {
   data(): PlutusList;
 
   /**
-   * @param {Int} tag
+   * @param {BigNum} alternative
    * @param {PlutusList} data
    * @returns {ConstrPlutusData}
    */
-  static new(tag: Int, data: PlutusList): ConstrPlutusData;
+  static new(alternative: BigNum, data: PlutusList): ConstrPlutusData;
 }
 /**
  */
@@ -1992,19 +2004,55 @@ declare export class Int {
   is_positive(): boolean;
 
   /**
+   * BigNum can only contain unsigned u64 values
+   *
+   * This function will return the BigNum representation
+   * only in case the underlying i128 value is positive.
+   *
+   * Otherwise nothing will be returned (undefined).
    * @returns {BigNum | void}
    */
   as_positive(): BigNum | void;
 
   /**
+   * BigNum can only contain unsigned u64 values
+   *
+   * This function will return the *absolute* BigNum representation
+   * only in case the underlying i128 value is negative.
+   *
+   * Otherwise nothing will be returned (undefined).
    * @returns {BigNum | void}
    */
   as_negative(): BigNum | void;
 
   /**
+   * !!! DEPRECATED !!!
+   * Returns an i32 value in case the underlying original i128 value is within the limits.
+   * Otherwise will just return an empty value (undefined).
    * @returns {number | void}
    */
   as_i32(): number | void;
+
+  /**
+   * Returns the underlying value converted to i32 if possible (within limits)
+   * Otherwise will just return an empty value (undefined).
+   * @returns {number | void}
+   */
+  as_i32_or_nothing(): number | void;
+
+  /**
+   * Returns the underlying value converted to i32 if possible (within limits)
+   * JsError in case of out of boundary overflow
+   * @returns {number}
+   */
+  as_i32_or_fail(): number;
+
+  /**
+   * Returns string representation of the underlying i128 value directly.
+   * Might contain the minus sign (-) in case of negative value.
+   * @returns {string}
+   */
+  to_str(): string;
 }
 /**
  */
@@ -2620,7 +2668,7 @@ declare export class NativeScript {
 
   /**
    * @param {number} namespace
-   * @returns {Ed25519KeyHash}
+   * @returns {ScriptHash}
    */
   hash(namespace: number): ScriptHash;
 
@@ -3382,10 +3430,18 @@ declare export class PrivateKey {
   static generate_ed25519extended(): PrivateKey;
 
   /**
-   * @param {string} bech_str
+   * Get private key from its bech32 representation
+   * ```javascript
+   * PrivateKey.from_bech32(&#39;ed25519_sk1ahfetf02qwwg4dkq7mgp4a25lx5vh9920cr5wnxmpzz9906qvm8qwvlts0&#39;);
+   * ```
+   * For an extended 25519 key
+   * ```javascript
+   * PrivateKey.from_bech32(&#39;ed25519e_sk1gqwl4szuwwh6d0yk3nsqcc6xxc3fpvjlevgwvt60df59v8zd8f8prazt8ln3lmz096ux3xvhhvm3ca9wj2yctdh3pnw0szrma07rt5gl748fp&#39;);
+   * ```
+   * @param {string} bech32_str
    * @returns {PrivateKey}
    */
-  static from_bech32(bech_str: string): PrivateKey;
+  static from_bech32(bech32_str: string): PrivateKey;
 
   /**
    * @returns {string}
@@ -4902,6 +4958,22 @@ declare export class TransactionBuilder {
   free(): void;
 
   /**
+   * This automatically selects and adds inputs from {inputs} consisting of just enough to cover
+   * the outputs that have already been added.
+   * This should be called after adding all certs/outputs/etc and will be an error otherwise.
+   * Uses CIP2: https://github.com/cardano-foundation/CIPs/blob/master/CIP-0002/CIP-0002.md
+   * Adding a change output must be called after via TransactionBuilder::add_change_if_needed()
+   * This function, diverging from CIP2, takes into account fees and will attempt to add additional
+   * inputs to cover the minimum fees. This does not, however, set the txbuilder's fee.
+   * @param {TransactionUnspentOutputs} inputs
+   * @param {number} strategy
+   */
+  add_inputs_from(inputs: TransactionUnspentOutputs, strategy: number): void;
+
+  /**
+   * We have to know what kind of inputs these are to know what kind of mock witnesses to create since
+   * 1) mock witnesses have different lengths depending on the type which changes the expecting fee
+   * 2) Witnesses are a set so we need to get rid of duplicates to avoid over-estimating the fee
    * @param {Ed25519KeyHash} hash
    * @param {TransactionInput} input
    * @param {Value} amount
@@ -5003,20 +5075,20 @@ declare export class TransactionBuilder {
 
   /**
    * @param {LinearFee} linear_fee
-   * @param {BigNum} minimum_utxo_val
    * @param {BigNum} pool_deposit
    * @param {BigNum} key_deposit
    * @param {number} max_value_size
    * @param {number} max_tx_size
+   * @param {BigNum} coins_per_utxo_word
    * @returns {TransactionBuilder}
    */
   static new(
     linear_fee: LinearFee,
-    minimum_utxo_val: BigNum,
     pool_deposit: BigNum,
     key_deposit: BigNum,
     max_value_size: number,
-    max_tx_size: number
+    max_tx_size: number,
+    coins_per_utxo_word: BigNum
   ): TransactionBuilder;
 
   /**
@@ -5403,6 +5475,32 @@ declare export class TransactionUnspentOutput {
    * @returns {TransactionOutput}
    */
   output(): TransactionOutput;
+}
+/**
+ */
+declare export class TransactionUnspentOutputs {
+  free(): void;
+
+  /**
+   * @returns {TransactionUnspentOutputs}
+   */
+  static new(): TransactionUnspentOutputs;
+
+  /**
+   * @returns {number}
+   */
+  len(): number;
+
+  /**
+   * @param {number} index
+   * @returns {TransactionUnspentOutput}
+   */
+  get(index: number): TransactionUnspentOutput;
+
+  /**
+   * @param {TransactionUnspentOutput} elem
+   */
+  add(elem: TransactionUnspentOutput): void;
 }
 /**
  */

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -930,7 +930,7 @@ mod tests {
         assert_eq!(map.get_str("sender_id").unwrap().as_text().unwrap(), "jkfdsufjdk34h3Sdfjdhfduf873");
         assert_eq!(map.get_str("comment").unwrap().as_text().unwrap(), "happy birthday");
         let tags = map.get_str("tags").unwrap().as_list().unwrap();
-        let tags_i32 = tags.0.iter().map(|md| md.as_int().unwrap().as_i32().unwrap()).collect::<Vec<i32>>();
+        let tags_i32 = tags.0.iter().map(|md| md.as_int().unwrap().as_i32_or_fail().unwrap()).collect::<Vec<i32>>();
         assert_eq!(tags_i32, vec![0, 264, -1024, 32]);
         let output_str = decode_metadatum_to_json_str(&metadata, MetadataJsonSchema::NoConversions).expect("decode failed");
         let input_json: serde_json::Value = serde_json::from_str(&input_str).unwrap();
@@ -991,11 +991,11 @@ mod tests {
     fn json_encoding_check_example_metadatum(metadata: &TransactionMetadatum) {
         let map = metadata.as_map().unwrap();
         assert_eq!(map.get(&TransactionMetadatum::new_bytes(hex::decode("8badf00d").unwrap()).unwrap()).unwrap().as_bytes().unwrap(), hex::decode("deadbeef").unwrap());
-        assert_eq!(map.get_i32(9).unwrap().as_int().unwrap().as_i32().unwrap(), 5);
+        assert_eq!(map.get_i32(9).unwrap().as_int().unwrap().as_i32_or_fail().unwrap(), 5);
         let inner_map = map.get_str("obj").unwrap().as_map().unwrap();
         let a = inner_map.get_str("a").unwrap().as_list().unwrap();
         let a1 = a.get(0).as_map().unwrap();
-        assert_eq!(a1.get_i32(5).unwrap().as_int().unwrap().as_i32().unwrap(), 2);
+        assert_eq!(a1.get_i32(5).unwrap().as_int().unwrap().as_i32_or_fail().unwrap(), 2);
         let a2 = a.get(1).as_map().unwrap();
         assert_eq!(a2.keys().len(), 0);
     }
@@ -1025,11 +1025,11 @@ mod tests {
 
         let map = metadata.as_map().unwrap();
         let key = map.keys().get(0);
-        assert_eq!(map.get(&key).unwrap().as_int().unwrap().as_i32().unwrap(), 5);
+        assert_eq!(map.get(&key).unwrap().as_int().unwrap().as_i32_or_fail().unwrap(), 5);
         let key_list = key.as_list().unwrap();
         assert_eq!(key_list.len(), 2);
         let key_map = key_list.get(0).as_map().unwrap();
-        assert_eq!(key_map.get_i32(5).unwrap().as_int().unwrap().as_i32().unwrap(), -7);
+        assert_eq!(key_map.get_i32(5).unwrap().as_int().unwrap().as_i32_or_fail().unwrap(), -7);
         assert_eq!(key_map.get_str("hello").unwrap().as_text().unwrap(), "world");
         let key_bytes = key_list.get(1).as_bytes().unwrap();
         assert_eq!(key_bytes, hex::decode("ff00ff00").unwrap());

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -487,6 +487,12 @@ impl Int {
         return self.0 >= 0
     }
 
+    /// BigNum can only contain unsigned u64 values
+    ///
+    /// This function will return the BigNum representation
+    /// only in case the underlying i128 value is positive.
+    ///
+    /// Otherwise nothing will be returned (undefined).
     pub fn as_positive(&self) -> Option<BigNum> {
         if self.is_positive() {
             Some(to_bignum(self.0 as u64))
@@ -495,6 +501,12 @@ impl Int {
         }
     }
 
+    /// BigNum can only contain unsigned u64 values
+    ///
+    /// This function will return the *absolute* BigNum representation
+    /// only in case the underlying i128 value is negative.
+    ///
+    /// Otherwise nothing will be returned (undefined).
     pub fn as_negative(&self) -> Option<BigNum> {
         if !self.is_positive() {
             Some(to_bignum((-self.0) as u64))
@@ -503,9 +515,36 @@ impl Int {
         }
     }
 
+    /// !!! DEPRECATED !!!
+    /// Returns an i32 value in case the underlying original i128 value is within the limits.
+    /// Otherwise will just return an empty value (undefined).
+    #[deprecated(
+        since = "10.0.0",
+        note = "Unsafe ignoring of possible boundary error and it's not clear from the function name. Use `as_i32_or_nothing`, `as_i32_or_fail`, or `to_str`"
+    )]
     pub fn as_i32(&self) -> Option<i32> {
+        self.as_i32_or_nothing()
+    }
+
+    /// Returns the underlying value converted to i32 if possible (within limits)
+    /// Otherwise will just return an empty value (undefined).
+    pub fn as_i32_or_nothing(&self) -> Option<i32> {
         use std::convert::TryFrom;
         i32::try_from(self.0).ok()
+    }
+
+    /// Returns the underlying value converted to i32 if possible (within limits)
+    /// JsError in case of out of boundary overflow
+    pub fn as_i32_or_fail(&self) -> Result<i32, JsError> {
+        use std::convert::TryFrom;
+        i32::try_from(self.0)
+            .map_err(|e| JsError::from_str(&format!("{}", e)))
+    }
+
+    /// Returns string representation of the underlying i128 value directly.
+    /// Might contain the minus sign (-) in case of negative value.
+    pub fn to_str(&self) -> String {
+        format!("{}", self.0)
     }
 }
 
@@ -2191,5 +2230,61 @@ mod tests {
             self_key.addr_keyhash(),
             Bip32PublicKey::from_bytes(&hex::decode(self_key_hex).unwrap()).unwrap().to_raw_key().hash()
         );
+    }
+
+    #[test]
+    fn int_to_str() {
+        assert_eq!(Int::new(&BigNum(u64::max_value())).to_str(), u64::max_value().to_string());
+        assert_eq!(Int::new(&BigNum(u64::min_value())).to_str(), u64::min_value().to_string());
+        assert_eq!(Int::new_negative(&BigNum(u64::max_value())).to_str(), (-(u64::max_value() as i128)).to_string());
+        assert_eq!(Int::new_negative(&BigNum(u64::min_value())).to_str(), (-(u64::min_value() as i128)).to_string());
+        assert_eq!(Int::new_i32(142).to_str(), "142");
+        assert_eq!(Int::new_i32(-142).to_str(), "-142");
+    }
+
+    #[test]
+    fn int_as_i32_or_nothing() {
+
+        let over_pos_i32 = (i32::max_value() as i64) + 1;
+        assert!(Int::new(&BigNum(over_pos_i32 as u64)).as_i32_or_nothing().is_none());
+
+        let valid_pos_i32 = (i32::max_value() as i64);
+        assert_eq!(Int::new(&BigNum(valid_pos_i32 as u64)).as_i32_or_nothing().unwrap(), i32::max_value());
+
+        let over_neg_i32 = (i32::min_value() as i64) - 1;
+        assert!(Int::new_negative(&BigNum((-over_neg_i32) as u64)).as_i32_or_nothing().is_none());
+
+        let valid_neg_i32 = (i32::min_value() as i64);
+        assert_eq!(Int::new_negative(&BigNum((-valid_neg_i32) as u64)).as_i32_or_nothing().unwrap(), i32::min_value());
+
+        assert!(Int::new(&BigNum(u64::max_value())).as_i32_or_nothing().is_none());
+        assert_eq!(Int::new(&BigNum(i32::max_value() as u64)).as_i32_or_nothing().unwrap(), i32::max_value());
+        assert_eq!(Int::new_negative(&BigNum(i32::max_value() as u64)).as_i32_or_nothing().unwrap(), -i32::max_value());
+
+        assert_eq!(Int::new_i32(42).as_i32_or_nothing().unwrap(), 42);
+        assert_eq!(Int::new_i32(-42).as_i32_or_nothing().unwrap(), -42);
+    }
+
+    #[test]
+    fn int_as_i32_or_fail() {
+
+        let over_pos_i32 = (i32::max_value() as i64) + 1;
+        assert!(Int::new(&BigNum(over_pos_i32 as u64)).as_i32_or_fail().is_err());
+
+        let valid_pos_i32 = (i32::max_value() as i64);
+        assert_eq!(Int::new(&BigNum(valid_pos_i32 as u64)).as_i32_or_fail().unwrap(), i32::max_value());
+
+        let over_neg_i32 = (i32::min_value() as i64) - 1;
+        assert!(Int::new_negative(&BigNum((-over_neg_i32) as u64)).as_i32_or_fail().is_err());
+
+        let valid_neg_i32 = (i32::min_value() as i64);
+        assert_eq!(Int::new_negative(&BigNum((-valid_neg_i32) as u64)).as_i32_or_fail().unwrap(), i32::min_value());
+
+        assert!(Int::new(&BigNum(u64::max_value())).as_i32_or_fail().is_err());
+        assert_eq!(Int::new(&BigNum(i32::max_value() as u64)).as_i32_or_fail().unwrap(), i32::max_value());
+        assert_eq!(Int::new_negative(&BigNum(i32::max_value() as u64)).as_i32_or_fail().unwrap(), -i32::max_value());
+
+        assert_eq!(Int::new_i32(42).as_i32_or_fail().unwrap(), 42);
+        assert_eq!(Int::new_i32(-42).as_i32_or_fail().unwrap(), -42);
     }
 }


### PR DESCRIPTION
Deprecated `Int::as_i32` and created new functions `as_i32_or_nothing`, `as_i32_or_fail`, and `Int::to_str` plus added tests and some new comments