### PR TITLE
feat: derive arithmetic traits for BTreeMap wrappers

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1337,6 +1337,7 @@ pub type PolicyIDs = ScriptHashes;
 pub struct Assets(pub(crate) std::collections::BTreeMap<AssetName, BigNum>);
 
 impl_to_from!(Assets);
+impl_btmap_wrapper!(Assets, AssetName, BigNum);
 
 #[wasm_bindgen]
 impl Assets {
@@ -1367,10 +1368,11 @@ impl Assets {
 }
 
 #[wasm_bindgen]
-#[derive(Clone, Debug, Eq, Ord, PartialEq, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, serde::Serialize, serde::Deserialize, JsonSchema)]
 pub struct MultiAsset(pub(crate) std::collections::BTreeMap<PolicyID, Assets>);
 
 impl_to_from!(MultiAsset);
+impl_btmap_wrapper!(MultiAsset, PolicyID, Assets, 0);
 
 #[wasm_bindgen]
 impl MultiAsset {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -27,6 +27,7 @@ use std::io::{BufRead, Seek, Write};
 #[cfg(any(not(all(target_arch = "wasm32", not(target_os = "emscripten"))), feature = "dont-expose-wasm"))]
 use noop_proc_macro::wasm_bindgen;
 
+use num_traits::SaturatingSub;
 #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten"), not(feature = "dont-expose-wasm")))]
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
@@ -1428,45 +1429,7 @@ impl MultiAsset {
     /// removes an asset from the list if the result is 0 or less
     /// does not modify this object, instead the result is returned
     pub fn sub(&self, rhs_ma: &MultiAsset) -> MultiAsset {
-        let mut lhs_ma = self.clone();
-        for (policy, assets) in &rhs_ma.0 {
-            for (asset_name, amount) in &assets.0 {
-                match lhs_ma.0.get_mut(policy) {
-                    Some(assets) => match assets.0.get_mut(asset_name) {
-                        Some(current) => match current.checked_sub(&amount) {
-                            Ok(new) => match new.compare(&BigNum(0)) {
-                                0 => {
-                                    assets.0.remove(asset_name);
-                                    match assets.0.len() {
-                                        0 => {
-                                            lhs_ma.0.remove(policy);
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                                _ => *current = new,
-                            },
-                            Err(_) => {
-                                assets.0.remove(asset_name);
-                                match assets.0.len() {
-                                    0 => {
-                                        lhs_ma.0.remove(policy);
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        },
-                        None => {
-                            // asset name is missing from left hand side
-                        }
-                    },
-                    None => {
-                        // policy id missing from left hand side
-                    }
-                }
-            }
-        }
-        lhs_ma
+        <Self as SaturatingSub>::saturating_sub(self, rhs_ma)
     }
 
     pub(crate) fn reduce_empty_to_none(&self) -> Option<&MultiAsset> {

--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -203,6 +203,80 @@ macro_rules! impl_vec_wrapper {
     };
 }
 
+macro_rules! impl_btmap_wrapper {
+    ($wrapper:ident, $key:ty, $val:ty) => {
+        impl_btmap_wrapper!($wrapper, $key, $val, 0);
+    };
+    ($wrapper:ident, $key:ty, $val:ty, $field:tt) => {
+        impl num::Zero for $wrapper {
+            fn is_zero(&self) -> bool {
+                self.$field.values().all(<$val>::is_zero)
+            }
+
+            fn zero() -> Self {
+                Self::default()
+            }
+        }
+
+        impl_btmap_wrapper!(@ops $wrapper, $key, $val, $field,
+            std::ops::Add, add,
+            num::CheckedAdd, checked_add,
+            num_traits::SaturatingAdd, saturating_add, "overflow");
+        impl_btmap_wrapper!(@ops $wrapper, $key, $val, $field,
+            std::ops::Sub, sub,
+            num::CheckedSub, checked_sub,
+            num_traits::SaturatingSub, saturating_sub, "underflow");
+
+    };
+    (@ops $wrapper:ident, $key:ty, $val:ty, $field:tt,
+        $BaseOp:path, $base_op:ident,
+        $CheckedOp:path, $checked_op:ident,
+        $SaturatingOp:path, $saturating_op:ident, $error_str:expr
+    ) => {
+        impl $BaseOp for $wrapper {
+            type Output = $wrapper;
+
+            fn $base_op(self, rhs: Self) -> Self::Output {
+                <Self as $CheckedOp>::$checked_op(&self, &rhs)
+                    .expect(concat!(stringify!($wrapper :: $base_op), " ", $error_str))
+            }
+        }
+
+        impl $CheckedOp for $wrapper {
+            fn $checked_op(&self, other: &Self) -> Option<Self> {
+                let mut result = self.clone();
+                for (key, rhs) in &other.$field {
+                    let lhs = result.$field.get(&key).cloned().unwrap_or_default();
+                    let new_value = <$val as $CheckedOp>::$checked_op(&lhs, rhs)?;
+                    if !num_traits::Zero::is_zero(&new_value) {
+                        result.$field.insert(key.clone(), new_value);
+                    } else {
+                        result.$field.remove(key);
+                    }
+                }
+                Some(result)
+            }
+        }
+
+        impl $SaturatingOp for $wrapper {
+            fn $saturating_op(&self, other: &Self) -> Self {
+                let mut result = self.clone();
+                for (key, rhs) in &other.$field {
+                    let lhs = result.$field.get(&key).cloned().unwrap_or_default();
+                    let new_value = <$val as $SaturatingOp>::$saturating_op(&lhs, rhs);
+                    if !num_traits::Zero::is_zero(&new_value) {
+                        result.$field.insert(key.clone(), new_value);
+                    } else {
+                        result.$field.remove(key);
+                    }
+                }
+                result
+            }
+        }
+
+    };
+}
+
 #[cfg(test)]
 mod tests {
     mod impl_num {
@@ -359,6 +433,159 @@ mod tests {
             } else {
                 assert_eq!(TestNum(a).saturating_sub(&TestNum(b)), TestNum(0));
             }
+        }
+    }
+
+    mod impl_btmap_wrapper {
+        use std::collections::BTreeMap;
+
+        #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+        struct TestKey(u8);
+
+        #[derive(Clone, Debug, PartialEq, Default)]
+        struct TestValue(u64);
+        impl_num_ops!(TestValue, u64);
+        impl_num_ops!(@saturating TestValue, u64);
+
+        impl From<u64> for TestValue {
+            fn from(value: u64) -> Self {
+                Self(value)
+            }
+        }
+
+        #[derive(Clone, Debug, PartialEq, Default)]
+        struct TestMap(BTreeMap<TestKey, TestValue>);
+        impl_btmap_wrapper!(TestMap, TestKey, TestValue);
+
+        fn test_map(entries: &[(u8, u64)]) -> TestMap {
+            TestMap(
+                entries
+                    .iter()
+                    .map(|&(k, v)| (TestKey(k), TestValue(v)))
+                    .collect(),
+            )
+        }
+
+        #[test]
+        fn zero_is_empty_map() {
+            use num::Zero;
+            assert_eq!(TestMap::zero(), TestMap::default());
+            assert!(TestMap::zero().is_zero());
+        }
+
+        #[test]
+        fn all_zero_values_is_zero() {
+            use num::Zero;
+            assert!(test_map(&[(1, 0), (2, 0)]).is_zero());
+        }
+
+        #[test]
+        fn nonzero_value_is_not_zero() {
+            use num::Zero;
+            assert!(!test_map(&[(1, 1)]).is_zero());
+        }
+
+        #[test]
+        fn checked_add_overlapping_keys() {
+            use num::CheckedAdd;
+            assert_eq!(
+                test_map(&[(1, 10), (2, 20)]).checked_add(&test_map(&[(2, 5), (3, 30)])),
+                Some(test_map(&[(1, 10), (2, 25), (3, 30)]))
+            );
+        }
+
+        #[test]
+        fn checked_add_disjoint_keys() {
+            use num::CheckedAdd;
+            assert_eq!(
+                test_map(&[(1, 10)]).checked_add(&test_map(&[(2, 20)])),
+                Some(test_map(&[(1, 10), (2, 20)]))
+            );
+        }
+
+        #[test]
+        fn checked_add_overflow() {
+            use num::CheckedAdd;
+            assert_eq!(
+                test_map(&[(1, u64::MAX)]).checked_add(&test_map(&[(1, 1)])),
+                None
+            );
+        }
+
+        #[test]
+        fn checked_sub_overlapping_keys() {
+            use num::CheckedSub;
+            assert_eq!(
+                test_map(&[(1, 10), (2, 20)]).checked_sub(&test_map(&[(1, 3), (2, 5)])),
+                Some(test_map(&[(1, 7), (2, 15)]))
+            );
+        }
+
+        #[test]
+        fn checked_sub_exact() {
+            use num::CheckedSub;
+            assert_eq!(
+                test_map(&[(1, 10)]).checked_sub(&test_map(&[(1, 10)])),
+                Some(test_map(&[]))
+            );
+        }
+
+        #[test]
+        fn checked_sub_rhs_key_missing_from_lhs() {
+            use num::CheckedSub;
+            assert_eq!(test_map(&[(1, 10)]).checked_sub(&test_map(&[(2, 5)])), None);
+        }
+
+        #[test]
+        fn checked_sub_overflow() {
+            use num::CheckedSub;
+            assert_eq!(test_map(&[(1, 5)]).checked_sub(&test_map(&[(1, 10)])), None);
+        }
+
+        #[test]
+        fn add_operator() {
+            assert_eq!(
+                test_map(&[(1, 10)]) + test_map(&[(1, 5), (2, 3)]),
+                test_map(&[(1, 15), (2, 3)])
+            );
+        }
+
+        #[test]
+        #[should_panic(expected = "overflow")]
+        fn add_operator_panics_on_overflow() {
+            let _ = test_map(&[(1, u64::MAX)]) + test_map(&[(1, 1)]);
+        }
+
+        #[test]
+        fn sub_operator() {
+            assert_eq!(
+                test_map(&[(1, 10), (2, 3)]) - test_map(&[(1, 5)]),
+                test_map(&[(1, 5), (2, 3)])
+            );
+        }
+
+        #[test]
+        #[should_panic(expected = "underflow")]
+        fn sub_operator_panics_on_underflow() {
+            let _ = test_map(&[(1, 5)]) - test_map(&[(1, 10)]);
+        }
+
+        #[test]
+        fn saturating_add_clamps_at_max() {
+            use num_traits::SaturatingAdd;
+            assert_eq!(
+                test_map(&[(1, u64::MAX)]).saturating_add(&test_map(&[(1, 100), (2, 5)])),
+                test_map(&[(1, u64::MAX), (2, 5)])
+            );
+        }
+
+        #[test]
+        fn saturating_sub_clamps_at_zero() {
+            use num_traits::SaturatingSub;
+            assert_eq!(
+                test_map(&[(1, 5)]).saturating_sub(&test_map(&[(1, 10), (2, 3)])),
+                test_map(&[])
+            );
         }
     }
 


### PR DESCRIPTION
1. Adds a `impl_btmap_wrapper` macro that genrates various numeric trait impls for types that wrap a BTreeMap with numeric values. These normalize the result by retaining only non-zero values in the map.
2. uses (1) for `MultiAsset` and `Assets`

note: This is the second of 4 stacked branches aimed at implementing correct arithmetic for Value. I'm unable to open stacked PRs targeting this repo from a fork, so I'm opening them one by one. The whole stack:
- landed: https://github.com/Emurgo/cardano-serialization-lib/pull/750
- this PR
- preview in my fork: [#9](https://github.com/AmbientTea/cardano-serialization-lib/pull/9) feat: arithmetic traits for Value
- preview in my fork: [#12](https://github.com/AmbientTea/cardano-serialization-lib/pull/12) fix: inconsistent Value arithmetic

