### PR TITLE
[babbage] BlockHeader VRF certs update

### DIFF
--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -1992,14 +1992,29 @@ declare export class HeaderBody {
   vrf_vkey(): VRFVKey;
 
   /**
-   * @returns {VRFCert}
+   * @returns {boolean}
    */
-  nonce_vrf(): VRFCert;
+  has_nonce_and_leader_vrf(): boolean;
 
   /**
-   * @returns {VRFCert}
+   * @returns {VRFCert | void}
    */
-  leader_vrf(): VRFCert;
+  nonce_vrf_or_nothing(): VRFCert | void;
+
+  /**
+   * @returns {VRFCert | void}
+   */
+  leader_vrf_or_nothing(): VRFCert | void;
+
+  /**
+   * @returns {boolean}
+   */
+  has_vrf_result(): boolean;
+
+  /**
+   * @returns {VRFCert | void}
+   */
+  vrf_result_or_nothing(): VRFCert | void;
 
   /**
    * @returns {number}
@@ -2030,8 +2045,7 @@ declare export class HeaderBody {
    * @param {BlockHash | void} prev_hash
    * @param {Vkey} issuer_vkey
    * @param {VRFVKey} vrf_vkey
-   * @param {VRFCert} nonce_vrf
-   * @param {VRFCert} leader_vrf
+   * @param {VRFCert} vrf_result
    * @param {number} block_body_size
    * @param {BlockHash} block_body_hash
    * @param {OperationalCert} operational_cert
@@ -2044,8 +2058,7 @@ declare export class HeaderBody {
     prev_hash: BlockHash | void,
     issuer_vkey: Vkey,
     vrf_vkey: VRFVKey,
-    nonce_vrf: VRFCert,
-    leader_vrf: VRFCert,
+    vrf_result: VRFCert,
     block_body_size: number,
     block_body_hash: BlockHash,
     operational_cert: OperationalCert,
@@ -2053,13 +2066,15 @@ declare export class HeaderBody {
   ): HeaderBody;
 
   /**
+   * !!! DEPRECATED !!!
+   * This constructor uses outdated slot number format.
+   * Use `.new_headerbody` instead
    * @param {number} block_number
    * @param {BigNum} slot
    * @param {BlockHash | void} prev_hash
    * @param {Vkey} issuer_vkey
    * @param {VRFVKey} vrf_vkey
-   * @param {VRFCert} nonce_vrf
-   * @param {VRFCert} leader_vrf
+   * @param {VRFCert} vrf_result
    * @param {number} block_body_size
    * @param {BlockHash} block_body_hash
    * @param {OperationalCert} operational_cert
@@ -2072,8 +2087,7 @@ declare export class HeaderBody {
     prev_hash: BlockHash | void,
     issuer_vkey: Vkey,
     vrf_vkey: VRFVKey,
-    nonce_vrf: VRFCert,
-    leader_vrf: VRFCert,
+    vrf_result: VRFCert,
     block_body_size: number,
     block_body_hash: BlockHash,
     operational_cert: OperationalCert,

--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -1992,26 +1992,34 @@ declare export class HeaderBody {
   vrf_vkey(): VRFVKey;
 
   /**
+   * If this function returns true, the `.nonce_vrf_or_nothing`
+   * and the `.leader_vrf_or_nothing` functions will return
+   * non-empty results
    * @returns {boolean}
    */
   has_nonce_and_leader_vrf(): boolean;
 
   /**
+   * Might return nothing in case `.has_nonce_and_leader_vrf` returns false
    * @returns {VRFCert | void}
    */
   nonce_vrf_or_nothing(): VRFCert | void;
 
   /**
+   * Might return nothing in case `.has_nonce_and_leader_vrf` returns false
    * @returns {VRFCert | void}
    */
   leader_vrf_or_nothing(): VRFCert | void;
 
   /**
+   * If this function returns true, the `.vrf_result_or_nothing`
+   * function will return a non-empty result
    * @returns {boolean}
    */
   has_vrf_result(): boolean;
 
   /**
+   * Might return nothing in case `.has_vrf_result` returns false
    * @returns {VRFCert | void}
    */
   vrf_result_or_nothing(): VRFCert | void;
@@ -2066,9 +2074,6 @@ declare export class HeaderBody {
   ): HeaderBody;
 
   /**
-   * !!! DEPRECATED !!!
-   * This constructor uses outdated slot number format.
-   * Use `.new_headerbody` instead
    * @param {number} block_number
    * @param {BigNum} slot
    * @param {BlockHash | void} prev_hash

--- a/rust/src/chain_crypto/algorithms/ed25519.rs
+++ b/rust/src/chain_crypto/algorithms/ed25519.rs
@@ -10,6 +10,7 @@ use rand_os::rand_core::{CryptoRng, RngCore};
 use ed25519_bip32::XPub;
 
 /// ED25519 Signing Algorithm
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Ed25519;
 
 #[derive(Clone)]

--- a/rust/src/chain_crypto/sign.rs
+++ b/rust/src/chain_crypto/sign.rs
@@ -189,6 +189,16 @@ impl<T, A: VerificationAlgorithm> Clone for Signature<T, A> {
     }
 }
 
+
+impl<T, A: VerificationAlgorithm> PartialEq<Self> for Signature<T, A> {
+    fn eq(&self, other: &Self) -> bool {
+        // <todo:check phantom field>
+        self.signdata.as_ref() == other.signdata.as_ref()
+    }
+}
+
+impl<T, A: VerificationAlgorithm> Eq for Signature<T, A> {}
+
 impl<T: ?Sized, A: VerificationAlgorithm> AsRef<[u8]> for Signature<T, A> {
     fn as_ref(&self) -> &[u8] {
         self.signdata.as_ref()

--- a/rust/src/chain_crypto/sign.rs
+++ b/rust/src/chain_crypto/sign.rs
@@ -192,8 +192,8 @@ impl<T, A: VerificationAlgorithm> Clone for Signature<T, A> {
 
 impl<T, A: VerificationAlgorithm> PartialEq<Self> for Signature<T, A> {
     fn eq(&self, other: &Self) -> bool {
-        // <todo:check phantom field>
         self.signdata.as_ref() == other.signdata.as_ref()
+            && self.phantom == other.phantom
     }
 }
 

--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -283,7 +283,7 @@ impl PrivateKey {
 
 /// ED25519 key used as public key
 #[wasm_bindgen]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PublicKey(crypto::PublicKey<crypto::Ed25519>);
 
 impl From<crypto::PublicKey<crypto::Ed25519>> for PublicKey {
@@ -329,7 +329,7 @@ impl PublicKey {
 }
 
 #[wasm_bindgen]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Vkey(PublicKey);
 
 to_from_bytes!(Vkey);
@@ -688,7 +688,7 @@ impl PublicKeys {
 macro_rules! impl_signature {
     ($name:ident, $signee_type:ty, $verifier_type:ty) => {
         #[wasm_bindgen]
-        #[derive(Clone)]
+        #[derive(Clone, Debug)]
         pub struct $name(crypto::Signature<$signee_type, $verifier_type>);
 
         #[wasm_bindgen]

--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -283,7 +283,7 @@ impl PrivateKey {
 
 /// ED25519 key used as public key
 #[wasm_bindgen]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PublicKey(crypto::PublicKey<crypto::Ed25519>);
 
 impl From<crypto::PublicKey<crypto::Ed25519>> for PublicKey {
@@ -329,7 +329,7 @@ impl PublicKey {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Vkey(PublicKey);
 
 to_from_bytes!(Vkey);
@@ -688,7 +688,7 @@ impl PublicKeys {
 macro_rules! impl_signature {
     ($name:ident, $signee_type:ty, $verifier_type:ty) => {
         #[wasm_bindgen]
-        #[derive(Clone, Debug)]
+        #[derive(Clone, Debug, Eq, PartialEq)]
         pub struct $name(crypto::Signature<$signee_type, $verifier_type>);
 
         #[wasm_bindgen]

--- a/rust/src/fakes.rs
+++ b/rust/src/fakes.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use crate::{Address, BaseAddress, Ed25519KeyHash, NetworkInfo, StakeCredential, to_bignum, TransactionHash, TransactionIndex, TransactionInput, TransactionOutput, Value};
+use crate::{Address, BaseAddress, Bip32PrivateKey, Ed25519KeyHash, NetworkInfo, StakeCredential, to_bignum, TransactionHash, TransactionIndex, TransactionInput, TransactionOutput, Value, Vkey};
 
 pub(crate) fn fake_bytes_32(x: u8) -> Vec<u8> {
     vec![x, 239, 181, 120, 142, 135, 19, 200, 68, 223, 211, 43, 46, 145, 222, 30, 48, 159, 239, 255, 213, 85, 248, 39, 204, 158, 225, 100, 1, 2, 3, 4]
@@ -49,4 +49,8 @@ pub(crate) fn fake_tx_output2(input_hash_byte: u8, val: u64) -> TransactionOutpu
         &fake_base_address(input_hash_byte),
         &fake_value2(val),
     )
+}
+
+pub(crate) fn fake_vkey() -> Vkey {
+    Vkey::new(&Bip32PrivateKey::generate_ed25519_bip32().unwrap().to_public().to_raw_key())
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2513,7 +2513,7 @@ impl Header {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OperationalCert {
     hot_vkey: KESVKey,
     sequence_number: u32,
@@ -2551,14 +2551,14 @@ impl OperationalCert {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum HeaderLeaderCertEnum {
     NonceAndLeader(VRFCert, VRFCert),
     VrfResult(VRFCert),
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HeaderBody {
     block_number: u32,
     slot: SlotBigNum,
@@ -2694,13 +2694,6 @@ impl HeaderBody {
         }
     }
 
-    /// !!! DEPRECATED !!!
-    /// This constructor uses outdated slot number format.
-    /// Use `.new_headerbody` instead
-    #[deprecated(
-    since = "10.3.0",
-    note = "Underlying value capacity of slot (BigNum u64) bigger then Slot32. Use new_bignum instead."
-    )]
     pub fn new_headerbody(
         block_number: u32,
         slot: &SlotBigNum,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2608,6 +2608,9 @@ impl HeaderBody {
         self.vrf_vkey.clone()
     }
 
+    /// If this function returns true, the `.nonce_vrf_or_nothing`
+    /// and the `.leader_vrf_or_nothing` functions will return
+    /// non-empty results
     pub fn has_nonce_and_leader_vrf(&self) -> bool {
         match &self.leader_cert {
             HeaderLeaderCertEnum::NonceAndLeader(_, _) => true,
@@ -2615,6 +2618,7 @@ impl HeaderBody {
         }
     }
 
+    /// Might return nothing in case `.has_nonce_and_leader_vrf` returns false
     pub fn nonce_vrf_or_nothing(&self) -> Option<VRFCert> {
         match &self.leader_cert {
             HeaderLeaderCertEnum::NonceAndLeader(nonce, _) => Some(nonce.clone()),
@@ -2622,6 +2626,7 @@ impl HeaderBody {
         }
     }
 
+    /// Might return nothing in case `.has_nonce_and_leader_vrf` returns false
     pub fn leader_vrf_or_nothing(&self) -> Option<VRFCert> {
         match &self.leader_cert {
             HeaderLeaderCertEnum::NonceAndLeader(_, leader) => Some(leader.clone()),
@@ -2629,6 +2634,8 @@ impl HeaderBody {
         }
     }
 
+    /// If this function returns true, the `.vrf_result_or_nothing`
+    /// function will return a non-empty result
     pub fn has_vrf_result(&self) -> bool {
         match &self.leader_cert {
             HeaderLeaderCertEnum::VrfResult(_) => true,
@@ -2636,6 +2643,7 @@ impl HeaderBody {
         }
     }
 
+    /// Might return nothing in case `.has_vrf_result` returns false
     pub fn vrf_result_or_nothing(&self) -> Option<VRFCert> {
         match &self.leader_cert {
             HeaderLeaderCertEnum::VrfResult(cert) => Some(cert.clone()),

--- a/rust/src/serialization.rs
+++ b/rust/src/serialization.rs
@@ -3540,7 +3540,7 @@ impl Deserialize for NetworkId {
 
 #[cfg(test)]
 mod tests {
-    use crate::fakes::{fake_tx_input, fake_tx_output};
+    use crate::fakes::{fake_bytes_32, fake_tx_input, fake_tx_output, fake_vkey};
     use super::*;
 
     #[test]
@@ -3594,7 +3594,7 @@ mod tests {
     }
 
     #[test]
-    fn tx_body_roundtrip() {
+    fn test_tx_body_roundtrip() {
         let mut txb = TransactionBody::new(
             &TransactionInputs(vec![
                 fake_tx_input(0),
@@ -3611,5 +3611,29 @@ mod tests {
 
         let txb2 = TransactionBody::from_bytes(txb.to_bytes()).unwrap();
         assert_eq!(txb, txb2);
+    }
+
+    #[test]
+    fn test_header_body_roundtrip() {
+        let hbody = HeaderBody::new_headerbody(
+            123,
+            &to_bignum(123),
+            Some(BlockHash::from_bytes(fake_bytes_32(1)).unwrap()),
+            &fake_vkey(),
+            &VRFVKey::from_bytes(fake_bytes_32(2)).unwrap(),
+            &VRFCert::new(fake_bytes_32(3), [0; 80].to_vec()).unwrap(),
+            123456,
+            &BlockHash::from_bytes(fake_bytes_32(4)).unwrap(),
+            &OperationalCert::new(
+                &KESVKey::from_bytes(fake_bytes_32(5)).unwrap(),
+                123,
+                456,
+                &Ed25519Signature::from_bytes([6; 64].to_vec()).unwrap(),
+            ),
+            &ProtocolVersion::new(12, 13),
+        );
+
+        let hbody2 = HeaderBody::from_bytes(hbody.to_bytes()).unwrap();
+        assert_eq!(hbody, hbody2);
     }
 }

--- a/rust/src/serialization.rs
+++ b/rust/src/serialization.rs
@@ -3302,17 +3302,35 @@ impl DeserializeEmbeddedGroup for HeaderBody {
             Ok(VRFVKey::deserialize(raw)?)
         })().map_err(|e| e.annotate("vrf_vkey"))?;
         let leader_cert = {
-            // TODO: check for two or single certs
-            let nonce_vrf = (|| -> Result<_, DeserializeError> {
+            // NONCE VFR CERT, first of two certs
+            // or a single VRF RESULT CERT
+            // depending on the protocol version
+            let first_vrf_cert = (|| -> Result<_, DeserializeError> {
                 Ok(VRFCert::deserialize(raw)?)
             })().map_err(|e| e.annotate("nonce_vrf"))?;
-            let leader_vrf = (|| -> Result<_, DeserializeError> {
-                Ok(VRFCert::deserialize(raw)?)
-            })().map_err(|e| e.annotate("leader_vrf"))?;
-            HeaderLeaderCertEnum::NonceAndLeader(
-                nonce_vrf,
-                leader_vrf,
-            )
+            let cbor_type: cbor_event::Type = raw.cbor_type()?;
+            match cbor_type {
+                cbor_event::Type::Array => {
+                    // Legacy format, reading the second VRF cert
+                    let leader_vrf = (|| -> Result<_, DeserializeError> {
+                        Ok(VRFCert::deserialize(raw)?)
+                    })().map_err(|e| e.annotate("leader_vrf"))?;
+                    HeaderLeaderCertEnum::NonceAndLeader(
+                        first_vrf_cert,
+                        leader_vrf,
+                    )
+                }
+                cbor_event::Type::UnsignedInteger => {
+                    // New format, no second VRF cert is present
+                    HeaderLeaderCertEnum::VrfResult(
+                        first_vrf_cert,
+                    )
+                }
+                t => return Err(DeserializeError::new(
+                    "HeaderBody.leader_cert",
+                    DeserializeFailure::UnexpectedKeyType(t)
+                ))
+            }
         };
         let block_body_size = (|| -> Result<_, DeserializeError> {
             Ok(u32::deserialize(raw)?)
@@ -3615,25 +3633,37 @@ mod tests {
 
     #[test]
     fn test_header_body_roundtrip() {
-        let hbody = HeaderBody::new_headerbody(
-            123,
-            &to_bignum(123),
-            Some(BlockHash::from_bytes(fake_bytes_32(1)).unwrap()),
-            &fake_vkey(),
-            &VRFVKey::from_bytes(fake_bytes_32(2)).unwrap(),
-            &VRFCert::new(fake_bytes_32(3), [0; 80].to_vec()).unwrap(),
-            123456,
-            &BlockHash::from_bytes(fake_bytes_32(4)).unwrap(),
-            &OperationalCert::new(
-                &KESVKey::from_bytes(fake_bytes_32(5)).unwrap(),
-                123,
-                456,
-                &Ed25519Signature::from_bytes([6; 64].to_vec()).unwrap(),
-            ),
-            &ProtocolVersion::new(12, 13),
-        );
+        fn fake_header_body(leader_cert: HeaderLeaderCertEnum) -> HeaderBody {
+            HeaderBody {
+                block_number: 123,
+                slot: to_bignum(123),
+                prev_hash: Some(BlockHash::from_bytes(fake_bytes_32(1)).unwrap()),
+                issuer_vkey: fake_vkey(),
+                vrf_vkey: VRFVKey::from_bytes(fake_bytes_32(2)).unwrap(),
+                leader_cert,
+                block_body_size: 123456,
+                block_body_hash: BlockHash::from_bytes(fake_bytes_32(4)).unwrap(),
+                operational_cert: OperationalCert::new(
+                    &KESVKey::from_bytes(fake_bytes_32(5)).unwrap(),
+                    123,
+                    456,
+                    &Ed25519Signature::from_bytes([6; 64].to_vec()).unwrap(),
+                ),
+                protocol_version: ProtocolVersion::new(12, 13),
+            }
+        }
 
-        let hbody2 = HeaderBody::from_bytes(hbody.to_bytes()).unwrap();
-        assert_eq!(hbody, hbody2);
+        let hbody1 = fake_header_body(HeaderLeaderCertEnum::VrfResult(
+            VRFCert::new(fake_bytes_32(3), [0; 80].to_vec()).unwrap(),
+        ));
+
+        assert_eq!(hbody1, HeaderBody::from_bytes(hbody1.to_bytes()).unwrap());
+
+        let hbody2 = fake_header_body(HeaderLeaderCertEnum::NonceAndLeader(
+            VRFCert::new(fake_bytes_32(4), [1; 80].to_vec()).unwrap(),
+            VRFCert::new(fake_bytes_32(5), [2; 80].to_vec()).unwrap(),
+        ));
+
+        assert_eq!(hbody2, HeaderBody::from_bytes(hbody2.to_bytes()).unwrap());
     }
 }


### PR DESCRIPTION
# ⚠️ This update includes some breaking API changes!

Two vrf-cert fields in the block header are getting replaced with a cingle crf-cert field: see the CDDL spec [before](https://github.com/input-output-hk/cardano-ledger/blob/37322df14d44d1370e8a72b677815d64a92baa00/alonzo/test/cddl-files/alonzo.cddl#L33-L34) and [after](https://github.com/input-output-hk/cardano-ledger/blob/master/eras/babbage/test-suite/cddl-files/babbage.cddl#L33).

The `HeaderBody` function `.nonce_vrf` and `.leader_vrf` are replaced with `.nonce_vrf_or_nothing` and `.leader_vrf_or_nothing`, plus new functions:
1. `.has_nonce_and_leader_vrf`
2. `.has_vrf_result`
3. `.vrf_result_or_nothing`

**The babbage release will have to be a major version change.**