### PR TITLE
Point to documentation on developers.cardano.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ This is a library, written in Rust, for serialization & deserialization of data 
 
 ## Documentation
 
-You can find documentation [here](https://docs.cardano.org/cardano-components/cardano-serialization-lib)
+You can find documentation [here](https://developers.cardano.org/docs/get-started/cardano-serialization-lib/overview)


### PR DESCRIPTION
Consider this pull request as a proposal to point to another location for documentation: https://developers.cardano.org/docs/get-started/cardano-serialization-lib/overview

Over a longer period of time, we automatically pull the changes in cardano-serialization-lib to the developer portal. In addition, it is more detailed and looks nicer than in the current link https://docs.cardano.org/cardano-components/cardano-serialization-lib.

<img width="852" alt="Screenshot 2023-05-04 at 11 22 41" src="https://user-images.githubusercontent.com/31965230/236167613-7fd66faf-3092-4cdb-a086-e76b19543672.png">

