### PR TITLE
Fix: nint deserialization below i64::MIN

### DIFF
--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -582,6 +582,8 @@ impl Deserialize for Int {
     }
 }
 
+/// TODO: this function can be removed in case `cbor_event` library ever gets a fix on their side
+/// See https://github.com/Emurgo/cardano-serialization-lib/pull/392
 fn read_nint<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result <i128, DeserializeError> {
     let found = raw.cbor_type()?;
     if found != cbor_event::Type::NegativeInteger {

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -479,6 +479,8 @@ impl Deserialize for Value {
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Int(pub (crate) i128);
 
+to_from_bytes!(Int);
+
 #[wasm_bindgen]
 impl Int {
     pub fn new(x: &BigNum) -> Self {
@@ -573,10 +575,25 @@ impl Deserialize for Int {
         (|| -> Result<_, DeserializeError> {
             match raw.cbor_type()? {
                 cbor_event::Type::UnsignedInteger => Ok(Self(raw.unsigned_integer()? as i128)),
-                cbor_event::Type::NegativeInteger => Ok(Self(raw.negative_integer()? as i128)),
+                cbor_event::Type::NegativeInteger => Ok(Self(read_nint(raw)?)),
                 _ => Err(DeserializeFailure::NoVariantMatched.into()),
             }
         })().map_err(|e| e.annotate("Int"))
+    }
+}
+
+fn read_nint<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result <i128, DeserializeError> {
+    let found = raw.cbor_type()?;
+    if found != cbor_event::Type::NegativeInteger {
+        return Err(cbor_event::Error::Expected(cbor_event::Type::NegativeInteger, found).into());
+    }
+    let (len, len_sz) = raw.cbor_len()?;
+    match len {
+        cbor_event::Len::Indefinite => Err(cbor_event::Error::IndefiniteLenNotSupported(cbor_event::Type::NegativeInteger).into()),
+        cbor_event::Len::Len(v) => {
+            raw.advance(1 + len_sz)?;
+            Ok(-(v as i128) - 1)
+        }
     }
 }
 
@@ -706,22 +723,28 @@ impl cbor_event::se::Serialize for BigInt {
                 num_bigint::Sign::Minus => serializer.write_negative_integer(-(*u64_digits.first().unwrap() as i128) as i64),
             },
             _ => {
+                // Small edge case: nint's minimum is -18446744073709551616 but in this bigint lib
+                // that takes 2 u64 bytes so we put that as a special case here:
+                if sign == num_bigint::Sign::Minus && u64_digits == vec![0, 1] {
+                    serializer.write_negative_integer(-18446744073709551616i128 as i64)
+                } else {
                 let (sign, bytes) = self.0.to_bytes_be();
-                match sign {
-                    // positive bigint
-                    num_bigint::Sign::Plus |
-                    num_bigint::Sign::NoSign => {
-                        serializer.write_tag(2u64)?;
-                        write_bounded_bytes(serializer, &bytes)
-                    },
-                    // negative bigint
-                    num_bigint::Sign::Minus => {
-                        serializer.write_tag(3u64)?;
-                        use std::ops::Neg;
-                        // CBOR RFC defines this as the bytes of -n -1
-                        let adjusted = self.0.clone().neg().checked_sub(&num_bigint::BigInt::from(1u32)).unwrap().to_biguint().unwrap();
-                        write_bounded_bytes(serializer, &adjusted.to_bytes_be())
-                    },
+                    match sign {
+                        // positive bigint
+                        num_bigint::Sign::Plus |
+                        num_bigint::Sign::NoSign => {
+                            serializer.write_tag(2u64)?;
+                            write_bounded_bytes(serializer, &bytes)
+                        },
+                        // negative bigint
+                        num_bigint::Sign::Minus => {
+                            serializer.write_tag(3u64)?;
+                            use std::ops::Neg;
+                            // CBOR RFC defines this as the bytes of -n -1
+                            let adjusted = self.0.clone().neg().checked_sub(&num_bigint::BigInt::from(1u32)).unwrap().to_biguint().unwrap();
+                            write_bounded_bytes(serializer, &adjusted.to_bytes_be())
+                        },
+                    }
                 }
             },
         }
@@ -753,7 +776,7 @@ impl Deserialize for BigInt {
                 // uint
                 CBORType::UnsignedInteger => Ok(Self(num_bigint::BigInt::from(raw.unsigned_integer()?))),
                 // nint
-                CBORType::NegativeInteger => Ok(Self(num_bigint::BigInt::from(raw.negative_integer()?))),
+                CBORType::NegativeInteger => Ok(Self(num_bigint::BigInt::from(read_nint(raw)?))),
                 _ => return Err(DeserializeFailure::NoVariantMatched.into()),
             }
         })().map_err(|e| e.annotate("BigInt"))
@@ -2085,9 +2108,8 @@ mod tests {
         assert_eq!(hex::decode("c249010000000000000000").unwrap(), BigInt::from_str("18446744073709551616").unwrap().to_bytes());
         // uint
         assert_eq!(hex::decode("1b000000e8d4a51000").unwrap(), BigInt::from_str("1000000000000").unwrap().to_bytes());
-        // nint
-        // we can't use this due to cbor_event actually not supporting the full NINT spectrum as it uses an i64 for some reason...
-        //assert_eq!(hex::decode("3bffffffffffffffff").unwrap(), BigInt::from_str("-18446744073709551616").unwrap().to_bytes());
+        // nint (lowest possible - used to be unsupported but works now)
+        assert_eq!(hex::decode("3bffffffffffffffff").unwrap(), BigInt::from_str("-18446744073709551616").unwrap().to_bytes());
         // this one fits in an i64 though
         assert_eq!(hex::decode("3903e7").unwrap(), BigInt::from_str("-1000").unwrap().to_bytes());
 
@@ -2298,5 +2320,23 @@ mod tests {
 
         assert_eq!(Int::new_i32(42).as_i32_or_fail().unwrap(), 42);
         assert_eq!(Int::new_i32(-42).as_i32_or_fail().unwrap(), -42);
+    }
+
+    #[test]
+    fn int_full_range() {
+        // cbor_event's nint API worked via i64 but we now have a workaround for it
+        // so these tests are here to make sure that workaround works.
+
+        // first nint below of i64::MIN
+        let bytes_x = vec![0x3b, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        let x = Int::from_bytes(bytes_x.clone()).unwrap();
+        assert_eq!(x.to_str(), "-9223372036854775809");
+        assert_eq!(bytes_x, x.to_bytes());
+
+        // smallest possible nint which is -u64::MAX - 1
+        let bytes_y = vec![0x3b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff];
+        let y = Int::from_bytes(bytes_y.clone()).unwrap();
+        assert_eq!(y.to_str(), "-18446744073709551616");
+        assert_eq!(bytes_y, y.to_bytes());
     }
 }


### PR DESCRIPTION
cbor_event's `Deserializer::negative_integer()` panics when it
encounters a number below i64::MIN despite numbers down to -u64::MAX - 1
being valid for a CBOR nint. This fix covers both `BigInt` as well as
`Int`.