### PR TITLE
feat: More std traits for public types

### DIFF
--- a/rust/src/legacy_address/address.rs
+++ b/rust/src/legacy_address/address.rs
@@ -25,8 +25,8 @@ use std::{
 use crate::wasm_bindgen;
 
 #[wasm_bindgen]
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
-#[cfg_attr(feature = "generic-serialization", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
+#[cfg_attr(feature = "generic-serialization", derive(serde::Serialize, serde::Deserialize))]
 pub enum ByronAddressType {
     ATPubKey,
     ATScript,
@@ -279,7 +279,7 @@ impl cbor_event::de::Deserialize for Addr {
 const EXTENDED_ADDR_LEN: usize = 28;
 
 /// A valid cardano address deconstructed
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct ExtendedAddr {
     pub addr: [u8; EXTENDED_ADDR_LEN],
     pub attributes: Attributes,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -800,7 +800,7 @@ impl RewardAddresses {
 impl_vec_wrapper!(RewardAddresses, RewardAddress);
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Withdrawals(LinkedHashMap<RewardAddress, Coin>);
 
 impl_to_from!(Withdrawals);
@@ -1019,7 +1019,7 @@ impl ScriptHashes {
 impl_vec_wrapper!(ScriptHashes, ScriptHash);
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ProposedProtocolParameterUpdates(
     LinkedHashMap<GenesisHash, ProtocolParamUpdate>,
 );
@@ -1128,7 +1128,7 @@ impl ProtocolVersion {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct AuxiliaryDataSet(LinkedHashMap<TransactionIndex, AuxiliaryData>);
 
 #[wasm_bindgen]
@@ -1546,7 +1546,7 @@ impl_vec_wrapper!(MintsAssets, MintAssets);
 
 #[wasm_bindgen]
 #[derive(
-    Clone, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize, JsonSchema,
+    Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize, JsonSchema,
 )]
 pub struct MintAssets(std::collections::BTreeMap<AssetName, Int>);
 
@@ -1596,7 +1596,7 @@ impl MintAssets {
 
 #[wasm_bindgen]
 #[derive(
-    Clone, Debug, Eq, Ord, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize, JsonSchema,
+    Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize, JsonSchema,
 )]
 pub struct Mint(Vec<(PolicyID, MintAssets)>);
 

--- a/rust/src/protocol_types/address.rs
+++ b/rust/src/protocol_types/address.rs
@@ -56,7 +56,7 @@ impl NetworkInfo {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct MalformedAddress(pub(crate) Vec<u8>);
 
 #[wasm_bindgen]
@@ -119,7 +119,7 @@ impl JsonSchema for MalformedAddress {
     }
 }
 
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub(crate) enum AddrType {
     Base(BaseAddress),
     Ptr(PointerAddress),
@@ -130,7 +130,7 @@ pub(crate) enum AddrType {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct ByronAddress(pub(crate) ExtendedAddr);
 #[wasm_bindgen]
 impl ByronAddress {
@@ -235,7 +235,7 @@ impl ByronAddress {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct Address(pub(crate) AddrType);
 
 from_bytes!(Address, data, { Self::from_bytes_impl_safe(data.as_ref()) });
@@ -571,7 +571,7 @@ impl Deserialize for Address {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct BaseAddress {
     pub(crate) network: u8,
     pub(crate) payment: Credential,
@@ -613,7 +613,7 @@ impl BaseAddress {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct EnterpriseAddress {
     pub(crate) network: u8,
     pub(crate) payment: Credential,
@@ -752,7 +752,7 @@ impl Deserialize for RewardAddress {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct PointerAddress {
     pub(crate) network: u8,
     pub(crate) payment: Credential,

--- a/rust/src/protocol_types/address.rs
+++ b/rust/src/protocol_types/address.rs
@@ -56,7 +56,7 @@ impl NetworkInfo {
 }
 
 #[wasm_bindgen]
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Hash)]
+#[derive(Debug, Clone, Default, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct MalformedAddress(pub(crate) Vec<u8>);
 
 #[wasm_bindgen]

--- a/rust/src/protocol_types/certificates/certificates_collection.rs
+++ b/rust/src/protocol_types/certificates/certificates_collection.rs
@@ -8,7 +8,7 @@ use std::slice;
 use std::sync::Arc;
 
 #[wasm_bindgen]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Certificates {
     pub(crate) certs: Vec<Arc<Certificate>>,
     pub(crate) dedup: HashSet<Arc<Certificate>>,

--- a/rust/src/protocol_types/certificates/move_instantaneous_rewards_cert.rs
+++ b/rust/src/protocol_types/certificates/move_instantaneous_rewards_cert.rs
@@ -80,7 +80,7 @@ pub enum MIRKind {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Default, Hash, Eq, Ord, PartialEq, PartialOrd)]
 pub struct MIRToStakeCredentials {
     pub(crate) rewards: LinkedHashMap<Credential, DeltaCoin>,
 }

--- a/rust/src/protocol_types/credential.rs
+++ b/rust/src/protocol_types/credential.rs
@@ -40,14 +40,26 @@ JsonSchema,
 )]
 pub struct Credential(pub(crate) CredType);
 
+impl From<ScriptHash> for Credential {
+    fn from(hash: ScriptHash) -> Self {
+        Credential(CredType::Script(hash))
+    }
+}
+
+impl From<Ed25519KeyHash> for Credential {
+    fn from(hash: Ed25519KeyHash) -> Self {
+        Credential(CredType::Key(hash))
+    }
+}
+
 #[wasm_bindgen]
 impl Credential {
     pub fn from_keyhash(hash: &Ed25519KeyHash) -> Self {
-        Credential(CredType::Key(hash.clone()))
+        Credential::from(hash.clone())
     }
 
     pub fn from_scripthash(hash: &ScriptHash) -> Self {
-        Credential(CredType::Script(hash.clone()))
+        Self::from(hash.clone())
     }
 
     pub fn to_keyhash(&self) -> Option<Ed25519KeyHash> {

--- a/rust/src/protocol_types/credentials.rs
+++ b/rust/src/protocol_types/credentials.rs
@@ -9,6 +9,7 @@ use crate::*;
 #[derive(
     Clone,
     Debug,
+    Default
 )]
 pub struct Credentials {
     pub(crate) credentials: Vec<Arc<Credential>>,

--- a/rust/src/protocol_types/ed25519_key_hashes.rs
+++ b/rust/src/protocol_types/ed25519_key_hashes.rs
@@ -13,6 +13,7 @@ pub type RequiredSigners = Ed25519KeyHashes;
 #[derive(
     Clone,
     Debug,
+    Default
 )]
 pub struct Ed25519KeyHashes {
     keyhashes: Vec<Arc<Ed25519KeyHash>>,

--- a/rust/src/protocol_types/governance/proposals/treasury_withdrawals.rs
+++ b/rust/src/protocol_types/governance/proposals/treasury_withdrawals.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
     PartialEq,
     PartialOrd,
     Hash,
+    Default,
     serde::Serialize,
     serde::Deserialize,
     JsonSchema,

--- a/rust/src/protocol_types/governance/proposals/voting_proposals.rs
+++ b/rust/src/protocol_types/governance/proposals/voting_proposals.rs
@@ -13,6 +13,7 @@ use crate::*;
 #[derive(
     Clone,
     Debug,
+    Default
 )]
 pub struct VotingProposals {
     proposals: Vec<Arc<VotingProposal>>,

--- a/rust/src/protocol_types/governance/voting_procedures.rs
+++ b/rust/src/protocol_types/governance/voting_procedures.rs
@@ -39,7 +39,7 @@ struct Vote {
     voting_procedure: VotingProcedure,
 }
 
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Hash)]
 #[wasm_bindgen]
 pub struct VotingProcedures(
     pub(crate) BTreeMap<Voter, BTreeMap<GovernanceActionId, VotingProcedure>>,

--- a/rust/src/protocol_types/metadata.rs
+++ b/rust/src/protocol_types/metadata.rs
@@ -4,7 +4,7 @@ use hashlink::LinkedHashMap;
 const MD_MAX_LEN: usize = 64;
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct MetadataMap(pub(crate) LinkedHashMap<TransactionMetadatum, TransactionMetadatum>);
 
 to_from_bytes!(MetadataMap);
@@ -282,7 +282,7 @@ impl TransactionMetadatumLabels {
 impl_vec_wrapper!(TransactionMetadatumLabels, TransactionMetadatumLabel);
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct GeneralTransactionMetadata(
     pub(crate) LinkedHashMap<TransactionMetadatumLabel, TransactionMetadatum>,
 );
@@ -358,7 +358,7 @@ impl JsonSchema for GeneralTransactionMetadata {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Ord, PartialOrd, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Ord, PartialOrd, serde::Serialize, serde::Deserialize, JsonSchema)]
 pub struct AuxiliaryData {
     pub(crate) metadata: Option<GeneralTransactionMetadata>,
     pub(crate) native_scripts: Option<NativeScripts>,

--- a/rust/src/protocol_types/native_scripts.rs
+++ b/rust/src/protocol_types/native_scripts.rs
@@ -3,7 +3,7 @@ use std::slice::{Iter, IterMut};
 
 #[wasm_bindgen]
 #[derive(
-    Clone, Debug
+    Clone, Debug, Default
 )]
 pub struct NativeScripts {
     pub(crate) scripts: Vec<NativeScript>,

--- a/rust/src/protocol_types/plutus/cost_model.rs
+++ b/rust/src/protocol_types/plutus/cost_model.rs
@@ -4,6 +4,7 @@ use crate::*;
 #[derive(
     Clone,
     Debug,
+    Default,
     Hash,
     Eq,
     Ord,

--- a/rust/src/protocol_types/plutus/cost_models.rs
+++ b/rust/src/protocol_types/plutus/cost_models.rs
@@ -4,6 +4,7 @@ use crate::*;
 #[derive(
     Clone,
     Debug,
+    Default,
     Hash,
     Eq,
     Ord,

--- a/rust/src/protocol_types/plutus/plutus_data.rs
+++ b/rust/src/protocol_types/plutus/plutus_data.rs
@@ -13,7 +13,7 @@ use schemars::JsonSchema;
 use serde::ser::SerializeStruct;
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct ConstrPlutusData {
     pub(crate) alternative: BigNum,
     pub(crate) data: PlutusList,
@@ -110,7 +110,7 @@ impl PlutusMapValues {
 
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+#[derive(Clone, Default, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct PlutusMap(pub(crate) LinkedHashMap<PlutusData, PlutusMapValues>);
 
 to_from_bytes!(PlutusMap);
@@ -614,7 +614,7 @@ impl<'de> serde::de::Deserialize<'de> for PlutusData {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PlutusList {
     pub(crate) elems: Vec<PlutusData>,
     // We should always preserve the original datums when deserialized as this is NOT canonicized

--- a/rust/src/protocol_types/plutus/plutus_scripts.rs
+++ b/rust/src/protocol_types/plutus/plutus_scripts.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 use crate::*;
 
 #[wasm_bindgen]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PlutusScripts {
     scripts: Vec<PlutusScript>,
     cbor_set_type: Option<HashMap<Language, CborSetType>>,

--- a/rust/src/protocol_types/plutus/redeemers.rs
+++ b/rust/src/protocol_types/plutus/redeemers.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Ord, PartialOrd)]
+#[derive(Clone, Debug, Default, Ord, PartialOrd)]
 pub struct Redeemers {
     pub(crate) redeemers: Vec<Redeemer>,
     pub(crate) serialization_format: Option<CborContainerType>,

--- a/rust/src/protocol_types/pointer.rs
+++ b/rust/src/protocol_types/pointer.rs
@@ -9,7 +9,7 @@ use std::convert::TryInto;
 use std::io::{Cursor, Read};
 
 #[wasm_bindgen]
-#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct Pointer {
     pub(crate) slot: BigNum,
     pub(crate) tx_index: BigNum,

--- a/rust/src/protocol_types/protocol_param_update.rs
+++ b/rust/src/protocol_types/protocol_param_update.rs
@@ -204,6 +204,7 @@ impl DRepVotingThresholds {
 #[derive(
     Clone,
     Debug,
+    Default,
     Hash,
     Eq,
     Ord,

--- a/rust/src/protocol_types/tx_inputs.rs
+++ b/rust/src/protocol_types/tx_inputs.rs
@@ -7,7 +7,7 @@ use std::slice;
 use std::sync::Arc;
 
 #[wasm_bindgen]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct TransactionInputs {
     pub(crate) inputs: Vec<Arc<TransactionInput>>,
     pub(crate) dedup: BTreeSet<Arc<TransactionInput>>,

--- a/rust/src/protocol_types/witnesses/bootstrap_witnesses.rs
+++ b/rust/src/protocol_types/witnesses/bootstrap_witnesses.rs
@@ -9,7 +9,7 @@ use schemars::JsonSchema;
 use crate::*;
 
 #[wasm_bindgen]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct BootstrapWitnesses {
     witnesses: Vec<Arc<BootstrapWitness>>,
     dedup: HashSet<Arc<BootstrapWitness>>,

--- a/rust/src/protocol_types/witnesses/transaction_witnesses_set.rs
+++ b/rust/src/protocol_types/witnesses/transaction_witnesses_set.rs
@@ -29,7 +29,7 @@ impl TransactionWitnessSetRaw {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Eq, PartialEq, Debug, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[derive(Clone, Default, Eq, PartialEq, Debug, serde::Serialize, serde::Deserialize, JsonSchema)]
 pub struct TransactionWitnessSet {
     pub(crate) vkeys: Option<Vkeywitnesses>,
     pub(crate) native_scripts: Option<NativeScripts>,

--- a/rust/src/protocol_types/witnesses/vkeywitnesses.rs
+++ b/rust/src/protocol_types/witnesses/vkeywitnesses.rs
@@ -12,6 +12,7 @@ use crate::*;
 #[derive(
     Clone,
     Debug,
+    Default
 )]
 pub struct Vkeywitnesses {
     witnesses: Vec<Arc<Vkeywitness>>,

--- a/rust/src/serialization/ser_info/types.rs
+++ b/rust/src/serialization/ser_info/types.rs
@@ -8,8 +8,9 @@ pub enum CborContainerType {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub enum CborSetType {
+    #[default]
     Tagged = 0,
     Untagged = 1,
 }

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -156,14 +156,11 @@ impl_to_from!(Value);
 #[wasm_bindgen]
 impl Value {
     pub fn new(coin: &Coin) -> Value {
-        Self {
-            coin: coin.clone(),
-            multiasset: None,
-        }
+        Self::from(coin.clone())
     }
 
     pub fn new_from_assets(multiasset: &MultiAsset) -> Value {
-        Value::new_with_assets(&Coin::zero(), multiasset)
+        Value::from(multiasset.clone())
     }
 
     pub fn new_with_assets(coin: &Coin, multiasset: &MultiAsset) -> Value {
@@ -287,6 +284,20 @@ impl Value {
             Some(std::cmp::Ordering::Greater) => Some(1),
         }
     }
+}
+
+impl From<MultiAsset> for Value {
+   fn from(ma: MultiAsset) -> Self {
+       Self { coin: Coin::zero(), multiasset: Some(ma) }
+
+   }
+}
+
+impl From<Coin> for Value {
+    fn from(coin: Coin) -> Self {
+       Self { coin, multiasset: None }
+
+   }
 }
 
 impl PartialEq for Value {

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -288,7 +288,7 @@ impl Value {
 
 impl From<MultiAsset> for Value {
    fn from(ma: MultiAsset) -> Self {
-       Self { coin: Coin::zero(), multiasset: Some(ma) }
+       Self { coin: Coin::zero(), multiasset: (ma.len() > 0).then_some(ma) }
 
    }
 }

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -27,7 +27,7 @@ pub fn from_bytes<T: Deserialize>(data: &Vec<u8>) -> Result<T, DeserializeError>
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, JsonSchema)]
 pub struct TransactionUnspentOutput {
     pub(crate) input: TransactionInput,
     pub(crate) output: TransactionOutput,
@@ -111,7 +111,7 @@ impl Deserialize for TransactionUnspentOutput {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, JsonSchema)]
 pub struct TransactionUnspentOutputs(pub(crate) Vec<TransactionUnspentOutput>);
 
 to_from_json!(TransactionUnspentOutputs);


### PR DESCRIPTION
Adds the following trait implementations:
- `From` for `Value` and `Credential` - this is mostly a devex change
- `PartialEq` and `Eq` for `TransactionUnspentOutputs` - useful for testing purposes
- `Default` for most public types - this aids in creating values, but also enables  `std::mem:take` and the like
- `Hash` for address types - enables using addresses as HashMap keys

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive trait derives/impls (`Default`, `Hash`, `Eq/PartialEq`, `From`) on public types with minimal logic changes; risk is mainly downstream compile/API-surface impact for consumers relying on previous trait bounds.
> 
> **Overview**
> Adds more standard trait support across public Rust/WASM-facing types to improve ergonomics.
> 
> Key updates include broad `Default` derives for many collection/map wrappers and protocol structs, `Hash` derives for multiple address-related types (including Byron/Shelley variants) to enable `HashMap` keys, and new `From` conversions for `Credential` (from `ScriptHash`/`Ed25519KeyHash`) and `Value` (from `Coin`/`MultiAsset`) with constructors updated to use these conversions. It also adds `Eq/PartialEq` to `TransactionUnspentOutput(s)` and updates some derives to use explicit `serde::Serialize`/`serde::Deserialize` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01bed13d6a12379b0e43ef6b5a07da713c64995d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->