### PR TITLE
feat: saturating arithmetic for numeric types

### DIFF
--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -102,6 +102,19 @@ macro_rules! impl_num_ops {
             }
         }
     };
+    (@saturating $wrapper:ident, $inner:ty) => {
+        impl num_traits::SaturatingAdd for $wrapper {
+            fn saturating_add(&self, v: &Self) -> Self {
+                Self(num_traits::SaturatingAdd::saturating_add(&self.0, &v.0))
+            }
+        }
+
+        impl num_traits::SaturatingSub for $wrapper {
+            fn saturating_sub(&self, v: &Self) -> Self {
+                Self(num_traits::SaturatingSub::saturating_sub(&self.0, &v.0))
+            }
+        }
+    };
 }
 
 macro_rules! impl_vec_wrapper {
@@ -198,6 +211,7 @@ mod tests {
         impl_num_from!(TestNum, u32, u16, u8);
         impl_num_into!(TestNum, u128, u64);
         impl_num_ops!(TestNum, u64);
+        impl_num_ops!(@saturating TestNum, u64);
 
         #[quickcheck]
         fn from(inner: u32) {
@@ -325,6 +339,26 @@ mod tests {
         fn checked_div_by_zero() {
             use num_traits::CheckedDiv;
             assert_eq!(TestNum(1).checked_div(&TestNum(0)), None);
+        }
+
+        #[quickcheck]
+        fn saturating_add(a: u64, b: u64) {
+            use num_traits::SaturatingAdd;
+            if a <= u64::MAX - b {
+                assert_eq!(TestNum(a).saturating_add(&TestNum(b)), TestNum(a+b));
+            } else {
+                assert_eq!(TestNum(a).saturating_add(&TestNum(b)), TestNum(u64::MAX));
+            }
+        }
+
+        #[quickcheck]
+        fn saturating_sub_within_range(a: u64, b: u64) {
+            use num_traits::SaturatingSub;
+            if a >= b {
+                assert_eq!(TestNum(a).saturating_sub(&TestNum(b)), TestNum(a - b));
+            } else {
+                assert_eq!(TestNum(a).saturating_sub(&TestNum(b)), TestNum(0));
+            }
         }
     }
 

--- a/rust/src/protocol_types/numeric/big_num.rs
+++ b/rust/src/protocol_types/numeric/big_num.rs
@@ -17,6 +17,7 @@ impl_to_from!(BigNum);
 impl_num_from!(BigNum, u8, u16, u32, u64);
 impl_num_into!(BigNum, u64, u128, i128);
 impl_num_ops!(BigNum, u64);
+impl_num_ops!(@saturating BigNum, u64);
 
 impl std::fmt::Display for BigNum {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -71,10 +72,7 @@ impl BigNum {
 
     /// returns 0 if it would otherwise underflow
     pub fn clamped_sub(&self, other: &BigNum) -> BigNum {
-        match self.0.checked_sub(other.0) {
-            Some(value) => BigNum(value),
-            None => BigNum(0),
-        }
+        <Self as num_traits::SaturatingSub>::saturating_sub(self, other)
     }
 
     pub fn compare(&self, rhs_value: &BigNum) -> i8 {


### PR DESCRIPTION
1. Adds a `@saturating` variant to `impl_num_ops` to that genrates saturating op traits for numeric types. It needs to be separate, because these can't be implemented for BigInt, at least not by delegating to the inner type.
2. Uses (2) for `BigNum` and replaces some manual implementations .

This is preliminary work to make it possible to implement all numeric traits for `Value` and co. using the same traits for their component types.

note: I put the implementations inside `impl_num_ops` to make it possible in the future to use it for `Int`. Ddin't do it on this branch, because `Int` requires special handling because of it wrapping i128 but limiting effective value range to +/-u64. I left this out as unrelated to `Value`.

note 2: This is the first of 4 stacked branches aimed at implementing correct arithmetic for `Value`. I'm unable to open stacked PRs targeting this repo from a fork, so I'm opening just this one for now and **all 4 PRs can be seen on my fork**:
- [#10](https://github.com/AmbientTea/cardano-serialization-lib/pull/10) feat: saturating arithmetic for numeric types
- [#11](https://github.com/AmbientTea/cardano-serialization-lib/pull/11) feat: numeric types for BTreeMap wrappers
- [#9](https://github.com/AmbientTea/cardano-serialization-lib/pull/9) feat: arithmetic traits for Value
- [#12](https://github.com/AmbientTea/cardano-serialization-lib/pull/12) fix: inconsistent Value arithmetic