### PR TITLE
Release / 10.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "9.1.2",
+  "version": "10.0.0-beta.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "10.0.0-beta.7",
+  "version": "10.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "9.1.2",
+  "version": "10.0.0-beta.7",
   "description": "(De)serialization functions for the Cardano blockchain along with related utility functions",
   "scripts": {
     "rust:build-nodejs": "(rimraf ./rust/pkg && cd rust; wasm-pack build --target=nodejs; wasm-pack pack) && npm run js:flowgen",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "10.0.0-beta.7",
+  "version": "10.0.0-beta.8",
   "description": "(De)serialization functions for the Cardano blockchain along with related utility functions",
   "scripts": {
     "rust:build-nodejs": "(rimraf ./rust/pkg && cd rust; wasm-pack build --target=nodejs; wasm-pack pack) && npm run js:flowgen",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "cardano-serialization-lib"
-version = "10.0.0-beta.7"
+version = "10.0.0-beta.8"
 dependencies = [
  "bech32",
  "cbor_event",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -50,7 +50,7 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "cardano-serialization-lib"
-version = "9.1.2"
+version = "10.0.0-beta.7"
 dependencies = [
  "bech32",
  "cbor_event",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-serialization-lib"
-version = "9.1.2"
+version = "10.0.0-beta.7"
 edition = "2018"
 authors = ["EMURGO"]
 license = "MIT"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-serialization-lib"
-version = "10.0.0-beta.7"
+version = "10.0.0-beta.8"
 edition = "2018"
 authors = ["EMURGO"]
 license = "MIT"

--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -5179,29 +5179,52 @@ declare export class TransactionBuilder {
   /**
    * Set explicit Mint object to this builder
    * it will replace any previously existing mint
+   * NOTE! If you use `set_mint` manually - you must use `set_mint_scripts`
+   * to provide matching policy scripts or min-fee calculation will be rejected!
    * @param {Mint} mint
    */
   set_mint(mint: Mint): void;
 
   /**
+   * Returns a copy of the current mint state in the builder
+   * @returns {Mint | void}
+   */
+  get_mint(): Mint | void;
+
+  /**
+   * Set explicit witness set to this builder
+   * It will replace any previously existing witnesses
+   * NOTE! Use carefully! If you are using `set_mint` - then you must be using
+   * this setter as well to be able to calculate fee automatically!
+   * @param {NativeScripts} mint_scripts
+   */
+  set_mint_scripts(mint_scripts: NativeScripts): void;
+
+  /**
+   * Returns a copy of the current mint witness scripts in the builder
+   * @returns {NativeScripts | void}
+   */
+  get_mint_scripts(): NativeScripts | void;
+
+  /**
    * Add a mint entry to this builder using a PolicyID and MintAssets object
    * It will be securely added to existing or new Mint in this builder
    * It will replace any existing mint assets with the same PolicyID
-   * @param {ScriptHash} policy_id
+   * @param {NativeScript} policy_script
    * @param {MintAssets} mint_assets
    */
-  set_mint_asset(policy_id: ScriptHash, mint_assets: MintAssets): void;
+  set_mint_asset(policy_script: NativeScript, mint_assets: MintAssets): void;
 
   /**
    * Add a mint entry to this builder using a PolicyID, AssetName, and Int object for amount
    * It will be securely added to existing or new Mint in this builder
    * It will replace any previous existing amount same PolicyID and AssetName
-   * @param {ScriptHash} policy_id
+   * @param {NativeScript} policy_script
    * @param {AssetName} asset_name
    * @param {Int} amount
    */
   add_mint_asset(
-    policy_id: ScriptHash,
+    policy_script: NativeScript,
     asset_name: AssetName,
     amount: Int
   ): void;
@@ -5211,14 +5234,14 @@ declare export class TransactionBuilder {
    * Using a PolicyID, AssetName, Int for amount, Address, and Coin (BigNum) objects
    * The asset will be securely added to existing or new Mint in this builder
    * A new output will be added with the specified Address, the Coin value, and the minted asset
-   * @param {ScriptHash} policy_id
+   * @param {NativeScript} policy_script
    * @param {AssetName} asset_name
    * @param {Int} amount
    * @param {Address} address
    * @param {BigNum} output_coin
    */
   add_mint_asset_and_output(
-    policy_id: ScriptHash,
+    policy_script: NativeScript,
     asset_name: AssetName,
     amount: Int,
     address: Address,
@@ -5231,13 +5254,13 @@ declare export class TransactionBuilder {
    * The asset will be securely added to existing or new Mint in this builder
    * A new output will be added with the specified Address and the minted asset
    * The output will be set to contain the minimum required amount of Coin
-   * @param {ScriptHash} policy_id
+   * @param {NativeScript} policy_script
    * @param {AssetName} asset_name
    * @param {Int} amount
    * @param {Address} address
    */
   add_mint_asset_and_output_min_required_coin(
-    policy_id: ScriptHash,
+    policy_script: NativeScript,
     asset_name: AssetName,
     amount: Int,
     address: Address
@@ -5300,14 +5323,14 @@ declare export class TransactionBuilder {
   /**
    * Returns object the body of the new transaction
    * Auxiliary data itself is not included
-   * You can use `get_auxiliary_date` or `build_tx`
+   * You can use `get_auxiliary_data` or `build_tx`
    * @returns {TransactionBody}
    */
   build(): TransactionBody;
 
   /**
    * Returns full Transaction object with the body and the auxiliary data
-   * NOTE: witness_set is set to just empty set
+   * NOTE: witness_set will contain all mint_scripts if any been added or set
    * NOTE: is_valid set to true
    * @returns {Transaction}
    */

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -46,12 +46,6 @@ fn fake_private_key() -> Bip32PrivateKey {
     ).unwrap()
 }
 
-fn fake_key_hash(x: u8) -> Ed25519KeyHash {
-    Ed25519KeyHash::from_bytes(
-        vec![x, 239, 181, 120, 142, 135, 19, 200, 68, 223, 211, 43, 46, 145, 222, 30, 48, 159, 239, 255, 213, 85, 248, 39, 204, 158, 225, 100]
-    ).unwrap()
-}
-
 // tx_body must be the result of building from tx_builder
 // constructs the rest of the Transaction using fake witness data of the correct length
 // for use in calculating the size of the final Transaction
@@ -1168,6 +1162,12 @@ mod tests {
         // art forum devote street sure rather head chuckle guard poverty release quote oak craft enemy
         let entropy = [0x0c, 0xcb, 0x74, 0xf3, 0x6b, 0x7d, 0xa1, 0x64, 0x9a, 0x81, 0x44, 0x67, 0x55, 0x22, 0xd4, 0xd8, 0x09, 0x7c, 0x64, 0x12];
         Bip32PrivateKey::from_bip39_entropy(&entropy, &[])
+    }
+
+    fn fake_key_hash(x: u8) -> Ed25519KeyHash {
+        Ed25519KeyHash::from_bytes(
+            vec![x, 239, 181, 120, 142, 135, 19, 200, 68, 223, 211, 43, 46, 145, 222, 30, 48, 159, 239, 255, 213, 85, 248, 39, 204, 158, 225, 100]
+        ).unwrap()
     }
 
     fn harden(index: u32) -> u32 {
@@ -3501,9 +3501,9 @@ mod tests {
 
         let hash0 = fake_key_hash(0);
 
-        let (mint_script1, policy_id1, hash1) = mint_script_and_policy_and_hash(1);
-        let (mint_script2, policy_id2, hash2) = mint_script_and_policy_and_hash(2);
-        let (mint_script3, policy_id3, hash3) = mint_script_and_policy_and_hash(3);
+        let (mint_script1, _, hash1) = mint_script_and_policy_and_hash(1);
+        let (mint_script2, _, _) = mint_script_and_policy_and_hash(2);
+        let (mint_script3, _, _) = mint_script_and_policy_and_hash(3);
 
         let name1 = AssetName::new(vec![0u8, 1, 2, 3]).unwrap();
         let name2 = AssetName::new(vec![1u8, 1, 2, 3]).unwrap();
@@ -3588,7 +3588,7 @@ mod tests {
         assert!(tx_builder.min_fee().is_ok());
 
         let (mint_script1, policy_id1) = mint_script_and_policy(0);
-        let (mint_script2, policy_id2) = mint_script_and_policy(1);
+        let (mint_script2, _) = mint_script_and_policy(1);
 
         let name1 = AssetName::new(vec![0u8, 1, 2, 3]).unwrap();
         let amount = Int::new_i32(1234);


### PR DESCRIPTION
Milestone: https://github.com/Emurgo/cardano-serialization-lib/milestone/5?closed=1

# Breaking Changes

## 1. Old protocol param `minimum_utxo_val` is replaced with `coins_per_utxo_word` (#219 #248)

The TransactionBuilder and the `min_ada_required` function now require new value introduced in Alonzo: **coins per utxo word**, see spec from IOHK: https://github.com/input-output-hk/cardano-ledger/blob/master/doc/explanations/min-utxo-alonzo.rst

The mainnet value for this at the moment is `34_482` (lovelaces).

The `min_ada_required` function API changed from two required arguments to three: the `Value` to be estimated, the boolean flag `has_data_hash` (`// whether the output includes a plutus data hash`), and the `coins_per_utxo_word` as `BigNum`.

## 2. TransactionBuilder construction API changed (#261 #269 #270)

The list of arguments is replaced with a new config struct and the config-builder, see example of the new usage in Rust here: https://github.com/Emurgo/cardano-serialization-lib/blob/master/rust/src/tx_builder.rs#L1144-L1153

In JS it's something like:
```
    RustModule.TransactionBuilder.new(
      RustModule.TransactionBuilderConfigBuilder.new()
        .fee_algo(linearFee)
        .pool_deposit(poolDeposit)
        .key_deposit(keyDeposit)
        .coins_per_utxo_word(coinsPerUtxoWord)
        .max_value_size(maxValueBytes)
        .max_tx_size(maxTxBytes)
        .build()
    );
```

## 3. Field replacement in ConstrPlutusData (#250)

The `ConstrPlutusData` field `tag: Int` is replaced to be `alternative: BigNum`

## 4. NativeScript hash return type fixed (#234)

The function `ScriptHash.hash` return type changed from incorrect `Ed25519KeyHash` to correct `ScriptHash`. They are both defined as 28-byte hash types, so functionally there's no fifference but type-checking might fail in strict systems if the incorrect type were used on the client side.

# New API features

## 1. Minting in TransactionBuilder (#231 #273)

The `Mint` is now can be set to the tx-builder using new `.set_mint` function, but this requires additional manual handling of witness scripts for minting using the new `.set_mint_scripts` function. **If the fee estimation is attempted without having all matching witness scripts for each used policy-id in the mint - an error will be raised** as the correct estimation is not possible. You can still use Mint without providing witness scripts and use automatic change calculation if you set the fee value manually.

Instead, new helper functions can be used: `.set_mint_asset`, `.add_mint_asset`, `.add_mint_asset_and_output`, `.add_mint_asset_and_output_min_required_coin`. These function take the minting script itself instead of just the policy-id and they both produce the correct mint entry with the policy-id **AND include the minting script into the list of witnesses** so that the correct fee estimation is possible. The `*_and_output` functions additionally produce a new output specifically for this new minted asset and either include the specified ADA value or automatically calculate and include the minimum required ADA value.

**NOTE:** added mint is correctly considered as part of the total input so if you don't send it to any explicit output and calculate the change - it will be added to the change output.

## 2. Metadata in TransactionBuilder (#231)

Few new helper functions for easier metadata handling: `.set_metadata`, `.add_metadatum`, `.add_json_metadatum`, `.add_json_metadatum_with_schema`. The `set` function overwrites the existing value. All `add_*` functions are null-secure, meaning that in case the auxiliary data or the metadata does not exist yet - it will be safely created and then the new entry will be added to it.

## 3. Building full Tx in TransactionBuilder (#231)

New function `.build_tx()` is added which produces an instance of the full `Transaction`, compared to the existing `.build()` which returns only the `TransactionBody`. The important difference is that the full returned `Transaction` contains the `witness_set` **which will already include all the native scripts if minting were added**, plus it contains the `auxiliary_data` in case the metadata were added, and the validity flag for better compatibility with Alonzo.

If NO minting and no metadata were used - there's not much difference which variant to use. **But if minting and/or metadata were added - then it is much more recommended to use `.build_tx()` and then only add vkey witnesses into the existing `witness_set` after signing the transaction.**

## 4. Coin-selection in TransactionBuilder (#232 #253 #254 #264)

New function `.add_inputs_from` is now available which takes an array of available utxo and allows to select the selection strategy: largest-first or random-improve (see [CIP2](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0002)), the function will try to select enough utxo to add them as inputs to cover the required outputs and the fees, which is why it is better to call this function after all target outputs, the mint, and the metadata are added, and before calling `.add_change_if_needed`.

## 5. PrivateKey from bech32 (#244 #245)

New construction option `PrivateKey::from_bech32` is now available

## 6. Cardano-wallet style multisig (#221)

New function are now available to create multisig scripts as supported by cardano-wallet, independent to [CIP29](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0029).

## 7. Deprecated `Int.as_i32` (#258)

Function `Int.as_i32()` is deprecated because it silently ignores potential overflow errors and does not indicate it with the name that well. New functions added: `.as_i32_or_nothing()` which does the same thing and `.as_i32_or_fail()` which potentially returns an error.

Additionally new function `Int.to_str` is added, which produces normal decimal string rendering of the underlying i128. Without that function before clients were forced to either use `as_i32` or use the awkward BigNum conversion API which requires to do a positive/negative check first.

# Internal improvements

1. More secure change with assets with breaking same-policy bundles into multiple outputs if needed (#236)
2. Plutus data serialisation fixes (#228) 
3. Plutus hash script data fixes (#217)
4. Asset size calculation fixed to reduce the min-required-ada for utxo a bit (#211)