### PR TITLE
Fixing minting API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "9.1.4",
+  "version": "10.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "9.1.2",
+  "version": "10.0.0-beta.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "10.0.0-beta.7",
+  "version": "10.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "9.1.2",
+  "version": "10.0.0-beta.7",
   "description": "(De)serialization functions for the Cardano blockchain along with related utility functions",
   "scripts": {
     "rust:build-nodejs": "(rimraf ./rust/pkg && cd rust; wasm-pack build --target=nodejs; wasm-pack pack) && npm run js:flowgen",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "10.0.0-beta.7",
+  "version": "10.0.0-beta.8",
   "description": "(De)serialization functions for the Cardano blockchain along with related utility functions",
   "scripts": {
     "rust:build-nodejs": "(rimraf ./rust/pkg && cd rust; wasm-pack build --target=nodejs; wasm-pack pack) && npm run js:flowgen",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "cardano-serialization-lib"
-version = "10.0.0-beta.7"
+version = "10.0.0-beta.8"
 dependencies = [
  "bech32",
  "cbor_event",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "cardano-serialization-lib"
-version = "9.1.4"
+version = "10.0.0-beta.8"
 dependencies = [
  "bech32",
  "cbor_event",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "cardano-serialization-lib"
-version = "9.1.2"
+version = "10.0.0-beta.7"
 dependencies = [
  "bech32",
  "cbor_event",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-serialization-lib"
-version = "9.1.2"
+version = "10.0.0-beta.7"
 edition = "2018"
 authors = ["EMURGO"]
 license = "MIT"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-serialization-lib"
-version = "10.0.0-beta.7"
+version = "10.0.0-beta.8"
 edition = "2018"
 authors = ["EMURGO"]
 license = "MIT"

--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -5177,28 +5177,19 @@ declare export class TransactionBuilder {
   ): void;
 
   /**
-   * Set explicit Mint object to this builder
-   * it will replace any previously existing mint
-   * NOTE! If you use `set_mint` manually - you must use `set_mint_scripts`
-   * to provide matching policy scripts or min-fee calculation will be rejected!
+   * Set explicit Mint object and the required witnesses to this builder
+   * it will replace any previously existing mint and mint scripts
+   * NOTE! Error will be returned in case a mint policy does not have a matching script
    * @param {Mint} mint
+   * @param {NativeScripts} mint_scripts
    */
-  set_mint(mint: Mint): void;
+  set_mint(mint: Mint, mint_scripts: NativeScripts): void;
 
   /**
    * Returns a copy of the current mint state in the builder
    * @returns {Mint | void}
    */
   get_mint(): Mint | void;
-
-  /**
-   * Set explicit witness set to this builder
-   * It will replace any previously existing witnesses
-   * NOTE! Use carefully! If you are using `set_mint` - then you must be using
-   * this setter as well to be able to calculate fee automatically!
-   * @param {NativeScripts} mint_scripts
-   */
-  set_mint_scripts(mint_scripts: NativeScripts): void;
 
   /**
    * Returns a copy of the current mint witness scripts in the builder

--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -5179,29 +5179,52 @@ declare export class TransactionBuilder {
   /**
    * Set explicit Mint object to this builder
    * it will replace any previously existing mint
+   * NOTE! If you use `set_mint` manually - you must use `set_mint_scripts`
+   * to provide matching policy scripts or min-fee calculation will be rejected!
    * @param {Mint} mint
    */
   set_mint(mint: Mint): void;
 
   /**
+   * Returns a copy of the current mint state in the builder
+   * @returns {Mint | void}
+   */
+  get_mint(): Mint | void;
+
+  /**
+   * Set explicit witness set to this builder
+   * It will replace any previously existing witnesses
+   * NOTE! Use carefully! If you are using `set_mint` - then you must be using
+   * this setter as well to be able to calculate fee automatically!
+   * @param {NativeScripts} mint_scripts
+   */
+  set_mint_scripts(mint_scripts: NativeScripts): void;
+
+  /**
+   * Returns a copy of the current mint witness scripts in the builder
+   * @returns {NativeScripts | void}
+   */
+  get_mint_scripts(): NativeScripts | void;
+
+  /**
    * Add a mint entry to this builder using a PolicyID and MintAssets object
    * It will be securely added to existing or new Mint in this builder
    * It will replace any existing mint assets with the same PolicyID
-   * @param {ScriptHash} policy_id
+   * @param {NativeScript} policy_script
    * @param {MintAssets} mint_assets
    */
-  set_mint_asset(policy_id: ScriptHash, mint_assets: MintAssets): void;
+  set_mint_asset(policy_script: NativeScript, mint_assets: MintAssets): void;
 
   /**
    * Add a mint entry to this builder using a PolicyID, AssetName, and Int object for amount
    * It will be securely added to existing or new Mint in this builder
    * It will replace any previous existing amount same PolicyID and AssetName
-   * @param {ScriptHash} policy_id
+   * @param {NativeScript} policy_script
    * @param {AssetName} asset_name
    * @param {Int} amount
    */
   add_mint_asset(
-    policy_id: ScriptHash,
+    policy_script: NativeScript,
     asset_name: AssetName,
     amount: Int
   ): void;
@@ -5211,14 +5234,14 @@ declare export class TransactionBuilder {
    * Using a PolicyID, AssetName, Int for amount, Address, and Coin (BigNum) objects
    * The asset will be securely added to existing or new Mint in this builder
    * A new output will be added with the specified Address, the Coin value, and the minted asset
-   * @param {ScriptHash} policy_id
+   * @param {NativeScript} policy_script
    * @param {AssetName} asset_name
    * @param {Int} amount
    * @param {Address} address
    * @param {BigNum} output_coin
    */
   add_mint_asset_and_output(
-    policy_id: ScriptHash,
+    policy_script: NativeScript,
     asset_name: AssetName,
     amount: Int,
     address: Address,
@@ -5231,13 +5254,13 @@ declare export class TransactionBuilder {
    * The asset will be securely added to existing or new Mint in this builder
    * A new output will be added with the specified Address and the minted asset
    * The output will be set to contain the minimum required amount of Coin
-   * @param {ScriptHash} policy_id
+   * @param {NativeScript} policy_script
    * @param {AssetName} asset_name
    * @param {Int} amount
    * @param {Address} address
    */
   add_mint_asset_and_output_min_required_coin(
-    policy_id: ScriptHash,
+    policy_script: NativeScript,
     asset_name: AssetName,
     amount: Int,
     address: Address
@@ -5300,14 +5323,14 @@ declare export class TransactionBuilder {
   /**
    * Returns object the body of the new transaction
    * Auxiliary data itself is not included
-   * You can use `get_auxiliary_date` or `build_tx`
+   * You can use `get_auxiliary_data` or `build_tx`
    * @returns {TransactionBody}
    */
   build(): TransactionBody;
 
   /**
    * Returns full Transaction object with the body and the auxiliary data
-   * NOTE: witness_set is set to just empty set
+   * NOTE: witness_set will contain all mint_scripts if any been added or set
    * NOTE: is_valid set to true
    * @returns {Transaction}
    */

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -34,6 +34,7 @@ use cbor_event::{
     se::{Serialize, Serializer},
 };
 
+pub mod traits;
 pub mod address;
 pub mod chain_core;
 pub mod chain_crypto;
@@ -59,6 +60,7 @@ use metadata::*;
 use utils::*;
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
+use crate::traits::NoneOrEmpty;
 
 type DeltaCoin = Int;
 
@@ -1732,6 +1734,21 @@ impl NativeScripts {
 
     pub fn add(&mut self, elem: &NativeScript) {
         self.0.push(elem.clone());
+    }
+}
+
+impl From<Vec<NativeScript>> for NativeScripts {
+    fn from(scripts: Vec<NativeScript>) -> Self {
+        scripts.iter().fold(NativeScripts::new(), |mut scripts, s| {
+            scripts.add(s);
+            scripts
+        })
+    }
+}
+
+impl NoneOrEmpty for NativeScripts {
+    fn is_none_or_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 

--- a/rust/src/traits.rs
+++ b/rust/src/traits.rs
@@ -1,0 +1,15 @@
+pub trait NoneOrEmpty {
+    fn is_none_or_empty(&self) -> bool;
+}
+
+impl<T: NoneOrEmpty> NoneOrEmpty for &T {
+    fn is_none_or_empty(&self) -> bool {
+        (*self).is_none_or_empty()
+    }
+}
+
+impl<T: NoneOrEmpty> NoneOrEmpty for Option<T> {
+    fn is_none_or_empty(&self) -> bool {
+        self.is_none() || self.as_ref().unwrap().is_none_or_empty()
+    }
+}

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -167,9 +167,13 @@ fn assert_required_mint_scripts(mint: &Mint, maybe_mint_scripts: Option<&NativeS
 }
 
 fn min_fee(tx_builder: &TransactionBuilder) -> Result<Coin, JsError> {
-    if let Some(mint) = tx_builder.mint.as_ref() {
-        assert_required_mint_scripts(mint, tx_builder.mint_scripts.as_ref())?;
-    }
+    // Commented out for performance, `min_fee` is a critical function
+    // This was mostly added here as a paranoid step anyways
+    // If someone is using `set_mint` and `add_mint*` API function, everything is expected to be intact
+    // TODO: figure out if assert is needed here and a better way to do it maybe only once if mint doesn't change
+    // if let Some(mint) = tx_builder.mint.as_ref() {
+    //     assert_required_mint_scripts(mint, tx_builder.mint_scripts.as_ref())?;
+    // }
     let full_tx = fake_full_tx(tx_builder, tx_builder.build()?)?;
     fees::min_fee(&full_tx, &tx_builder.config.fee_algo)
 }

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -304,7 +304,6 @@ pub struct TransactionBuilder {
     input_types: MockWitnessSet,
     mint: Option<Mint>,
     mint_scripts: Option<NativeScripts>,
-    inputs_auto_added: bool,
 }
 
 #[wasm_bindgen]
@@ -807,7 +806,6 @@ impl TransactionBuilder {
             validity_start_interval: None,
             mint: None,
             mint_scripts: None,
-            inputs_auto_added: false,
         }
     }
 

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -46,12 +46,6 @@ fn fake_private_key() -> Bip32PrivateKey {
     ).unwrap()
 }
 
-fn fake_key_hash() -> Ed25519KeyHash {
-    Ed25519KeyHash::from(
-        [142, 239, 181, 120, 142, 135, 19, 200, 68, 223, 211, 43, 46, 145, 222, 30, 48, 159, 239, 255, 213, 85, 248, 39, 204, 158, 225, 100]
-    )
-}
-
 fn fake_raw_key_sig() -> Ed25519Signature {
     Ed25519Signature::from_bytes(
         vec![36, 248, 153, 211, 155, 23, 253, 93, 102, 193, 146, 196, 181, 13, 52, 62, 66, 247, 35, 91, 48, 80, 76, 138, 231, 97, 159, 147, 200, 40, 220, 109, 206, 69, 104, 221, 105, 23, 124, 85, 24, 40, 73, 45, 119, 122, 103, 39, 253, 102, 194, 251, 204, 189, 168, 194, 174, 237, 146, 3, 44, 153, 121, 10]
@@ -80,7 +74,6 @@ fn count_needed_vkeys(tx_builder: &TransactionBuilder) -> usize {
 // for use in calculating the size of the final Transaction
 fn fake_full_tx(tx_builder: &TransactionBuilder, body: TransactionBody) -> Result<Transaction, JsError> {
     let fake_key_root = fake_private_key();
-    let fake_key_hash = fake_key_hash();
     let raw_key_public = fake_raw_key_public();
     let fake_sig = fake_raw_key_sig();
 
@@ -88,7 +81,6 @@ fn fake_full_tx(tx_builder: &TransactionBuilder, body: TransactionBody) -> Resul
     let vkeys = match count_needed_vkeys(tx_builder) {
         0 => None,
         x => {
-            let raw_key = fake_key_root.to_raw_key();
             let fake_vkey_witness = Vkeywitness::new(
                 &Vkey::new(&raw_key_public),
                 &fake_sig

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -64,7 +64,7 @@ fn count_needed_vkeys(tx_builder: &TransactionBuilder) -> usize {
         None => input_hashes.len(),
         Some(scripts) => {
             // Union all input keys with minting keys
-            input_hashes.union(&get_all_pubkeys_from_scripts(scripts)).count()
+            input_hashes.union(&RequiredSignersSet::from(scripts)).count()
         }
     }
 }

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -1142,6 +1142,10 @@ impl TransactionBuilder {
         }
     }
 
+    // This function should be producing the total witness-set
+    // that is created by the tx-builder itself,
+    // before the transaction is getting signed by the actual wallet.
+    // E.g. scripts or something else that has been used during the tx preparation
     fn get_witness_set(&self) -> TransactionWitnessSet {
         let mut wit = TransactionWitnessSet::new();
         if let Some(scripts) = self.mint_scripts.as_ref() {

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -711,7 +711,7 @@ impl TransactionBuilder {
             }
             witness_scripts
         };
-        self.mint = Some(mint.clone());
+        self.mint = Some(mint);
         self.mint_scripts = Some(mint_scripts.clone());
     }
 

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -3654,30 +3654,34 @@ mod tests {
         let est2 = tx_builder.min_fee();
         assert!(est2.is_ok());
 
-        // Remove one mint script
-        tx_builder.mint_scripts =
-            Some(NativeScripts::from(vec![tx_builder.mint_scripts.unwrap().get(1)]));
+        // Native script assertion has been commented out in `.min_fee`
+        // Until implemented in a more performant manner
+        // TODO: these test parts might be returned back when it's done
 
-        // Now two different policies are minted but only one witness script is present
-        let est3 = tx_builder.min_fee();
-        assert!(est3.is_err());
-        assert!(est3.err().unwrap().to_string().contains(&format!("{:?}", hex::encode(policy_id1.to_bytes()))));
-
-        // Remove all mint scripts
-        tx_builder.mint_scripts = Some(NativeScripts::new());
-
-        // Mint exists but no witness scripts at all present
-        let est4 = tx_builder.min_fee();
-        assert!(est4.is_err());
-        assert!(est4.err().unwrap().to_string().contains("witness scripts are not provided"));
-
-        // Remove all mint scripts
-        tx_builder.mint_scripts = None;
-
-        // Mint exists but no witness scripts at all present
-        let est5 = tx_builder.min_fee();
-        assert!(est5.is_err());
-        assert!(est5.err().unwrap().to_string().contains("witness scripts are not provided"));
+        // // Remove one mint script
+        // tx_builder.mint_scripts =
+        //     Some(NativeScripts::from(vec![tx_builder.mint_scripts.unwrap().get(1)]));
+        //
+        // // Now two different policies are minted but only one witness script is present
+        // let est3 = tx_builder.min_fee();
+        // assert!(est3.is_err());
+        // assert!(est3.err().unwrap().to_string().contains(&format!("{:?}", hex::encode(policy_id1.to_bytes()))));
+        //
+        // // Remove all mint scripts
+        // tx_builder.mint_scripts = Some(NativeScripts::new());
+        //
+        // // Mint exists but no witness scripts at all present
+        // let est4 = tx_builder.min_fee();
+        // assert!(est4.is_err());
+        // assert!(est4.err().unwrap().to_string().contains("witness scripts are not provided"));
+        //
+        // // Remove all mint scripts
+        // tx_builder.mint_scripts = None;
+        //
+        // // Mint exists but no witness scripts at all present
+        // let est5 = tx_builder.min_fee();
+        // assert!(est5.is_err());
+        // assert!(est5.err().unwrap().to_string().contains("witness scripts are not provided"));
     }
 
     #[test]

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -46,12 +46,6 @@ fn fake_private_key() -> Bip32PrivateKey {
     ).unwrap()
 }
 
-fn fake_key_hash(x: u8) -> Ed25519KeyHash {
-    Ed25519KeyHash::from_bytes(
-        vec![x, 239, 181, 120, 142, 135, 19, 200, 68, 223, 211, 43, 46, 145, 222, 30, 48, 159, 239, 255, 213, 85, 248, 39, 204, 158, 225, 100]
-    ).unwrap()
-}
-
 // tx_body must be the result of building from tx_builder
 // constructs the rest of the Transaction using fake witness data of the correct length
 // for use in calculating the size of the final Transaction
@@ -1168,6 +1162,12 @@ mod tests {
         // art forum devote street sure rather head chuckle guard poverty release quote oak craft enemy
         let entropy = [0x0c, 0xcb, 0x74, 0xf3, 0x6b, 0x7d, 0xa1, 0x64, 0x9a, 0x81, 0x44, 0x67, 0x55, 0x22, 0xd4, 0xd8, 0x09, 0x7c, 0x64, 0x12];
         Bip32PrivateKey::from_bip39_entropy(&entropy, &[])
+    }
+
+    fn fake_key_hash(x: u8) -> Ed25519KeyHash {
+        Ed25519KeyHash::from_bytes(
+            vec![x, 239, 181, 120, 142, 135, 19, 200, 68, 223, 211, 43, 46, 145, 222, 30, 48, 159, 239, 255, 213, 85, 248, 39, 204, 158, 225, 100]
+        ).unwrap()
     }
 
     fn harden(index: u32) -> u32 {
@@ -3501,9 +3501,9 @@ mod tests {
 
         let hash0 = fake_key_hash(0);
 
-        let (mint_script1, policy_id1, hash1) = mint_script_and_policy_and_hash(1);
-        let (mint_script2, policy_id2, hash2) = mint_script_and_policy_and_hash(2);
-        let (mint_script3, policy_id3, hash3) = mint_script_and_policy_and_hash(3);
+        let (mint_script1, _, hash1) = mint_script_and_policy_and_hash(1);
+        let (mint_script2, _, _) = mint_script_and_policy_and_hash(2);
+        let (mint_script3, _, _) = mint_script_and_policy_and_hash(3);
 
         let name1 = AssetName::new(vec![0u8, 1, 2, 3]).unwrap();
         let name2 = AssetName::new(vec![1u8, 1, 2, 3]).unwrap();
@@ -3588,7 +3588,7 @@ mod tests {
         assert!(tx_builder.min_fee().is_ok());
 
         let (mint_script1, policy_id1) = mint_script_and_policy(0);
-        let (mint_script2, policy_id2) = mint_script_and_policy(1);
+        let (mint_script2, _) = mint_script_and_policy(1);
 
         let name1 = AssetName::new(vec![0u8, 1, 2, 3]).unwrap();
         let amount = Int::new_i32(1234);


### PR DESCRIPTION
Reworked mint helper function to accept minting script instead of just the hash, and added storing these scripts in the resulting witness set