### PR TITLE
Deserialization fixe for Update + support for Pre-Alonzo Blocks

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -3744,14 +3744,14 @@ declare export class ProtocolParamUpdate {
   extra_entropy(): Nonce | void;
 
   /**
-   * @param {ProtocolVersions} protocol_version
+   * @param {ProtocolVersion} protocol_version
    */
-  set_protocol_version(protocol_version: ProtocolVersions): void;
+  set_protocol_version(protocol_version: ProtocolVersion): void;
 
   /**
-   * @returns {ProtocolVersions | void}
+   * @returns {ProtocolVersion | void}
    */
-  protocol_version(): ProtocolVersions | void;
+  protocol_version(): ProtocolVersion | void;
 
   /**
    * @param {BigNum} min_pool_cost
@@ -3880,43 +3880,6 @@ declare export class ProtocolVersion {
    * @returns {ProtocolVersion}
    */
   static new(major: number, minor: number): ProtocolVersion;
-}
-/**
- */
-declare export class ProtocolVersions {
-  free(): void;
-
-  /**
-   * @returns {Uint8Array}
-   */
-  to_bytes(): Uint8Array;
-
-  /**
-   * @param {Uint8Array} bytes
-   * @returns {ProtocolVersions}
-   */
-  static from_bytes(bytes: Uint8Array): ProtocolVersions;
-
-  /**
-   * @returns {ProtocolVersions}
-   */
-  static new(): ProtocolVersions;
-
-  /**
-   * @returns {number}
-   */
-  len(): number;
-
-  /**
-   * @param {number} index
-   * @returns {ProtocolVersion}
-   */
-  get(index: number): ProtocolVersion;
-
-  /**
-   * @param {ProtocolVersion} elem
-   */
-  add(elem: ProtocolVersion): void;
 }
 /**
  * ED25519 key used as public key

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1920,32 +1920,6 @@ impl ProtocolVersion {
 
 #[wasm_bindgen]
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct ProtocolVersions(Vec<ProtocolVersion>);
-
-to_from_bytes!(ProtocolVersions);
-
-#[wasm_bindgen]
-impl ProtocolVersions {
-    pub fn new() -> Self {
-        Self(Vec::new())
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn get(&self, index: usize) -> ProtocolVersion {
-        self.0[index].clone()
-    }
-
-    pub fn add(&mut self, elem: &ProtocolVersion) {
-        self.0.push(elem.clone());
-    }
-}
-
-
-#[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ProtocolParamUpdate {
     minfee_a: Option<Coin>,
     minfee_b: Option<Coin>,
@@ -1963,7 +1937,7 @@ pub struct ProtocolParamUpdate {
     // decentralization constant
     d: Option<UnitInterval>,
     extra_entropy: Option<Nonce>,
-    protocol_version: Option<ProtocolVersions>,
+    protocol_version: Option<ProtocolVersion>,
     min_pool_cost: Option<Coin>,
     ada_per_utxo_byte: Option<Coin>,
     cost_models: Option<Costmdls>,
@@ -2091,11 +2065,11 @@ impl ProtocolParamUpdate {
         self.extra_entropy.clone()
     }
 
-    pub fn set_protocol_version(&mut self, protocol_version: &ProtocolVersions) {
+    pub fn set_protocol_version(&mut self, protocol_version: &ProtocolVersion) {
         self.protocol_version = Some(protocol_version.clone())
     }
 
-    pub fn protocol_version(&self) -> Option<ProtocolVersions> {
+    pub fn protocol_version(&self) -> Option<ProtocolVersion> {
         self.protocol_version.clone()
     }
 


### PR DESCRIPTION
Update's ProtocolVersion was generated as an array due to cddl-codegen
not supporting occurencies so it treated [protocol_version] as an array
rather than a single one as all other occurences of an array with a
single element were * occurences in the cddl.

As of Alozno, Blocks have a mandatory invalid_transactions field which
makes it one of the 2 non-backwards-compatible (the other being
transaction which we already support deserializing both) era changes to
the CDDL. This includes a fix for this by ignoring it if it's not
present.