### PR TITLE
Fix link to documentation

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 authors = ["EMURGO"]
 license = "MIT"
 description = "(De)serialization functions for the Cardano blockchain along with related utility functions"
-documentation = "https://docs.cardano.org/projects/cardano-serialization-lib/en/latest/"
+documentation = "https://docs.cardano.org/cardano-components/cardano-serialization-lib"
 repository = "https://github.com/Emurgo/cardano-serialization-lib"
 exclude = [
     "pkg/*",


### PR DESCRIPTION
This fixes the documentation link at: https://crates.io/crates/cardano-serialization-lib