### PR TITLE
14.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "14.1.0",
+  "version": "14.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cardano-serialization-lib",
-      "version": "14.1.0",
+      "version": "14.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "14.1.1",
+  "version": "14.1.2",
   "description": "(De)serialization functions for the Cardano blockchain along with related utility functions",
   "scripts": {
     "rust:build-nodejs": "(rimraf ./rust/pkg && cd rust; wasm-pack build --target=nodejs; cd ..; npm run js:ts-json-gen; cd rust; wasm-pack pack) && npm run js:flowgen",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-serialization-lib"
-version = "14.1.1"
+version = "14.1.2"
 edition = "2018"
 authors = ["EMURGO"]
 license = "MIT"

--- a/rust/json-gen/Cargo.lock
+++ b/rust/json-gen/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "cardano-serialization-lib"
-version = "14.1.1"
+version = "14.1.2"
 dependencies = [
  "bech32",
  "cbor_event",

--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -6,6 +6,107 @@
  */
 
 /**
+ * @param {Transaction} tx
+ * @param {LinearFee} linear_fee
+ * @returns {BigNum}
+ */
+declare export function min_fee(tx: Transaction, linear_fee: LinearFee): BigNum;
+
+/**
+ * @param {ExUnits} ex_units
+ * @param {ExUnitPrices} ex_unit_prices
+ * @returns {BigNum}
+ */
+declare export function calculate_ex_units_ceil_cost(
+  ex_units: ExUnits,
+  ex_unit_prices: ExUnitPrices
+): BigNum;
+
+/**
+ * @param {Transaction} tx
+ * @param {ExUnitPrices} ex_unit_prices
+ * @returns {BigNum}
+ */
+declare export function min_script_fee(
+  tx: Transaction,
+  ex_unit_prices: ExUnitPrices
+): BigNum;
+
+/**
+ * @param {number} total_ref_scripts_size
+ * @param {UnitInterval} ref_script_coins_per_byte
+ * @returns {BigNum}
+ */
+declare export function min_ref_script_fee(
+  total_ref_scripts_size: number,
+  ref_script_coins_per_byte: UnitInterval
+): BigNum;
+
+/**
+ * @param {string} json
+ * @param {$Values<
+                typeof 
+                PlutusDatumSchema>} schema
+ * @returns {PlutusData}
+ */
+declare export function encode_json_str_to_plutus_datum(
+  json: string,
+  schema: $Values<typeof PlutusDatumSchema>
+): PlutusData;
+
+/**
+ * @param {PlutusData} datum
+ * @param {$Values<
+                typeof 
+                PlutusDatumSchema>} schema
+ * @returns {string}
+ */
+declare export function decode_plutus_datum_to_json_str(
+  datum: PlutusData,
+  schema: $Values<typeof PlutusDatumSchema>
+): string;
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {TransactionMetadatum}
+ */
+declare export function encode_arbitrary_bytes_as_metadatum(
+  bytes: Uint8Array
+): TransactionMetadatum;
+
+/**
+ * @param {TransactionMetadatum} metadata
+ * @returns {Uint8Array}
+ */
+declare export function decode_arbitrary_bytes_from_metadatum(
+  metadata: TransactionMetadatum
+): Uint8Array;
+
+/**
+ * @param {string} json
+ * @param {$Values<
+                typeof 
+                MetadataJsonSchema>} schema
+ * @returns {TransactionMetadatum}
+ */
+declare export function encode_json_str_to_metadatum(
+  json: string,
+  schema: $Values<typeof MetadataJsonSchema>
+): TransactionMetadatum;
+
+/**
+ * @param {TransactionMetadatum} metadatum
+ * @param {$Values<
+                typeof 
+                MetadataJsonSchema>} schema
+ * @returns {string}
+ */
+declare export function decode_metadatum_to_json_str(
+  metadatum: TransactionMetadatum,
+  schema: $Values<typeof MetadataJsonSchema>
+): string;
+
+/**
  * @param {TransactionHash} tx_body_hash
  * @param {ByronAddress} addr
  * @param {LegacyDaedalusPrivateKey} key
@@ -140,119 +241,6 @@ declare export function has_transaction_set_tag(
 ): $Values<typeof TransactionSetsState>;
 
 /**
- * @param {Address} address
- * @param {TransactionUnspentOutputs} utxos
- * @param {TransactionBuilderConfig} config
- * @returns {TransactionBatchList}
- */
-declare export function create_send_all(
-  address: Address,
-  utxos: TransactionUnspentOutputs,
-  config: TransactionBuilderConfig
-): TransactionBatchList;
-
-/**
- * @param {Transaction} tx
- * @param {LinearFee} linear_fee
- * @returns {BigNum}
- */
-declare export function min_fee(tx: Transaction, linear_fee: LinearFee): BigNum;
-
-/**
- * @param {ExUnits} ex_units
- * @param {ExUnitPrices} ex_unit_prices
- * @returns {BigNum}
- */
-declare export function calculate_ex_units_ceil_cost(
-  ex_units: ExUnits,
-  ex_unit_prices: ExUnitPrices
-): BigNum;
-
-/**
- * @param {Transaction} tx
- * @param {ExUnitPrices} ex_unit_prices
- * @returns {BigNum}
- */
-declare export function min_script_fee(
-  tx: Transaction,
-  ex_unit_prices: ExUnitPrices
-): BigNum;
-
-/**
- * @param {number} total_ref_scripts_size
- * @param {UnitInterval} ref_script_coins_per_byte
- * @returns {BigNum}
- */
-declare export function min_ref_script_fee(
-  total_ref_scripts_size: number,
-  ref_script_coins_per_byte: UnitInterval
-): BigNum;
-
-/**
- * @param {string} json
- * @param {$Values<
-                typeof 
-                PlutusDatumSchema>} schema
- * @returns {PlutusData}
- */
-declare export function encode_json_str_to_plutus_datum(
-  json: string,
-  schema: $Values<typeof PlutusDatumSchema>
-): PlutusData;
-
-/**
- * @param {PlutusData} datum
- * @param {$Values<
-                typeof 
-                PlutusDatumSchema>} schema
- * @returns {string}
- */
-declare export function decode_plutus_datum_to_json_str(
-  datum: PlutusData,
-  schema: $Values<typeof PlutusDatumSchema>
-): string;
-
-/**
- * @param {Uint8Array} bytes
- * @returns {TransactionMetadatum}
- */
-declare export function encode_arbitrary_bytes_as_metadatum(
-  bytes: Uint8Array
-): TransactionMetadatum;
-
-/**
- * @param {TransactionMetadatum} metadata
- * @returns {Uint8Array}
- */
-declare export function decode_arbitrary_bytes_from_metadatum(
-  metadata: TransactionMetadatum
-): Uint8Array;
-
-/**
- * @param {string} json
- * @param {$Values<
-                typeof 
-                MetadataJsonSchema>} schema
- * @returns {TransactionMetadatum}
- */
-declare export function encode_json_str_to_metadatum(
-  json: string,
-  schema: $Values<typeof MetadataJsonSchema>
-): TransactionMetadatum;
-
-/**
- * @param {TransactionMetadatum} metadatum
- * @param {$Values<
-                typeof 
-                MetadataJsonSchema>} schema
- * @returns {string}
- */
-declare export function decode_metadatum_to_json_str(
-  metadatum: TransactionMetadatum,
-  schema: $Values<typeof MetadataJsonSchema>
-): string;
-
-/**
  * @param {string} password
  * @param {string} salt
  * @param {string} nonce
@@ -277,6 +265,82 @@ declare export function decrypt_with_password(
 ): string;
 
 /**
+ * @param {Address} address
+ * @param {TransactionUnspentOutputs} utxos
+ * @param {TransactionBuilderConfig} config
+ * @returns {TransactionBatchList}
+ */
+declare export function create_send_all(
+  address: Address,
+  utxos: TransactionUnspentOutputs,
+  config: TransactionBuilderConfig
+): TransactionBatchList;
+
+/**
+ */
+
+declare export var CborContainerType: {|
+  +Array: 0, // 0
+  +Map: 1, // 1
+|};
+
+/**
+ * JSON <-> PlutusData conversion schemas.
+ * Follows ScriptDataJsonSchema in cardano-cli defined at:
+ * https://github.com/input-output-hk/cardano-node/blob/master/cardano-api/src/Cardano/Api/ScriptData.hs#L254
+ *
+ * All methods here have the following restrictions due to limitations on dependencies:
+ * * JSON numbers above u64::MAX (positive) or below i64::MIN (negative) will throw errors
+ * * Hex strings for bytes don't accept odd-length (half-byte) strings.
+ *      cardano-cli seems to support these however but it seems to be different than just 0-padding
+ *      on either side when tested so proceed with caution
+ */
+
+declare export var PlutusDatumSchema: {|
+  +BasicConversions: 0, // 0
+  +DetailedSchema: 1, // 1
+|};
+
+/**
+ */
+
+declare export var MetadataJsonSchema: {|
+  +NoConversions: 0, // 0
+  +BasicConversions: 1, // 1
+  +DetailedSchema: 2, // 2
+|};
+
+/**
+ * Used to choosed the schema for a script JSON string
+ */
+
+declare export var ScriptSchema: {|
+  +Wallet: 0, // 0
+  +Node: 1, // 1
+|};
+
+/**
+ */
+
+declare export var AddressKind: {|
+  +Base: 0, // 0
+  +Pointer: 1, // 1
+  +Enterprise: 2, // 2
+  +Reward: 3, // 3
+  +Byron: 4, // 4
+  +Malformed: 5, // 5
+|};
+
+/**
+ */
+
+declare export var RelayKind: {|
+  +SingleHostAddr: 0, // 0
+  +SingleHostName: 1, // 1
+  +MultiHostName: 2, // 2
+|};
+
+/**
  */
 
 declare export var NativeScriptKind: {|
@@ -291,18 +355,28 @@ declare export var NativeScriptKind: {|
 /**
  */
 
-declare export var CborSetType: {|
-  +Tagged: 0, // 0
-  +Untagged: 1, // 1
+declare export var MIRKind: {|
+  +ToOtherPot: 0, // 0
+  +ToStakeCredentials: 1, // 1
 |};
 
 /**
  */
 
-declare export var VoteKind: {|
-  +No: 0, // 0
-  +Yes: 1, // 1
-  +Abstain: 2, // 2
+declare export var MIRPot: {|
+  +Reserves: 0, // 0
+  +Treasury: 1, // 1
+|};
+
+/**
+ */
+
+declare export var TransactionMetadatumKind: {|
+  +MetadataMap: 0, // 0
+  +MetadataList: 1, // 1
+  +Int: 2, // 2
+  +Bytes: 3, // 3
+  +Text: 4, // 4
 |};
 
 /**
@@ -322,137 +396,9 @@ declare export var BlockEra: {|
 /**
  */
 
-declare export var TransactionSetsState: {|
-  +AllSetsHaveTag: 0, // 0
-  +AllSetsHaveNoTag: 1, // 1
-  +MixedSets: 2, // 2
-|};
-
-/**
- */
-
-declare export var MIRKind: {|
-  +ToOtherPot: 0, // 0
-  +ToStakeCredentials: 1, // 1
-|};
-
-/**
- */
-
-declare export var RedeemerTagKind: {|
-  +Spend: 0, // 0
-  +Mint: 1, // 1
-  +Cert: 2, // 2
-  +Reward: 3, // 3
-  +Vote: 4, // 4
-  +VotingProposal: 5, // 5
-|};
-
-/**
- */
-
-declare export var ByronAddressType: {|
-  +ATPubKey: 0, // 0
-  +ATScript: 1, // 1
-  +ATRedeem: 2, // 2
-|};
-
-/**
- */
-
 declare export var CredKind: {|
   +Key: 0, // 0
   +Script: 1, // 1
-|};
-
-/**
- */
-
-declare export var DRepKind: {|
-  +KeyHash: 0, // 0
-  +ScriptHash: 1, // 1
-  +AlwaysAbstain: 2, // 2
-  +AlwaysNoConfidence: 3, // 3
-|};
-
-/**
- */
-
-declare export var PlutusDataKind: {|
-  +ConstrPlutusData: 0, // 0
-  +Map: 1, // 1
-  +List: 2, // 2
-  +Integer: 3, // 3
-  +Bytes: 4, // 4
-|};
-
-/**
- */
-
-declare export var RelayKind: {|
-  +SingleHostAddr: 0, // 0
-  +SingleHostName: 1, // 1
-  +MultiHostName: 2, // 2
-|};
-
-/**
- */
-
-declare export var NetworkIdKind: {|
-  +Testnet: 0, // 0
-  +Mainnet: 1, // 1
-|};
-
-/**
- */
-
-declare export var LanguageKind: {|
-  +PlutusV1: 0, // 0
-  +PlutusV2: 1, // 1
-  +PlutusV3: 2, // 2
-|};
-
-/**
- * Each new language uses a different namespace for hashing its script
- * This is because you could have a language where the same bytes have different semantics
- * So this avoids scripts in different languages mapping to the same hash
- * Note that the enum value here is different than the enum value for deciding the cost model of a script
- */
-
-declare export var ScriptHashNamespace: {|
-  +NativeScript: 0, // 0
-  +PlutusScript: 1, // 1
-  +PlutusScriptV2: 2, // 2
-  +PlutusScriptV3: 3, // 3
-|};
-
-/**
- * Used to choosed the schema for a script JSON string
- */
-
-declare export var ScriptSchema: {|
-  +Wallet: 0, // 0
-  +Node: 1, // 1
-|};
-
-/**
- */
-
-declare export var MIRPot: {|
-  +Reserves: 0, // 0
-  +Treasury: 1, // 1
-|};
-
-/**
- */
-
-declare export var AddressKind: {|
-  +Base: 0, // 0
-  +Pointer: 1, // 1
-  +Enterprise: 2, // 2
-  +Reward: 3, // 3
-  +Byron: 4, // 4
-  +Malformed: 5, // 5
 |};
 
 /**
@@ -492,56 +438,101 @@ declare export var CertificateKind: {|
 /**
  */
 
-declare export var CborContainerType: {|
-  +Array: 0, // 0
-  +Map: 1, // 1
-|};
-
-/**
- * JSON <-> PlutusData conversion schemas.
- * Follows ScriptDataJsonSchema in cardano-cli defined at:
- * https://github.com/input-output-hk/cardano-node/blob/master/cardano-api/src/Cardano/Api/ScriptData.hs#L254
- *
- * All methods here have the following restrictions due to limitations on dependencies:
- * * JSON numbers above u64::MAX (positive) or below i64::MIN (negative) will throw errors
- * * Hex strings for bytes don't accept odd-length (half-byte) strings.
- *      cardano-cli seems to support these however but it seems to be different than just 0-padding
- *      on either side when tested so proceed with caution
- */
-
-declare export var PlutusDatumSchema: {|
-  +BasicConversions: 0, // 0
-  +DetailedSchema: 1, // 1
-|};
-
-/**
- */
-
-declare export var TransactionMetadatumKind: {|
-  +MetadataMap: 0, // 0
-  +MetadataList: 1, // 1
-  +Int: 2, // 2
-  +Bytes: 3, // 3
-  +Text: 4, // 4
-|};
-
-/**
- */
-
-declare export var MetadataJsonSchema: {|
-  +NoConversions: 0, // 0
-  +BasicConversions: 1, // 1
-  +DetailedSchema: 2, // 2
-|};
-
-/**
- */
-
 declare export var CoinSelectionStrategyCIP2: {|
   +LargestFirst: 0, // 0
   +RandomImprove: 1, // 1
   +LargestFirstMultiAsset: 2, // 2
   +RandomImproveMultiAsset: 3, // 3
+|};
+
+/**
+ */
+
+declare export var ByronAddressType: {|
+  +ATPubKey: 0, // 0
+  +ATScript: 1, // 1
+  +ATRedeem: 2, // 2
+|};
+
+/**
+ */
+
+declare export var RedeemerTagKind: {|
+  +Spend: 0, // 0
+  +Mint: 1, // 1
+  +Cert: 2, // 2
+  +Reward: 3, // 3
+  +Vote: 4, // 4
+  +VotingProposal: 5, // 5
+|};
+
+/**
+ * Each new language uses a different namespace for hashing its script
+ * This is because you could have a language where the same bytes have different semantics
+ * So this avoids scripts in different languages mapping to the same hash
+ * Note that the enum value here is different than the enum value for deciding the cost model of a script
+ */
+
+declare export var ScriptHashNamespace: {|
+  +NativeScript: 0, // 0
+  +PlutusScript: 1, // 1
+  +PlutusScriptV2: 2, // 2
+  +PlutusScriptV3: 3, // 3
+|};
+
+/**
+ */
+
+declare export var CborSetType: {|
+  +Tagged: 0, // 0
+  +Untagged: 1, // 1
+|};
+
+/**
+ */
+
+declare export var PlutusDataKind: {|
+  +ConstrPlutusData: 0, // 0
+  +Map: 1, // 1
+  +List: 2, // 2
+  +Integer: 3, // 3
+  +Bytes: 4, // 4
+|};
+
+/**
+ */
+
+declare export var NetworkIdKind: {|
+  +Testnet: 0, // 0
+  +Mainnet: 1, // 1
+|};
+
+/**
+ */
+
+declare export var TransactionSetsState: {|
+  +AllSetsHaveTag: 0, // 0
+  +AllSetsHaveNoTag: 1, // 1
+  +MixedSets: 2, // 2
+|};
+
+/**
+ */
+
+declare export var DRepKind: {|
+  +KeyHash: 0, // 0
+  +ScriptHash: 1, // 1
+  +AlwaysAbstain: 2, // 2
+  +AlwaysNoConfidence: 3, // 3
+|};
+
+/**
+ */
+
+declare export var VoteKind: {|
+  +No: 0, // 0
+  +Yes: 1, // 1
+  +Abstain: 2, // 2
 |};
 
 /**
@@ -555,6 +546,15 @@ declare export var GovernanceActionKind: {|
   +UpdateCommitteeAction: 4, // 4
   +NewConstitutionAction: 5, // 5
   +InfoAction: 6, // 6
+|};
+
+/**
+ */
+
+declare export var LanguageKind: {|
+  +PlutusV1: 0, // 0
+  +PlutusV2: 1, // 1
+  +PlutusV3: 2, // 2
 |};
 
 /**
@@ -14626,11 +14626,11 @@ export type CertificateJSON =
     };
 export type CredTypeJSON =
   | {
-      Key: string,
+      Script: string,
       ...
     }
   | {
-      Script: string,
+      Key: string,
       ...
     };
 export type RelayJSON =

--- a/rust/src/builders/tx_builder_constants.rs
+++ b/rust/src/builders/tx_builder_constants.rs
@@ -5,48 +5,16 @@ use crate::*;
 // The cost-model values are taken from the genesis block - https://github.com/input-output-hk/cardano-node/blob/master/configuration/cardano/mainnet-alonzo-genesis.json#L26-L195
 // The keys on the genesis block object (operation names) are sorted plain alphabetically.
 
-/// !!! DEPRECATED !!!
-/// Use API provider or cardano cli to retrieve the latest cost modes
-/// Predefined cost models will be deleted in the CSL from 15.0.0 version.
-#[deprecated(
-    since = "14.1.2",
-    note = "Use API provider or cardano cli to retrieve the latest cost modes. \
-        Predefined cost models will be deleted in the CSL from 15.0.0 version."
-)]
 #[allow(dead_code)]
 pub(crate) struct TxBuilderConstants();
 
-/// !!! DEPRECATED !!!
-/// Use API provider or cardano cli to retrieve the latest cost modes
-/// Predefined cost models will be deleted in the CSL from 15.0.0 version.
-#[deprecated(
-    since = "14.1.2",
-    note = "Use API provider or cardano cli to retrieve the latest cost modes. \
-        Predefined cost models will be deleted in the CSL from 15.0.0 version."
-)]
 #[allow(dead_code)]
 impl TxBuilderConstants {
 
-    /// !!! DEPRECATED !!!
-    /// Use API provider or cardano cli to retrieve the latest cost modes
-    /// Predefined cost models will be deleted in the CSL from 15.0.0 version.
-    #[deprecated(
-        since = "14.1.2",
-        note = "Use API provider or cardano cli to retrieve the latest cost modes. \
-        Predefined cost models will be deleted in the CSL from 15.0.0 version."
-    )]
     pub(crate) fn plutus_default_cost_models() -> Costmdls {
         TxBuilderConstants::plutus_conway_cost_models()
     }
 
-    /// !!! DEPRECATED !!!
-    /// Use API provider or cardano cli to retrieve the latest cost modes
-    /// Predefined cost models will be deleted in the CSL from 15.0.0 version.
-    #[deprecated(
-        since = "14.1.2",
-        note = "Use API provider or cardano cli to retrieve the latest cost modes. \
-        Predefined cost models will be deleted in the CSL from 15.0.0 version."
-    )]
     pub(crate) fn plutus_alonzo_cost_models() -> Costmdls {
         let mut res = Costmdls::new();
         res.insert(
@@ -69,14 +37,6 @@ impl TxBuilderConstants {
         res
     }
 
-    /// !!! DEPRECATED !!!
-    /// Use API provider or cardano cli to retrieve the latest cost modes
-    /// Predefined cost models will be deleted in the CSL from 15.0.0 version.
-    #[deprecated(
-        since = "14.1.2",
-        note = "Use API provider or cardano cli to retrieve the latest cost modes. \
-        Predefined cost models will be deleted in the CSL from 15.0.0 version."
-    )]
     pub(crate) fn plutus_vasil_cost_models() -> Costmdls {
         let mut res = Costmdls::new();
         res.insert(
@@ -115,14 +75,6 @@ impl TxBuilderConstants {
         res
     }
 
-    /// !!! DEPRECATED !!!
-    /// Use API provider or cardano cli to retrieve the latest cost modes
-    /// Predefined cost models will be deleted in the CSL from 15.0.0 version.
-    #[deprecated(
-        since = "14.1.2",
-        note = "Use API provider or cardano cli to retrieve the latest cost modes. \
-        Predefined cost models will be deleted in the CSL from 15.0.0 version."
-    )]
     pub(crate) fn plutus_conway_cost_models() -> Costmdls {
         let mut res = Costmdls::new();
         res.insert(

--- a/rust/src/builders/tx_builder_constants.rs
+++ b/rust/src/builders/tx_builder_constants.rs
@@ -9,7 +9,7 @@ use crate::*;
 /// Use API provider or cardano cli to retrieve the latest cost modes
 /// Predefined cost models will be deleted in the CSL from 15.0.0 version.
 #[deprecated(
-    since = "14.0.1",
+    since = "14.1.2",
     note = "Use API provider or cardano cli to retrieve the latest cost modes. \
         Predefined cost models will be deleted in the CSL from 15.0.0 version."
 )]
@@ -20,7 +20,7 @@ pub(crate) struct TxBuilderConstants();
 /// Use API provider or cardano cli to retrieve the latest cost modes
 /// Predefined cost models will be deleted in the CSL from 15.0.0 version.
 #[deprecated(
-    since = "14.0.1",
+    since = "14.1.2",
     note = "Use API provider or cardano cli to retrieve the latest cost modes. \
         Predefined cost models will be deleted in the CSL from 15.0.0 version."
 )]
@@ -31,7 +31,7 @@ impl TxBuilderConstants {
     /// Use API provider or cardano cli to retrieve the latest cost modes
     /// Predefined cost models will be deleted in the CSL from 15.0.0 version.
     #[deprecated(
-        since = "14.0.1",
+        since = "14.1.2",
         note = "Use API provider or cardano cli to retrieve the latest cost modes. \
         Predefined cost models will be deleted in the CSL from 15.0.0 version."
     )]
@@ -43,7 +43,7 @@ impl TxBuilderConstants {
     /// Use API provider or cardano cli to retrieve the latest cost modes
     /// Predefined cost models will be deleted in the CSL from 15.0.0 version.
     #[deprecated(
-        since = "14.0.1",
+        since = "14.1.2",
         note = "Use API provider or cardano cli to retrieve the latest cost modes. \
         Predefined cost models will be deleted in the CSL from 15.0.0 version."
     )]
@@ -73,7 +73,7 @@ impl TxBuilderConstants {
     /// Use API provider or cardano cli to retrieve the latest cost modes
     /// Predefined cost models will be deleted in the CSL from 15.0.0 version.
     #[deprecated(
-        since = "14.0.1",
+        since = "14.1.2",
         note = "Use API provider or cardano cli to retrieve the latest cost modes. \
         Predefined cost models will be deleted in the CSL from 15.0.0 version."
     )]
@@ -119,7 +119,7 @@ impl TxBuilderConstants {
     /// Use API provider or cardano cli to retrieve the latest cost modes
     /// Predefined cost models will be deleted in the CSL from 15.0.0 version.
     #[deprecated(
-        since = "14.0.1",
+        since = "14.1.2",
         note = "Use API provider or cardano cli to retrieve the latest cost modes. \
         Predefined cost models will be deleted in the CSL from 15.0.0 version."
     )]

--- a/rust/src/builders/tx_builder_constants.rs
+++ b/rust/src/builders/tx_builder_constants.rs
@@ -5,15 +5,48 @@ use crate::*;
 // The cost-model values are taken from the genesis block - https://github.com/input-output-hk/cardano-node/blob/master/configuration/cardano/mainnet-alonzo-genesis.json#L26-L195
 // The keys on the genesis block object (operation names) are sorted plain alphabetically.
 
+/// !!! DEPRECATED !!!
+/// Use API provider or cardano cli to retrieve the latest cost modes
+/// Predefined cost models will be deleted in the CSL from 15.0.0 version.
+#[deprecated(
+    since = "14.0.1",
+    note = "Use API provider or cardano cli to retrieve the latest cost modes. \
+        Predefined cost models will be deleted in the CSL from 15.0.0 version."
+)]
 #[allow(dead_code)]
 pub(crate) struct TxBuilderConstants();
 
+/// !!! DEPRECATED !!!
+/// Use API provider or cardano cli to retrieve the latest cost modes
+/// Predefined cost models will be deleted in the CSL from 15.0.0 version.
+#[deprecated(
+    since = "14.0.1",
+    note = "Use API provider or cardano cli to retrieve the latest cost modes. \
+        Predefined cost models will be deleted in the CSL from 15.0.0 version."
+)]
 #[allow(dead_code)]
 impl TxBuilderConstants {
+
+    /// !!! DEPRECATED !!!
+    /// Use API provider or cardano cli to retrieve the latest cost modes
+    /// Predefined cost models will be deleted in the CSL from 15.0.0 version.
+    #[deprecated(
+        since = "14.0.1",
+        note = "Use API provider or cardano cli to retrieve the latest cost modes. \
+        Predefined cost models will be deleted in the CSL from 15.0.0 version."
+    )]
     pub(crate) fn plutus_default_cost_models() -> Costmdls {
-        TxBuilderConstants::plutus_vasil_cost_models()
+        TxBuilderConstants::plutus_conway_cost_models()
     }
 
+    /// !!! DEPRECATED !!!
+    /// Use API provider or cardano cli to retrieve the latest cost modes
+    /// Predefined cost models will be deleted in the CSL from 15.0.0 version.
+    #[deprecated(
+        since = "14.0.1",
+        note = "Use API provider or cardano cli to retrieve the latest cost modes. \
+        Predefined cost models will be deleted in the CSL from 15.0.0 version."
+    )]
     pub(crate) fn plutus_alonzo_cost_models() -> Costmdls {
         let mut res = Costmdls::new();
         res.insert(
@@ -36,6 +69,14 @@ impl TxBuilderConstants {
         res
     }
 
+    /// !!! DEPRECATED !!!
+    /// Use API provider or cardano cli to retrieve the latest cost modes
+    /// Predefined cost models will be deleted in the CSL from 15.0.0 version.
+    #[deprecated(
+        since = "14.0.1",
+        note = "Use API provider or cardano cli to retrieve the latest cost modes. \
+        Predefined cost models will be deleted in the CSL from 15.0.0 version."
+    )]
     pub(crate) fn plutus_vasil_cost_models() -> Costmdls {
         let mut res = Costmdls::new();
         res.insert(
@@ -74,6 +115,14 @@ impl TxBuilderConstants {
         res
     }
 
+    /// !!! DEPRECATED !!!
+    /// Use API provider or cardano cli to retrieve the latest cost modes
+    /// Predefined cost models will be deleted in the CSL from 15.0.0 version.
+    #[deprecated(
+        since = "14.0.1",
+        note = "Use API provider or cardano cli to retrieve the latest cost modes. \
+        Predefined cost models will be deleted in the CSL from 15.0.0 version."
+    )]
     pub(crate) fn plutus_conway_cost_models() -> Costmdls {
         let mut res = Costmdls::new();
         res.insert(
@@ -129,7 +178,9 @@ impl TxBuilderConstants {
                 18, 52948122, 18, 1995836, 36, 3227919, 12, 901022, 1, 166917843, 4307, 36, 284546,
                 36, 158221314, 26549, 36, 74698472, 36, 333849714, 1, 254006273, 72, 2174038, 72,
                 2261318, 64571, 4, 207616, 8310, 4, 1293828, 28716, 63, 0, 1, 1006041, 43623, 251,
-                0, 1,
+                0, 1, 100181, 726, 719, 0, 1, 100181, 726, 719, 0, 1, 100181, 726, 719, 0, 1,
+                107878, 680, 0, 1, 95336, 1, 281145, 18848, 0, 1, 180194, 159, 1, 1, 158519, 8942,
+                0, 1, 159378, 8813, 0, 1, 107490, 3298, 1, 106057, 655, 1, 1964219, 24520, 3,
             ]),
         );
 

--- a/rust/src/builders/withdrawals_builder.rs
+++ b/rust/src/builders/withdrawals_builder.rs
@@ -1,17 +1,18 @@
+use std::collections::BTreeMap;
 use crate::*;
 use hashlink::LinkedHashMap;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug)]
 pub struct WithdrawalsBuilder {
-    withdrawals: LinkedHashMap<RewardAddress, (Coin, Option<ScriptWitnessType>)>,
+    withdrawals: BTreeMap<RewardAddress, (Coin, Option<ScriptWitnessType>)>,
 }
 
 #[wasm_bindgen]
 impl WithdrawalsBuilder {
     pub fn new() -> Self {
         Self {
-            withdrawals: LinkedHashMap::new(),
+            withdrawals: BTreeMap::new(),
         }
     }
 

--- a/rust/src/builders/withdrawals_builder.rs
+++ b/rust/src/builders/withdrawals_builder.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 use crate::*;
-use hashlink::LinkedHashMap;
 
 #[wasm_bindgen]
 #[derive(Clone, Debug)]

--- a/rust/src/legacy_address/cbor.rs
+++ b/rust/src/legacy_address/cbor.rs
@@ -23,7 +23,12 @@ pub mod util {
         raw: &mut Deserializer<R>,
     ) -> cbor_event::Result<Vec<u8>> {
         let len = raw.array()?;
-        assert!(len == Len::Len(2));
+        if len != Len::Len(2) {
+            return Err(cbor_event::Error::CustomError(format!(
+                "Invalid array length: {:?}, expected Len(2)",
+                len
+            )));
+        }
 
         let tag = raw.tag()?;
         if tag != 24 {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -840,6 +840,10 @@ impl Withdrawals {
                 .collect::<Vec<RewardAddress>>(),
         )
     }
+
+    pub(crate) fn as_vec(&self) -> Vec<(&RewardAddress, &Coin)> {
+        self.0.iter().collect()
+    }
 }
 
 impl serde::Serialize for Withdrawals {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -841,6 +841,7 @@ impl Withdrawals {
         )
     }
 
+    #[allow(dead_code)]
     pub(crate) fn as_vec(&self) -> Vec<(&RewardAddress, &Coin)> {
         self.0.iter().collect()
     }

--- a/rust/src/protocol_types/credential.rs
+++ b/rust/src/protocol_types/credential.rs
@@ -13,8 +13,8 @@ serde::Deserialize,
 JsonSchema,
 )]
 pub enum CredType {
-    Key(Ed25519KeyHash),
     Script(ScriptHash),
+    Key(Ed25519KeyHash),
 }
 
 #[wasm_bindgen]

--- a/rust/src/tests/builders/tx_builder.rs
+++ b/rust/src/tests/builders/tx_builder.rs
@@ -3353,7 +3353,7 @@ fn add_output_asset_and_min_required_coin() {
 
     assert_eq!(out.address.to_bytes(), address.to_bytes());
     assert_eq!(out.amount.multiasset.unwrap(), multiasset);
-    assert_eq!(out.amount.coin, BigNum(1146460));
+    assert_eq!(out.amount.coin, BigNum(1086120));
 }
 
 #[test]
@@ -3480,7 +3480,7 @@ fn add_mint_asset_and_min_required_coin() {
     let out = tx_builder.outputs.get(0);
 
     assert_eq!(out.address.to_bytes(), address.to_bytes());
-    assert_eq!(out.amount.coin, BigNum(1146460));
+    assert_eq!(out.amount.coin, BigNum(1086120));
 
     let multiasset = out.amount.multiasset.unwrap();
 


### PR DESCRIPTION
Thought for a couple of seconds
Changes:

* **Credential definition**
Change script hash and key hash definition order in credential enum to respect cardano ledger behavior 

* **CBOR parsing**
  – Swapped `assert!(len==2)` for a proper `Err(CustomError)` on invalid array length

* **Transaction builders**
  – **`with_asset_and_min_required_coin_by_utxo_cost`** refactored to:
  • take into account an output address
  • compute required ADA in one pass 

* **Withdrawals**
  – Swapped `LinkedHashMap`→`BTreeMap` for deterministic ordering
  – Updated sort logic so script-withdrawals come before key-withdrawals in accordance with ledger implementation

* **Static assertions**
  – Removed obsolete `static_assert!` in `legacy_address/cbor.rs`

* **Tests**
  • correct withdrawal sorting order
