### PR TITLE
feat: Implement more traits for numeric types

### DIFF
--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -77,6 +77,30 @@ macro_rules! impl_num_ops {
                 Self(num_traits::One::one())
             }
         }
+
+        impl num_traits::CheckedAdd for $wrapper {
+            fn checked_add(&self, v: &Self) -> Option<Self> {
+                num_traits::CheckedAdd::checked_add(&self.0, &v.0).map(Self)
+            }
+        }
+
+        impl num_traits::CheckedSub for $wrapper {
+            fn checked_sub(&self, v: &Self) -> Option<Self> {
+                num_traits::CheckedSub::checked_sub(&self.0, &v.0).map(Self)
+            }
+        }
+
+        impl num_traits::CheckedMul for $wrapper {
+            fn checked_mul(&self, v: &Self) -> Option<Self> {
+                num_traits::CheckedMul::checked_mul(&self.0, &v.0).map(Self)
+            }
+        }
+
+        impl num_traits::CheckedDiv for $wrapper {
+            fn checked_div(&self, v: &Self) -> Option<Self> {
+                num_traits::CheckedDiv::checked_div(&self.0, &v.0).map(Self)
+            }
+        }
     };
 }
 
@@ -207,6 +231,62 @@ mod tests {
         fn one() {
             use num_traits::One;
             assert_eq!(TestNum::one(), TestNum(1));
+        }
+
+        #[quickcheck]
+        fn checked_add(a: u32, b: u32) {
+            use num_traits::CheckedAdd;
+            let a = a as u64;
+            let b = b as u64;
+            assert_eq!(TestNum(a).checked_add(&TestNum(b)), Some(TestNum(a + b)));
+        }
+
+        #[test]
+        fn checked_add_overflow() {
+            use num_traits::CheckedAdd;
+            assert_eq!(TestNum(u64::MAX).checked_add(&TestNum(1)), None);
+        }
+
+        #[quickcheck]
+        fn checked_sub(a: u64, b: u64) {
+            use num_traits::CheckedSub;
+            if a >= b {
+                assert_eq!(TestNum(a).checked_sub(&TestNum(b)), Some(TestNum(a - b)));
+            }
+        }
+
+        #[test]
+        fn checked_sub_underflow() {
+            use num_traits::CheckedSub;
+            assert_eq!(TestNum(0).checked_sub(&TestNum(1)), None);
+        }
+
+        #[quickcheck]
+        fn checked_mul(a: u32, b: u32) {
+            use num_traits::CheckedMul;
+            let a = a as u64;
+            let b = b as u64;
+            assert_eq!(TestNum(a).checked_mul(&TestNum(b)), Some(TestNum(a * b)));
+        }
+
+        #[test]
+        fn checked_mul_overflow() {
+            use num_traits::CheckedMul;
+            assert_eq!(TestNum(u64::MAX).checked_mul(&TestNum(2)), None);
+        }
+
+        #[quickcheck]
+        fn checked_div(a: u64, b: u64) {
+            use num_traits::CheckedDiv;
+            if b != 0 {
+                assert_eq!(TestNum(a).checked_div(&TestNum(b)), Some(TestNum(a / b)));
+            }
+        }
+
+        #[test]
+        fn checked_div_by_zero() {
+            use num_traits::CheckedDiv;
+            assert_eq!(TestNum(1).checked_div(&TestNum(0)), None);
         }
     }
 

--- a/rust/src/protocol_types/numeric/big_int.rs
+++ b/rust/src/protocol_types/numeric/big_int.rs
@@ -4,7 +4,7 @@ use num_traits::Signed;
 use crate::*;
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct BigInt(pub(crate) num_bigint::BigInt);
 
 impl_to_from!(BigInt);

--- a/rust/src/protocol_types/numeric/big_int.rs
+++ b/rust/src/protocol_types/numeric/big_int.rs
@@ -10,6 +10,14 @@ pub struct BigInt(pub(crate) num_bigint::BigInt);
 impl_to_from!(BigInt);
 impl_num_ops!(BigInt, num_bigint::BigInt);
 
+impl std::ops::Neg for BigInt {
+    type Output = BigInt;
+
+    fn neg(self) -> Self::Output {
+        Self(-self.0)
+    }
+}
+
 impl std::fmt::Display for BigInt {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         self.0.fmt(f)

--- a/rust/src/protocol_types/numeric/big_num.rs
+++ b/rust/src/protocol_types/numeric/big_num.rs
@@ -1,5 +1,6 @@
 use std::convert::TryFrom;
 use std::ops::Div;
+
 use crate::*;
 
 // Generic u64 wrapper for platforms that don't support u64 or BigInt/etc
@@ -54,24 +55,18 @@ impl BigNum {
     }
 
     pub fn checked_mul(&self, other: &BigNum) -> Result<BigNum, JsError> {
-        match self.0.checked_mul(other.0) {
-            Some(value) => Ok(BigNum(value)),
-            None => Err(JsError::from_str("overflow")),
-        }
+        <Self as num::CheckedMul>::checked_mul(&self, other)
+            .ok_or_else(|| JsError::from_str("overflow"))
     }
 
     pub fn checked_add(&self, other: &BigNum) -> Result<BigNum, JsError> {
-        match self.0.checked_add(other.0) {
-            Some(value) => Ok(BigNum(value)),
-            None => Err(JsError::from_str("overflow")),
-        }
+        <Self as num::CheckedAdd>::checked_add(&self, other)
+            .ok_or_else(|| JsError::from_str("overflow"))
     }
 
     pub fn checked_sub(&self, other: &BigNum) -> Result<BigNum, JsError> {
-        match self.0.checked_sub(other.0) {
-            Some(value) => Ok(BigNum(value)),
-            None => Err(JsError::from_str("underflow")),
-        }
+        <Self as num::CheckedSub>::checked_sub(&self, other)
+            .ok_or_else(|| JsError::from_str("underflow"))
     }
 
     /// returns 0 if it would otherwise underflow

--- a/rust/src/protocol_types/numeric/int.rs
+++ b/rust/src/protocol_types/numeric/int.rs
@@ -9,6 +9,14 @@ impl_to_from!(Int);
 impl_num_from!(Int, i32, u32, i64, u64, BigNum);
 impl_num_into!(Int, i128);
 
+impl std::ops::Neg for Int {
+    type Output = Int;
+
+    fn neg(self) -> Self::Output {
+        Self(-self.0)
+    }
+}
+
 #[wasm_bindgen]
 impl Int {
     pub fn new(x: &BigNum) -> Self {


### PR DESCRIPTION
Adds:
- `Checked{Add,Sub,Mul,Div}` for `BigNum`, `BigInt` and `Int`
- `Neg` for `Int` and `BigInt`
- `Default` for `BigInt`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the public trait surface for core numeric wrappers and adjusts `BigNum` checked ops to route through trait implementations, which could affect downstream generic code and overflow/underflow behavior if assumptions differ.
> 
> **Overview**
> **Numeric wrapper types now implement additional standard numeric traits.** The `impl_num_ops!` macro adds `num_traits::Checked{Add,Sub,Mul,Div}` implementations for all wrapper types that use it, with new property/unit tests covering overflow/underflow and divide-by-zero cases.
> 
> `BigInt` gains `Default` and `std::ops::Neg`, and `Int` gains `std::ops::Neg`. `BigNum`’s `checked_add`/`checked_mul`/`checked_sub` methods are refactored to delegate to the corresponding `Checked*` trait impls while preserving the same `JsError` messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5564f8878fe47028c8f28350f1d56f9b1ef2d200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->