### PR TITLE
[10.0.3] Added function `NativeScript.get_required_signers()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "description": "(De)serialization functions for the Cardano blockchain along with related utility functions",
   "scripts": {
     "rust:build-nodejs": "(rimraf ./rust/pkg && cd rust; wasm-pack build --target=nodejs; wasm-pack pack) && npm run js:flowgen",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -52,7 +52,7 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "cardano-serialization-lib"
-version = "10.0.2"
+version = "10.0.3"
 dependencies = [
  "bech32",
  "cbor_event",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-serialization-lib"
-version = "10.0.2"
+version = "10.0.3"
 edition = "2018"
 authors = ["EMURGO"]
 license = "MIT"

--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -2800,6 +2800,9 @@ declare export class NativeScript {
   as_timelock_expiry(): TimelockExpiry | void;
 
   /**
+   * Returns an array of unique Ed25519KeyHashes
+   * contained within this script recursively on any depth level.
+   * The order of the keys in the result is not determined in any way.
    * @returns {Ed25519KeyHashes}
    */
   get_required_signers(): Ed25519KeyHashes;

--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -2798,6 +2798,11 @@ declare export class NativeScript {
    * @returns {TimelockExpiry | void}
    */
   as_timelock_expiry(): TimelockExpiry | void;
+
+  /**
+   * @returns {Ed25519KeyHashes}
+   */
+  get_required_signers(): Ed25519KeyHashes;
 }
 /**
  */

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1724,6 +1724,13 @@ impl NativeScript {
             _ => None,
         }
     }
+
+    pub fn get_required_signers(&self) -> RequiredSigners {
+        Ed25519KeyHashes(
+            RequiredSignersSet::from(self).iter()
+                .map(|k| { k.clone() }).collect()
+        )
+    }
 }
 
 #[wasm_bindgen]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1725,7 +1725,10 @@ impl NativeScript {
         }
     }
 
-    pub fn get_required_signers(&self) -> RequiredSigners {
+    /// Returns an array of unique Ed25519KeyHashes
+    /// contained within this script recursively on any depth level.
+    /// The order of the keys in the result is not determined in any way.
+    pub fn get_required_signers(&self) -> Ed25519KeyHashes {
         Ed25519KeyHashes(
             RequiredSignersSet::from(self).iter()
                 .map(|k| { k.clone() }).collect()


### PR DESCRIPTION
The new function returns an array of all **unique** key-hashes used in the script **recursively**. So e.g.

```
All(
  Key(X),
  Any(
    Key(Y),
    TimelockExpiry(42),
  )
)
```

Calling `get_required_signers()` on the top script will return `[X, Y]` (the order is not guaranteed in any way).