### PR TITLE
Fix dependency issues 

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -76,6 +76,7 @@ dependencies = [
  "rand_os",
  "schemars",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "sha2",
  "wasm-bindgen",
@@ -238,9 +239,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -555,6 +556,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfc62771e7b829b517cb213419236475f434fb480eddd76112ae182d274434a"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,8 +669,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,7 +32,6 @@ num-integer = "0.1.45"
 # feature or this one
 clear_on_drop = { version = "0.2", features = ["no_cc"] }
 itertools = "0.10.1"
-getrandom = { version = "0.2.3", features = ["js"] }
 rand = "0.8.4"
 schemars = "0.8.8"
 serde = { version = "1.0", features = ["derive"] }
@@ -41,12 +40,15 @@ serde = { version = "1.0", features = ["derive"] }
 [target.'cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))'.dependencies]
 rand_os = "0.1"
 noop_proc_macro = "0.3.0"
+getrandom = "0.2.3"
 
 # wasm
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
-wasm-bindgen = { version = "=0.2.78", features = ["serde-serialize"] }
+serde-wasm-bindgen = "0.4.3"
+wasm-bindgen = "=0.2.78"
 rand_os = { version = "0.1", features = ["wasm-bindgen"] }
-js-sys = "=0.3.51"
+js-sys = "0.3.51"
+getrandom = { version = "0.2.3", features = ["js"] }
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/rust/src/serialization_macros.rs
+++ b/rust/src/serialization_macros.rs
@@ -116,7 +116,7 @@ macro_rules! to_from_json {
 
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
             pub fn to_js_value(&self) -> Result<JsValue, JsError> {
-                JsValue::from_serde(&self)
+                serde_wasm_bindgen::to_value(&self)
                     .map_err(|e| JsError::from_str(&format!("to_js_value: {}", e)))
             }
 

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -43,7 +43,7 @@ macro_rules! to_from_json {
 
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
             pub fn to_js_value(&self) -> Result<JsValue, JsError> {
-                JsValue::from_serde(&self)
+                serde_wasm_bindgen::to_value(&self)
                     .map_err(|e| JsError::from_str(&format!("to_js_value: {}", e)))
             }
 


### PR DESCRIPTION
1. Reorganize dependencies and remove requirements ("=") on wasm-bindgen
   and js-sys, due to conflicts that can occur when using this crate.
2. Replace wasm-bindgen's "serde-serialize" feature with
   serde-wasm-bindgen due to cyclical dependency issue.

Relates to:
https://github.com/tkaitchuck/aHash/issues/95
https://github.com/rustwasm/wasm-bindgen/pull/3031