### PR TITLE
add wasm_bindgen to PlutusDataEnum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "11.1.0",
+  "version": "11.1.1",
   "description": "(De)serialization functions for the Cardano blockchain along with related utility functions",
   "scripts": {
     "rust:build-nodejs": "(rimraf ./rust/pkg && cd rust; wasm-pack build --target=nodejs; cd ..; npm run js:ts-json-gen; cd rust; wasm-pack pack) && npm run js:flowgen",

--- a/rust/src/plutus.rs
+++ b/rust/src/plutus.rs
@@ -596,6 +596,7 @@ pub enum PlutusDataKind {
     Bytes,
 }
 
+#[wasm_bindgen]
 #[derive(
     Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum PlutusDataEnum {


### PR DESCRIPTION
Without this, the generated typescript definition file `cardano_serialization_lib.d.ts` could not be used (`Cannot find name 'PlutusDataEnum'.`)