### PR TITLE
expose payment_cred for addresses

### DIFF
--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -625,10 +625,10 @@ impl Address {
     
     pub fn payment_cred(&self) -> Result<&StakeCredential, JsError> {
         match &self.0 {
-            AddrType::Base(a) => Ok(a.payment),
-            AddrType::Enterprise(a) => Ok(a.payment),
-            AddrType::Ptr(a) => Ok(a.payment),
-            AddrType::Reward(a) => Ok(a.payment),
+            AddrType::Base(a) => Ok(&a.payment),
+            AddrType::Enterprise(a) => Ok(&a.payment),
+            AddrType::Ptr(a) => Ok(&a.payment),
+            AddrType::Reward(a) => Ok(&a.payment),
             AddrType::Byron(a) =>  Err(JsError::from_str("byron not supported"))
         }
     }

--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -623,7 +623,7 @@ impl Address {
         }
     }
     
-    pub fn payment_cred(&self) -> Result<u8, JsError> {
+    pub fn payment_cred(&self) -> Result<&StakeCredential, JsError> {
         match &self.0 {
             AddrType::Base(a) => Ok(a.payment),
             AddrType::Enterprise(a) => Ok(a.payment),

--- a/rust/src/address.rs
+++ b/rust/src/address.rs
@@ -622,6 +622,16 @@ impl Address {
             AddrType::Byron(a) => a.network_id(),
         }
     }
+    
+    pub fn payment_cred(&self) -> Result<u8, JsError> {
+        match &self.0 {
+            AddrType::Base(a) => Ok(a.payment),
+            AddrType::Enterprise(a) => Ok(a.payment),
+            AddrType::Ptr(a) => Ok(a.payment),
+            AddrType::Reward(a) => Ok(a.payment),
+            AddrType::Byron(a) =>  Err(JsError::from_str("byron not supported"))
+        }
+    }
 }
 
 impl cbor_event::se::Serialize for Address {


### PR DESCRIPTION
inner struct is private, so add a helper function to get payment credentials, byron does not support it, so it throws an error.