### PR TITLE
feat: Deref, AsRef<[T]>, Default for Vec wrappers

### DIFF
--- a/rust/src/builders/script_structs/plutus_witnesses.rs
+++ b/rust/src/builders/script_structs/plutus_witnesses.rs
@@ -58,9 +58,3 @@ impl PlutusWitnesses {
 }
 
 impl_vec_wrapper!(PlutusWitnesses, PlutusWitness);
-
-impl From<Vec<PlutusWitness>> for PlutusWitnesses {
-    fn from(scripts: Vec<PlutusWitness>) -> Self {
-        Self(scripts)
-    }
-}

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -81,50 +81,11 @@ macro_rules! impl_num_ops {
 }
 
 macro_rules! impl_vec_wrapper {
+    ($wrapper:ident, $item:ty, $field:ident) => {
+        impl_vec_wrapper!(@inner $wrapper, $item, $field);
+    };
     ($wrapper:ident, $item:ty) => {
-        impl<'a> std::iter::IntoIterator for &'a $wrapper {
-            type Item = &'a $item;
-            type IntoIter = std::slice::Iter<'a, $item>;
-
-            fn into_iter(self) -> std::slice::Iter<'a, $item> {
-                self.0.iter()
-            }
-        }
-
-        impl std::iter::IntoIterator for $wrapper {
-            type Item = $item;
-            type IntoIter = std::vec::IntoIter<$item>;
-
-            fn into_iter(self) -> std::vec::IntoIter<$item> {
-                self.0.into_iter()
-            }
-        }
-
-        impl std::iter::FromIterator<$item> for $wrapper {
-            fn from_iter<I: IntoIterator<Item = $item>>(iter: I) -> Self {
-                Self(iter.into_iter().collect())
-            }
-        }
-
-        impl std::iter::Extend<$item> for $wrapper {
-            fn extend<I: IntoIterator<Item = $item>>(&mut self, iter: I) {
-                self.0.extend(iter);
-            }
-        }
-
-        impl std::ops::Index<usize> for $wrapper {
-            type Output = $item;
-
-            fn index(&self, index: usize) -> &$item {
-                &self.0[index]
-            }
-        }
-
-        impl<const N: usize> std::convert::From<[$item; N]> for $wrapper {
-            fn from(slice: [$item; N]) -> $wrapper {
-                Self(Vec::from(slice))
-            }
-        }
+        impl_vec_wrapper!(@inner $wrapper, $item, 0);
 
         impl std::convert::From<Vec<$item>> for $wrapper {
             fn from(vec: Vec<$item>) -> $wrapper {
@@ -137,18 +98,69 @@ macro_rules! impl_vec_wrapper {
                 Self(Vec::new())
             }
         }
+    };
+    (@inner $wrapper:ident, $item:ty, $field:tt) => {
+        impl<'a> std::iter::IntoIterator for &'a $wrapper {
+            type Item = &'a $item;
+            type IntoIter = std::slice::Iter<'a, $item>;
+
+            fn into_iter(self) -> std::slice::Iter<'a, $item> {
+                self.$field.iter()
+            }
+        }
+
+        impl std::iter::IntoIterator for $wrapper {
+            type Item = $item;
+            type IntoIter = std::vec::IntoIter<$item>;
+
+            fn into_iter(self) -> std::vec::IntoIter<$item> {
+                self.$field.into_iter()
+            }
+        }
+
+        impl std::iter::FromIterator<$item> for $wrapper {
+            fn from_iter<I: IntoIterator<Item = $item>>(iter: I) -> Self {
+                Self::from(iter.into_iter().collect::<Vec<_>>())
+            }
+        }
+
+        impl std::iter::Extend<$item> for $wrapper {
+            fn extend<I: IntoIterator<Item = $item>>(&mut self, iter: I) {
+                self.$field.extend(iter);
+            }
+        }
+
+        impl std::ops::Index<usize> for $wrapper {
+            type Output = $item;
+
+            fn index(&self, index: usize) -> &$item {
+                &self.$field[index]
+            }
+        }
+
+        impl<const N: usize> std::convert::From<[$item; N]> for $wrapper {
+            fn from(slice: [$item; N]) -> $wrapper {
+                Self::from(Vec::from(slice))
+            }
+        }
 
         impl std::ops::Deref for $wrapper {
             type Target = [$item];
 
             fn deref(&self) -> &[$item] {
-                &self.0
+                &self.$field
             }
         }
 
         impl AsRef<[$item]> for $wrapper {
             fn as_ref(&self) -> &[$item] {
-                &self.0
+                &self.$field
+            }
+        }
+
+        impl $crate::NoneOrEmpty for $wrapper {
+            fn is_none_or_empty(&self) -> bool {
+                self.$field.is_empty()
             }
         }
     };
@@ -313,6 +325,92 @@ mod tests {
             let wrapper = TestWrapper(vec![1, 2, 3]);
             let slice: &[u32] = wrapper.as_ref();
             assert_eq!(slice.len(), 3);
+        }
+
+        #[test]
+        fn none_or_empty() {
+            use crate::NoneOrEmpty;
+            assert!(TestWrapper(vec![]).is_none_or_empty());
+            assert!(!TestWrapper(vec![1]).is_none_or_empty());
+        }
+    }
+
+    mod impl_vec_wrapper_named_field {
+        #[derive(Debug, PartialEq)]
+        struct TestNamedWrapper {
+            items: Vec<u32>,
+            extra: Option<bool>,
+        }
+
+        impl_vec_wrapper!(TestNamedWrapper, u32, items);
+
+        impl From<Vec<u32>> for TestNamedWrapper {
+            fn from(items: Vec<u32>) -> Self {
+                Self { items, extra: None }
+            }
+        }
+
+        #[quickcheck]
+        fn uses_vec_into_iterator_owned(vec: Vec<u32>) {
+            let wrapper = TestNamedWrapper { items: vec.clone(), extra: None };
+            assert_eq!(wrapper.into_iter().collect::<Vec<_>>(), vec);
+        }
+
+        #[quickcheck]
+        fn uses_vec_into_iterator_ref(vec: Vec<u32>) {
+            let wrapper = TestNamedWrapper { items: vec.clone(), extra: None };
+            assert_eq!(
+                (&wrapper).into_iter().collect::<Vec<_>>(),
+                vec.iter().collect::<Vec<_>>()
+            );
+        }
+
+        #[quickcheck]
+        fn uses_vec_from_iterator(vec: Vec<u32>) {
+            let wrapper: TestNamedWrapper = vec.clone().into_iter().collect();
+            assert_eq!(wrapper.items, vec);
+            assert_eq!(wrapper.extra, None);
+        }
+
+        #[quickcheck]
+        fn uses_vec_extend(vec1: Vec<u32>, vec2: Vec<u32>) {
+            let mut wrapper = TestNamedWrapper { items: vec1.clone(), extra: Some(true) };
+            wrapper.extend(vec2.iter().cloned());
+            assert_eq!(wrapper.items, [vec1, vec2].concat());
+            assert_eq!(wrapper.extra, Some(true));
+        }
+
+        #[quickcheck]
+        fn uses_vec_index(vec: Vec<u32>, index: usize) {
+            let len = vec.len();
+            if len != 0 {
+                let wrapper = TestNamedWrapper { items: vec.clone(), extra: None };
+                assert_eq!(wrapper[index % len], vec[index % len]);
+            }
+        }
+
+        #[test]
+        fn from_slice_delegates_to_from_vec() {
+            let wrapper = TestNamedWrapper::from([1, 2, 3]);
+            assert_eq!(wrapper.items, vec![1, 2, 3]);
+            assert_eq!(wrapper.extra, None);
+        }
+
+        #[test]
+        fn deref_to_slice() {
+            let wrapper = TestNamedWrapper { items: vec![1, 2, 3], extra: None };
+            let slice: &[u32] = &wrapper;
+            assert_eq!(slice, &[1, 2, 3]);
+            assert_eq!(wrapper.first(), Some(&1));
+        }
+
+        #[test]
+        fn none_or_empty() {
+            use crate::NoneOrEmpty;
+            let empty = TestNamedWrapper { items: vec![], extra: None };
+            let non_empty = TestNamedWrapper { items: vec![1], extra: None };
+            assert!(empty.is_none_or_empty());
+            assert!(!non_empty.is_none_or_empty());
         }
     }
 }

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -126,6 +126,12 @@ macro_rules! impl_vec_wrapper {
             }
         }
 
+        impl std::convert::From<Vec<$item>> for $wrapper {
+            fn from(vec: Vec<$item>) -> $wrapper {
+                Self(vec)
+            }
+        }
+
         impl Default for $wrapper {
             fn default() -> Self {
                 Self(Vec::new())
@@ -279,6 +285,11 @@ mod tests {
             let mut arr = [0; 32];
             arr.copy_from_slice(&(0..32).collect::<Vec<_>>());
             assert_eq!(TestWrapper::from(arr.clone()), TestWrapper(arr.to_vec()))
+        }
+
+        #[quickcheck]
+        fn from_wraps_vec(vec: Vec<u32>) {
+            assert_eq!(TestWrapper::from(vec.clone()), TestWrapper(vec))
         }
 
         #[test]

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -125,6 +125,26 @@ macro_rules! impl_vec_wrapper {
                 Self(Vec::from(slice))
             }
         }
+
+        impl Default for $wrapper {
+            fn default() -> Self {
+                Self(Vec::new())
+            }
+        }
+
+        impl std::ops::Deref for $wrapper {
+            type Target = [$item];
+
+            fn deref(&self) -> &[$item] {
+                &self.0
+            }
+        }
+
+        impl AsRef<[$item]> for $wrapper {
+            fn as_ref(&self) -> &[$item] {
+                &self.0
+            }
+        }
     };
 }
 
@@ -259,6 +279,29 @@ mod tests {
             let mut arr = [0; 32];
             arr.copy_from_slice(&(0..32).collect::<Vec<_>>());
             assert_eq!(TestWrapper::from(arr.clone()), TestWrapper(arr.to_vec()))
+        }
+
+        #[test]
+        fn default_is_empty() {
+            let wrapper = TestWrapper::default();
+            assert!(wrapper.is_empty());
+            assert!(!TestWrapper(vec![1]).is_empty());
+        }
+
+        #[test]
+        fn deref_to_slice() {
+            let wrapper = TestWrapper(vec![1, 2, 3]);
+            let slice: &[u32] = &wrapper;
+            assert_eq!(slice, &[1, 2, 3]);
+            assert_eq!(wrapper.first(), Some(&1));
+            assert_eq!(wrapper.last(), Some(&3));
+        }
+
+        #[test]
+        fn as_ref_slice() {
+            let wrapper = TestWrapper(vec![1, 2, 3]);
+            let slice: &[u32] = wrapper.as_ref();
+            assert_eq!(slice.len(), 3);
         }
     }
 }

--- a/rust/src/protocol_types/native_scripts.rs
+++ b/rust/src/protocol_types/native_scripts.rs
@@ -1,5 +1,4 @@
 use crate::*;
-use std::vec::IntoIter;
 use std::slice::{Iter, IterMut};
 
 #[wasm_bindgen]
@@ -72,6 +71,7 @@ impl NativeScripts {
 }
 
 impl_to_from!(NativeScripts);
+impl_vec_wrapper!(NativeScripts, NativeScript, scripts);
 
 impl PartialEq for NativeScripts {
     fn eq(&self, other: &Self) -> bool {
@@ -111,12 +111,6 @@ impl From<Vec<&NativeScript>> for NativeScripts {
     }
 }
 
-impl NoneOrEmpty for NativeScripts {
-    fn is_none_or_empty(&self) -> bool {
-        self.scripts.is_empty()
-    }
-}
-
 impl From<&NativeScripts> for Ed25519KeyHashes {
     fn from(scripts: &NativeScripts) -> Self {
         scripts
@@ -125,24 +119,6 @@ impl From<&NativeScripts> for Ed25519KeyHashes {
                 set.extend_move(Ed25519KeyHashes::from(s));
                 set
             })
-    }
-}
-
-impl IntoIterator for NativeScripts {
-    type Item = NativeScript;
-    type IntoIter = IntoIter<NativeScript>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.scripts.into_iter()
-    }
-}
-
-impl<'a> IntoIterator for &'a NativeScripts {
-    type Item = &'a NativeScript;
-    type IntoIter = Iter<'a, NativeScript>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.scripts.iter()
     }
 }
 

--- a/rust/src/protocol_types/plutus/plutus_data.rs
+++ b/rust/src/protocol_types/plutus/plutus_data.rs
@@ -77,6 +77,14 @@ pub struct PlutusMapValues {
     pub(crate) elems: Vec<PlutusData>,
 }
 
+impl_vec_wrapper!(PlutusMapValues, PlutusData, elems);
+
+impl From<Vec<PlutusData>> for PlutusMapValues {
+    fn from(elems: Vec<PlutusData>) -> Self {
+        Self { elems }
+    }
+}
+
 #[wasm_bindgen]
 impl PlutusMapValues {
     pub fn new() -> Self {
@@ -617,6 +625,7 @@ pub struct PlutusList {
 }
 
 to_from_bytes!(PlutusList);
+impl_vec_wrapper!(PlutusList, PlutusData, elems);
 
 #[wasm_bindgen]
 impl PlutusList {
@@ -692,12 +701,6 @@ impl PlutusList {
     }
 }
 
-impl NoneOrEmpty for PlutusList {
-    fn is_none_or_empty(&self) -> bool {
-        self.elems.is_empty()
-    }
-}
-
 #[derive(serde::Deserialize, JsonSchema)]
 struct PlutusListFields {
     elems: Vec<PlutusData>,
@@ -740,15 +743,6 @@ impl JsonSchema for PlutusList {
     }
     fn is_referenceable() -> bool {
         PlutusListFields::is_referenceable()
-    }
-}
-
-impl<'a> IntoIterator for &'a PlutusList {
-    type Item = &'a PlutusData;
-    type IntoIter = std::slice::Iter<'a, PlutusData>;
-
-    fn into_iter(self) -> std::slice::Iter<'a, PlutusData> {
-        self.elems.iter()
     }
 }
 

--- a/rust/src/protocol_types/plutus/plutus_scripts.rs
+++ b/rust/src/protocol_types/plutus/plutus_scripts.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use itertools::Itertools;
-use std::slice;
 use crate::*;
 
 #[wasm_bindgen]
@@ -11,10 +10,11 @@ pub struct PlutusScripts {
 }
 
 impl_to_from!(PlutusScripts);
+impl_vec_wrapper!(PlutusScripts, PlutusScript, scripts);
 
-impl NoneOrEmpty for PlutusScripts {
-    fn is_none_or_empty(&self) -> bool {
-        self.scripts.is_empty()
+impl From<Vec<PlutusScript>> for PlutusScripts {
+    fn from(scripts: Vec<PlutusScript>) -> Self {
+        Self { scripts, cbor_set_type: None }
     }
 }
 
@@ -142,15 +142,6 @@ impl PlutusScripts {
         if let Some(m) = &mut self.cbor_set_type {
             m.insert(language.clone(), cbor_set_type);
         }
-    }
-}
-
-impl<'a> IntoIterator for &'a PlutusScripts {
-    type Item = &'a PlutusScript;
-    type IntoIter = slice::Iter<'a, PlutusScript>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.scripts.iter()
     }
 }
 

--- a/rust/src/protocol_types/plutus/redeemers.rs
+++ b/rust/src/protocol_types/plutus/redeemers.rs
@@ -8,6 +8,7 @@ pub struct Redeemers {
 }
 
 impl_to_from!(Redeemers);
+impl_vec_wrapper!(Redeemers, Redeemer, redeemers);
 
 #[wasm_bindgen]
 impl Redeemers {
@@ -58,12 +59,6 @@ impl Redeemers {
             tot_steps = tot_steps.checked_add(&r.ex_units().steps())?;
         }
         Ok(ExUnits::new(&tot_mem, &tot_steps))
-    }
-}
-
-impl NoneOrEmpty for Redeemers {
-    fn is_none_or_empty(&self) -> bool {
-        self.redeemers.is_empty()
     }
 }
 


### PR DESCRIPTION
1. Implements `From<Vec<T>>`, `Default`, `AsRef<[T]>` and `Deref<Target = [T]>` for all `Vec` wrappers that use `impl_vec_wrapper`. The last two give use access to all slice functions and automatic reference casts, so eg. `&TransactionUnspentOutputs` can be passed to any function expecting `&[TransactionUnspentOutput]`.
2. Changes `impl_vec_wrapper` to also support implementing the same traits for non-tuple wrappers and uses it for `PlutusList`, `PlutusScripts, `Redeemers`, `NativeScripts`, and `PlutusMapValues`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds convenience trait impls and refactors several wrappers to use the shared macro, with minimal behavioral change beyond new conversions and slice-like access.
> 
> **Overview**
> Adds broader trait support to `impl_vec_wrapper!`: **`From<Vec<T>>`, `Default`, `Deref<Target=[T]>`, `AsRef<[T]>`, and `NoneOrEmpty`**, plus a new macro form that works with wrappers whose `Vec` lives in a *named field*.
> 
> Refactors `NativeScripts`, `PlutusList`, `PlutusScripts`, `Redeemers`, and `PlutusMapValues` to use the updated macro and removes their bespoke `IntoIterator`/`NoneOrEmpty` impls; also drops a now-redundant `From<Vec<_>>` impl for `PlutusWitnesses`. Adds macro tests covering the new behaviors and named-field wrappers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a909e18d19d5d715aae57e3a3219d4776e6e622b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->