### PR TITLE
Revert "change undefined to null in tx example"

### DIFF
--- a/doc/getting-started/generating-transactions.md
+++ b/doc/getting-started/generating-transactions.md
@@ -110,7 +110,7 @@ witnesses.set_bootstraps(bootstrapWitnesses);
 const transaction = CardanoWasm.Transaction.new(
     txBody,
     witnesses,
-    null, // transaction metadata
+    undefined, // transaction metadata
 );
 ```
 


### PR DESCRIPTION
This reverts commit cff614b4bcb886e9bf33790c3a81ca71f8b0a7fb

For some reason, it changed the parameter of `Transaction.new` in the example to use `null` instead of `undefined`. This is incorrect and will give you a typescript type error if you try and use null. Not sure why this change was made to the docs.