### PR TITLE
Add Witness builder

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -251,10 +251,13 @@ declare export var NativeScriptKind: {|
  * This is because you could have a language where the same bytes have different semantics
  * So this avoids scripts in different languages mapping to the same hash
  * Note that the enum value here is different than the enum value for deciding the cost model of a script
+ * https://github.com/input-output-hk/cardano-ledger/blob/9c3b4737b13b30f71529e76c5330f403165e28a6/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs#L127
  */
 
 declare export var ScriptHashNamespace: {|
   +NativeScript: 0, // 0
+  +PlutusV1: 1, // 1
+  +PlutusV2: 2, // 2
 |};
 
 /**
@@ -278,6 +281,7 @@ declare export var StakeCredKind: {|
 
 declare export var LanguageKind: {|
   +PlutusV1: 0, // 0
+  +PlutusV2: 1, // 1
 |};
 
 /**
@@ -2174,6 +2178,11 @@ declare export class Language {
   static new_plutus_v1(): Language;
 
   /**
+   * @returns {Language}
+   */
+  static new_plutus_v2(): Language;
+
+  /**
    * @returns {number}
    */
   kind(): number;
@@ -3114,6 +3123,12 @@ declare export class PlutusScript {
    * @returns {PlutusScript}
    */
   static from_bytes(bytes: Uint8Array): PlutusScript;
+
+  /**
+   * @param {number} namespace
+   * @returns {ScriptHash}
+   */
+  hash(namespace: number): ScriptHash;
 
   /**
    * @param {Uint8Array} bytes
@@ -5820,6 +5835,60 @@ declare export class TransactionWitnessSet {
    * @returns {TransactionWitnessSet}
    */
   static new(): TransactionWitnessSet;
+}
+/**
+ * Builder de-duplicates witnesses as they are added
+ */
+declare export class TransactionWitnessSetBuilder {
+  free(): void;
+
+  /**
+   * @param {Vkeywitness} vkey
+   */
+  add_vkey(vkey: Vkeywitness): void;
+
+  /**
+   * @param {BootstrapWitness} bootstrap
+   */
+  add_bootstrap(bootstrap: BootstrapWitness): void;
+
+  /**
+   * @param {NativeScript} native_script
+   */
+  add_native_script(native_script: NativeScript): void;
+
+  /**
+   * @param {PlutusScript} plutus_script
+   */
+  add_plutus_script(plutus_script: PlutusScript): void;
+
+  /**
+   * @param {PlutusData} plutus_datum
+   */
+  add_plutus_datum(plutus_datum: PlutusData): void;
+
+  /**
+   * @param {Redeemer} redeemer
+   */
+  add_redeemer(redeemer: Redeemer): void;
+
+  /**
+   * @returns {TransactionWitnessSetBuilder}
+   */
+  static new(): TransactionWitnessSetBuilder;
+
+  /**
+   * @param {TransactionWitnessSet} wit_set
+   * @returns {TransactionWitnessSetBuilder}
+   */
+  static from_existing(
+    wit_set: TransactionWitnessSet
+  ): TransactionWitnessSetBuilder;
+
+  /**
+   * @returns {TransactionWitnessSet}
+   */
+  build(): TransactionWitnessSet;
 }
 /**
  */

--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -283,7 +283,7 @@ impl PrivateKey {
 
 /// ED25519 key used as public key
 #[wasm_bindgen]
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PublicKey(crypto::PublicKey<crypto::Ed25519>);
 
 impl From<crypto::PublicKey<crypto::Ed25519>> for PublicKey {
@@ -329,7 +329,7 @@ impl PublicKey {
 }
 
 #[wasm_bindgen]
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Vkey(PublicKey);
 
 to_from_bytes!(Vkey);
@@ -471,7 +471,7 @@ impl Deserialize for Vkeywitness {
 
 #[wasm_bindgen]
 #[derive(Clone)]
-pub struct Vkeywitnesses(Vec<Vkeywitness>);
+pub struct Vkeywitnesses(pub (crate) Vec<Vkeywitness>);
 
 #[wasm_bindgen]
 impl Vkeywitnesses {
@@ -613,7 +613,7 @@ impl DeserializeEmbeddedGroup for BootstrapWitness {
 
 #[wasm_bindgen]
 #[derive(Clone)]
-pub struct BootstrapWitnesses(Vec<BootstrapWitness>);
+pub struct BootstrapWitnesses(pub (crate) Vec<BootstrapWitness>);
 
 #[wasm_bindgen]
 impl BootstrapWitnesses {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -50,6 +50,7 @@ pub mod typed_bytes;
 pub mod emip3;
 #[macro_use]
 pub mod utils;
+pub mod witness_builder;
 
 use address::*;
 use crypto::*;
@@ -1613,24 +1614,10 @@ pub struct NativeScript(NativeScriptEnum);
 
 to_from_bytes!(NativeScript);
 
-/// Each new language uses a different namespace for hashing its script
-/// This is because you could have a language where the same bytes have different semantics
-/// So this avoids scripts in different languages mapping to the same hash
-/// Note that the enum value here is different than the enum value for deciding the cost model of a script
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub enum ScriptHashNamespace {
-    NativeScript,
-    // TODO: do we need to update this for Plutus?
-}
-
 #[wasm_bindgen]
 impl NativeScript {
     pub fn hash(&self, namespace: ScriptHashNamespace) -> ScriptHash {
-        let mut bytes = Vec::with_capacity(self.to_bytes().len() + 1);
-        bytes.extend_from_slice(&vec![namespace as u8]);
-        bytes.extend_from_slice(&self.to_bytes());
-        ScriptHash::from(blake2b224(bytes.as_ref()))
+        hash_script(namespace, self.to_bytes())
     }
 
     pub fn new_script_pubkey(script_pubkey: &ScriptPubkey) -> Self {

--- a/rust/src/plutus.rs
+++ b/rust/src/plutus.rs
@@ -15,6 +15,10 @@ to_from_bytes!(PlutusScript);
 
 #[wasm_bindgen]
 impl PlutusScript {
+    pub fn hash(&self, namespace: ScriptHashNamespace) -> ScriptHash {
+        hash_script(namespace, self.to_bytes())
+    }
+
     pub fn new(bytes: Vec<u8>) -> PlutusScript {
         Self(bytes)
     }
@@ -26,7 +30,7 @@ impl PlutusScript {
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct PlutusScripts(Vec<PlutusScript>);
+pub struct PlutusScripts(pub (crate) Vec<PlutusScript>);
 
 to_from_bytes!(PlutusScripts);
 
@@ -258,6 +262,7 @@ impl ExUnits {
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum LanguageKind {
     PlutusV1,
+    PlutusV2,
 }
 
 #[wasm_bindgen]
@@ -269,6 +274,10 @@ to_from_bytes!(Language);
 #[wasm_bindgen]
 impl Language {
     pub fn new_plutus_v1() -> Self {
+        Self(LanguageKind::PlutusV1)
+    }
+
+    pub fn new_plutus_v2() -> Self {
         Self(LanguageKind::PlutusV1)
     }
 
@@ -424,7 +433,7 @@ impl PlutusData {
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct PlutusList(Vec<PlutusData>);
+pub struct PlutusList(pub (crate) Vec<PlutusData>);
 
 to_from_bytes!(PlutusList);
 
@@ -487,7 +496,7 @@ impl Redeemer {
 }
 
 #[wasm_bindgen]
-#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub enum RedeemerTagKind {
     Spend,
     Mint,
@@ -496,7 +505,7 @@ pub enum RedeemerTagKind {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct RedeemerTag(RedeemerTagKind);
 
 to_from_bytes!(RedeemerTag);
@@ -526,7 +535,7 @@ impl RedeemerTag {
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Redeemers(Vec<Redeemer>);
+pub struct Redeemers(pub (crate) Vec<Redeemer>);
 
 to_from_bytes!(Redeemers);
 
@@ -831,6 +840,9 @@ impl cbor_event::se::Serialize for Language {
         match self.0 {
             LanguageKind::PlutusV1 => {
                 serializer.write_unsigned_integer(0u64)
+            },
+            LanguageKind::PlutusV2 => {
+                serializer.write_unsigned_integer(1u64)
             },
         }
     }

--- a/rust/src/witness_builder.rs
+++ b/rust/src/witness_builder.rs
@@ -1,0 +1,225 @@
+use std::collections::HashMap;
+use super::*;
+
+/// Builder de-duplicates witnesses as they are added 
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct TransactionWitnessSetBuilder {
+    // See Alonzo spec section 3.1 which defines the keys for these types
+    vkeys: HashMap<Vkey, Vkeywitness>,
+    bootstraps: HashMap<Vkey, BootstrapWitness>,
+    native_scripts: HashMap<ScriptHash, NativeScript>,
+    plutus_scripts: HashMap<ScriptHash, PlutusScript>,
+    plutus_data: HashMap<DataHash, PlutusData>,
+    redeemers: HashMap<RedeemerTag, Redeemer>,
+}
+
+#[wasm_bindgen]
+impl TransactionWitnessSetBuilder {
+    pub fn add_vkey(&mut self, vkey: &Vkeywitness) {
+        self.vkeys.insert(vkey.vkey(), vkey.clone());
+    }
+
+    pub fn add_bootstrap(&mut self, bootstrap: &BootstrapWitness) {
+        self.bootstraps.insert(bootstrap.vkey(), bootstrap.clone());
+    }
+
+    pub fn add_native_script(&mut self, native_script: &NativeScript) {
+        self.native_scripts.insert(native_script.hash(ScriptHashNamespace::NativeScript), native_script.clone());
+    }
+
+    pub fn add_plutus_script(&mut self, plutus_script: &PlutusScript) {
+        // TODO: don't assume PlutusV1 and instead somehow calculate this
+        self.plutus_scripts.insert(plutus_script.hash(ScriptHashNamespace::PlutusV1), plutus_script.clone());
+    }
+
+    pub fn add_plutus_datum(&mut self, plutus_datum: &PlutusData) {
+        self.plutus_data.insert(hash_plutus_data(&plutus_datum), plutus_datum.clone());
+    }
+
+    pub fn add_redeemer(&mut self, redeemer: &Redeemer) {
+        self.redeemers.insert(redeemer.tag().clone(), redeemer.clone());
+    }
+
+    pub fn new() -> Self {
+        Self {
+            vkeys: HashMap::new(),
+            bootstraps: HashMap::new(),
+            native_scripts: HashMap::new(),
+            plutus_scripts: HashMap::new(),
+            plutus_data: HashMap::new(),
+            redeemers: HashMap::new(),
+        }
+    }
+
+    pub fn from_existing(wit_set: &TransactionWitnessSet) -> Self {
+        let mut builder = TransactionWitnessSetBuilder::new();
+        match &wit_set.vkeys() {
+            None => (),
+            Some(vkeys) => vkeys.0.iter().for_each(|vkey| { builder.add_vkey(vkey); } ),
+        };
+        match &wit_set.bootstraps() {
+            None => (),
+            Some(bootstraps) => bootstraps.0.iter().for_each(|bootstrap| { builder.add_bootstrap(bootstrap); } ),
+        };
+        match &wit_set.native_scripts() {
+            None => (),
+            Some(native_scripts) => native_scripts.0.iter().for_each(|native_script| { builder.add_native_script(native_script); } ),
+        };
+        match &wit_set.plutus_scripts() {
+            None => (),
+            Some(plutus_scripts) => plutus_scripts.0.iter().for_each(|plutus_script| { builder.add_plutus_script(plutus_script); } ),
+        };
+        match &wit_set.plutus_data() {
+            None => (),
+            Some(plutus_data) => plutus_data.0.iter().for_each(|plutus_datum| { builder.add_plutus_datum(plutus_datum); } ),
+        };
+        match &wit_set.redeemers() {
+            None => (),
+            Some(redeemers) => redeemers.0.iter().for_each(|redeemer| { builder.add_redeemer(redeemer); } ),
+        };
+
+        builder
+    }
+
+    pub fn build(&self) -> TransactionWitnessSet {
+        let mut result = TransactionWitnessSet::new();
+        
+        if self.vkeys.len() > 0 {
+            result.set_vkeys(&Vkeywitnesses(self.vkeys.values().cloned().collect()));
+        }
+        if self.bootstraps.len() > 0 {
+            result.set_bootstraps(&BootstrapWitnesses(self.bootstraps.values().cloned().collect()));
+        }
+        if self.native_scripts.len() > 0 {
+            result.set_native_scripts(&NativeScripts(self.native_scripts.values().cloned().collect()));
+        }
+        if self.plutus_scripts.len() > 0 {
+            result.set_plutus_scripts(&PlutusScripts(self.plutus_scripts.values().cloned().collect()));
+        }
+        if self.plutus_data.len() > 0 {
+            result.set_plutus_data(&PlutusList(self.plutus_data.values().cloned().collect()));
+        }
+        if self.redeemers.len() > 0 {
+            result.set_redeemers(&Redeemers(self.redeemers.values().cloned().collect()));
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_raw_key_sig(id: u8) -> Ed25519Signature {
+        Ed25519Signature::from_bytes(
+            vec![id, 248, 153, 211, 155, 23, 253, 93, 102, 193, 146, 196, 181, 13, 52, 62, 66, 247, 35, 91, 48, 80, 76, 138, 231, 97, 159, 147, 200, 40, 220, 109, 206, 69, 104, 221, 105, 23, 124, 85, 24, 40, 73, 45, 119, 122, 103, 39, 253, 102, 194, 251, 204, 189, 168, 194, 174, 237, 146, 3, 44, 153, 121, 10]
+        ).unwrap()
+    }
+    
+    fn fake_raw_key_public(id: u8) -> PublicKey {
+        PublicKey::from_bytes(
+            &[id, 118, 57, 154, 33, 13, 232, 114, 14, 159, 168, 148, 228, 94, 65, 226, 154, 181, 37, 227, 11, 196, 2, 128, 28, 7, 98, 80, 209, 88, 91, 205]
+        ).unwrap()
+    }
+
+    fn fake_private_key1() -> Bip32PrivateKey {
+        Bip32PrivateKey::from_bytes(
+            &[0xb8, 0xf2, 0xbe, 0xce, 0x9b, 0xdf, 0xe2, 0xb0, 0x28, 0x2f, 0x5b, 0xad, 0x70, 0x55, 0x62, 0xac, 0x99, 0x6e, 0xfb, 0x6a, 0xf9, 0x6b, 0x64, 0x8f,
+                0x44, 0x45, 0xec, 0x44, 0xf4, 0x7a, 0xd9, 0x5c, 0x10, 0xe3, 0xd7, 0x2f, 0x26, 0xed, 0x07, 0x54, 0x22, 0xa3, 0x6e, 0xd8, 0x58, 0x5c, 0x74, 0x5a,
+                0x0e, 0x11, 0x50, 0xbc, 0xce, 0xba, 0x23, 0x57, 0xd0, 0x58, 0x63, 0x69, 0x91, 0xf3, 0x8a, 0x37, 0x91, 0xe2, 0x48, 0xde, 0x50, 0x9c, 0x07, 0x0d,
+                0x81, 0x2a, 0xb2, 0xfd, 0xa5, 0x78, 0x60, 0xac, 0x87, 0x6b, 0xc4, 0x89, 0x19, 0x2c, 0x1e, 0xf4, 0xce, 0x25, 0x3c, 0x19, 0x7e, 0xe2, 0x19, 0xa4]
+        ).unwrap()
+    }
+
+    fn fake_private_key2() -> Bip32PrivateKey {
+        Bip32PrivateKey::from_bytes(
+            &hex::decode("d84c65426109a36edda5375ea67f1b738e1dacf8629f2bb5a2b0b20f3cd5075873bf5cdfa7e533482677219ac7d639e30a38e2e645ea9140855f44ff09e60c52c8b95d0d35fe75a70f9f5633a3e2439b2994b9e2bc851c49e9f91d1a5dcbb1a3").unwrap()
+        ).unwrap()
+    }
+    
+
+    #[test]
+    fn vkey_test() {
+        let mut builder = TransactionWitnessSetBuilder::new();
+        
+        let raw_key_public = fake_raw_key_public(0);
+        let fake_sig = fake_raw_key_sig(0);
+
+        // add the same element twice
+        builder.add_vkey(&Vkeywitness::new(
+            &Vkey::new(&raw_key_public),
+            &fake_sig
+        ));
+        builder.add_vkey(&Vkeywitness::new(
+            &Vkey::new(&raw_key_public),
+            &fake_sig
+        ));
+
+        // add a different element
+        builder.add_vkey(&Vkeywitness::new(
+            &Vkey::new(&fake_raw_key_public(1)),
+            &fake_raw_key_sig(1)
+        ));
+
+        let wit_set = builder.build();
+        assert_eq!(
+            wit_set.vkeys().unwrap().len(),
+            2
+        );
+    }
+
+    #[test]
+    fn bootstrap_test() {
+        let mut builder = TransactionWitnessSetBuilder::new();
+
+        // add the same element twice
+        let wit1 = make_icarus_bootstrap_witness(
+            &TransactionHash::from([0u8; TransactionHash::BYTE_COUNT]),
+            &ByronAddress::from_base58("Ae2tdPwUPEZGUEsuMAhvDcy94LKsZxDjCbgaiBBMgYpR8sKf96xJmit7Eho").unwrap(),
+            &fake_private_key1()
+        );
+        builder.add_bootstrap(&wit1);
+        builder.add_bootstrap(&wit1);
+
+        // add a different element
+        builder.add_bootstrap(&make_icarus_bootstrap_witness(
+            &TransactionHash::from([0u8; TransactionHash::BYTE_COUNT]),
+            &ByronAddress::from_base58("Ae2tdPwUPEZGUEsuMAhvDcy94LKsZxDjCbgaiBBMgYpR8sKf96xJmit7Eho").unwrap(),
+            &fake_private_key2()
+        ));
+
+        let wit_set = builder.build();
+        assert_eq!(
+            wit_set.bootstraps().unwrap().len(),
+            2
+        );
+    }
+
+    #[test]
+    fn native_script_test() {
+        let mut builder = TransactionWitnessSetBuilder::new();
+
+        // add the same element twice
+        let wit1 = NativeScript::new_timelock_start(
+            &TimelockStart::new(1),
+        );
+        builder.add_native_script(&wit1);
+        builder.add_native_script(&wit1);
+
+        // add a different element
+        builder.add_native_script(&NativeScript::new_timelock_start(
+            &TimelockStart::new(2),
+        ));
+
+        let wit_set = builder.build();
+        assert_eq!(
+            wit_set.native_scripts().unwrap().len(),
+            2
+        );
+    }
+
+    // TODO: tests for plutus_scripts, plutus_data, redeemers
+    // once we have mock data for them
+}


### PR DESCRIPTION
The problem with `TransactionWitnessSet` is that at the protocol level it should be a set, but at the CDDL level it's just a list. This means it's up to individual implementations to de-duplication which is not ideal.

This PR adds a TransactionWitnessSetBuilder which handles the deduplication for you. It's a first step to #37 and can also help with #273 