### PR TITLE
TransactionOutputBuilder - Argument order fix

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -5707,13 +5707,13 @@ declare export class TransactionOutputAmountBuilder {
   ): TransactionOutputAmountBuilder;
 
   /**
-   * @param {BigNum} coins_per_utxo_word
    * @param {MultiAsset} multiasset
+   * @param {BigNum} coins_per_utxo_word
    * @returns {TransactionOutputAmountBuilder}
    */
   with_asset_and_min_required_coin(
-    coins_per_utxo_word: BigNum,
-    multiasset: MultiAsset
+    multiasset: MultiAsset,
+    coins_per_utxo_word: BigNum
   ): TransactionOutputAmountBuilder;
 
   /**

--- a/rust/src/output_builder.rs
+++ b/rust/src/output_builder.rs
@@ -76,7 +76,7 @@ impl TransactionOutputAmountBuilder {
         cfg
     }
 
-    pub fn with_asset_and_min_required_coin(&self, coins_per_utxo_word: &Coin, multiasset: &MultiAsset) -> Result<TransactionOutputAmountBuilder, JsError> {
+    pub fn with_asset_and_min_required_coin(&self, multiasset: &MultiAsset, coins_per_utxo_word: &Coin) -> Result<TransactionOutputAmountBuilder, JsError> {
         let min_possible_coin = min_pure_ada(&coins_per_utxo_word, self.data_hash.is_some())?;
         let mut value = Value::new(&min_possible_coin);
         value.set_multiasset(multiasset);

--- a/rust/src/tx_builder.rs
+++ b/rust/src/tx_builder.rs
@@ -897,7 +897,7 @@ impl TransactionBuilder {
         ).as_positive_multiasset();
 
         self.add_output(&output_builder
-            .with_asset_and_min_required_coin(&self.config.coins_per_utxo_word, &multiasset)?
+            .with_asset_and_min_required_coin(&multiasset, &self.config.coins_per_utxo_word)?
             .build()?
         )
     }
@@ -3862,7 +3862,7 @@ mod tests {
             &TransactionOutputBuilder::new()
                 .with_address(&address)
                 .next().unwrap()
-                .with_asset_and_min_required_coin(&tx_builder.config.coins_per_utxo_word, &multiasset).unwrap()
+                .with_asset_and_min_required_coin(&multiasset, &tx_builder.config.coins_per_utxo_word).unwrap()
                 .build().unwrap()
             ).unwrap();
 


### PR DESCRIPTION
Changed the `with_asset_and_min_required_coin` arguments from `(Coin, MultiAsset)` to `(MultiAsset, Coin)` to not match other functions and make it harder to confuse them, cuz other `(Coin, MultiAsset)` functions mean the `Coin` as the output value, and in this case the `Coin` is a protocol parameter.