### PR TITLE
Fix use after free

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -421,7 +421,7 @@ impl TransactionBody {
         self.validity_start_interval = Some(validity_start_interval.into())
     }
 
-    pub fn set_validity_start_interval_bignum(&mut self, validity_start_interval: SlotBigNum) {
+    pub fn set_validity_start_interval_bignum(&mut self, validity_start_interval: &SlotBigNum) {
         self.validity_start_interval = Some(validity_start_interval.clone())
     }
 


### PR DESCRIPTION
The value is moved and freed.

Repro: 

```
const csl = await import ('@emurgo/cardano-serialization-lib-nodejs');

let body = csl.TransactionBody.new(
  csl.TransactionInputs.new(),
  csl.TransactionOutputs.new(),
  csl.BigNum.from_str('1')
);

let interval = csl.BigNum.one();
body.set_validity_start_interval_bignum(interval);
let witnessSet = csl.TransactionWitnessSet.new();
let tx = csl.Transaction.new(body, witnessSet);

setInterval(() => {
  console.log(interval.to_bytes());
} , 1000);
```
