### PR TITLE
fix: Rust compilation errors for --all-features

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "rust:publish": "cd rust && cargo publish && cd ../",
     "asm:build": "./binaryen/bin/wasm2js ./rust/pkg/cardano_serialization_lib_bg.wasm --output ./rust/pkg/cardano_serialization_lib.asm.js && node ./scripts/wasm-to-asm && node ./scripts/fix-buffer-ref.js",
     "rust:check-warnings": "(cd rust; RUSTFLAGS=\"-D warnings\" cargo +stable build)",
-    "rust:test": "(cd rust; cargo test)",
+    "rust:test": "(cd rust; cargo test --all-features --all-targets)",
     "js:flowgen": "flowgen ./rust/pkg/cardano_serialization_lib.d.ts -o ./rust/pkg/cardano_serialization_lib.js.flow --add-flow-header",
     "js:prepublish": "npm run rust:test && rimraf ./publish && cp -r ./rust/pkg ./publish && cp README.md publish/ && cp LICENSE publish/",
     "js:ts-json-gen": "cd rust/json-gen && cargo +stable run && cd ../.. && node ./scripts/run-json2ts.js && node ./scripts/json-ts-types.js",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "rust:publish": "cd rust && cargo publish && cd ../",
     "asm:build": "./binaryen/bin/wasm2js ./rust/pkg/cardano_serialization_lib_bg.wasm --output ./rust/pkg/cardano_serialization_lib.asm.js && node ./scripts/wasm-to-asm && node ./scripts/fix-buffer-ref.js",
     "rust:check-warnings": "(cd rust; RUSTFLAGS=\"-D warnings\" cargo +stable build)",
-    "rust:test": "(cd rust; cargo test --all-features --all-targets)",
+    "rust:test": "(cd rust; cargo +nightly test --all-features --all-targets)",
     "js:flowgen": "flowgen ./rust/pkg/cardano_serialization_lib.d.ts -o ./rust/pkg/cardano_serialization_lib.js.flow --add-flow-header",
     "js:prepublish": "npm run rust:test && rimraf ./publish && cp -r ./rust/pkg ./publish && cp README.md publish/ && cp LICENSE publish/",
     "js:ts-json-gen": "cd rust/json-gen && cargo +stable run && cd ../.. && node ./scripts/run-json2ts.js && node ./scripts/json-ts-types.js",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 default = ["arbitrary-precision-json"]
 arbitrary-precision-json = ["serde_json/arbitrary_precision"]
 #TODO: need to review the features and delete legacy ones. List is defined to avoid warnings.
-property-test-api = []
+property-test-api = ["dep:quickcheck", "dep:rand_chacha"]
 generic-serialization = []
 with-bench = []
 dont-expose-wasm = []
@@ -47,6 +47,8 @@ serde = { version = "1.0", features = ["derive"] }
 num-derive = "0.4.0"
 num-traits = "0.2.16"
 num = "0.4.1"
+quickcheck = { version = "0.9.2", optional = true }
+rand_chacha = { version = "0.1", optional = true }
 
 # non-wasm
 [target.'cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))'.dependencies]

--- a/rust/src/legacy_address/address.rs
+++ b/rust/src/legacy_address/address.rs
@@ -26,7 +26,7 @@ use crate::wasm_bindgen;
 
 #[wasm_bindgen]
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
-#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "generic-serialization", derive(serde::Serialize, serde::Deserialize))]
 pub enum ByronAddressType {
     ATPubKey,
     ATScript,

--- a/rust/src/legacy_address/cbor.rs
+++ b/rust/src/legacy_address/cbor.rs
@@ -59,7 +59,6 @@ pub mod util {
         use super::*;
         use cbor_event::{
             self,
-            de::RawCbor,
             se::{Serialize, Serializer},
         };
 
@@ -76,15 +75,14 @@ pub mod util {
         #[bench]
         fn encode_crc32_with_cbor_event(b: &mut test::Bencher) {
             b.iter(|| {
-                let _ = encode_with_crc32_(&Test(BYTES), Serializer::new_vec()).unwrap();
+                let _ = encode_with_crc32_(&Test(BYTES), &mut Serializer::new_vec()).unwrap();
             })
         }
 
         #[bench]
         fn decode_crc32_with_cbor_event(b: &mut test::Bencher) {
             b.iter(|| {
-                let mut raw = RawCbor::from(CBOR);
-                let bytes = raw_with_crc32(&mut raw).unwrap();
+                let _ = raw_with_crc32(&mut Deserializer::from(CBOR)).unwrap();
             })
         }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "with-bench", feature(test))]
+#![cfg_attr(all(test, feature = "with-bench"), feature(test))]
 #![allow(deprecated)]
 
 #[macro_use]


### PR DESCRIPTION
Fixes small compilation issues in code behind feature flags that weren't covered by CI:

1. missing crate dependencies for `property-test-api` (quickcheck and rand_chacha)
2. compile errors in code behind `with-bench` feature, most likely caused by `cbor_event` version change
3. serde derivations for `ByronAddressType`

Also adds `--all-features --all-targets` in `rust:test` npm target, which should catch similar issues in the future.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to feature-flagged compilation fixes (optional deps, serde derive path, bench code) plus broader test coverage via `cargo test --all-features --all-targets`.
> 
> **Overview**
> Fixes Rust build failures when running with `--all-features` by wiring the `property-test-api` feature to optional deps (`quickcheck`, `rand_chacha`) and updating `ByronAddressType`’s conditional serde derives to use fully-qualified `serde::Serialize/Deserialize`.
> 
> Adjusts `with-bench`-gated code to match newer `cbor_event` APIs (serializer mut refs and deserializer usage) and tightens the crate-level `test` feature gate to `all(test, feature = "with-bench")`. Updates the npm `rust:test` script to run `cargo test --all-features --all-targets` to catch similar feature-flag issues earlier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8454d2ebe0650ae0008ab984a0848361aea3336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->