### PR TITLE
Value arithmetic

### DIFF
--- a/rust/src/tests/fakes.rs
+++ b/rust/src/tests/fakes.rs
@@ -651,6 +651,32 @@ pub(crate) fn fake_bootsrap_witness_with_attrs(x: u8, attributes: Vec<u8>) -> Bo
     )
 }
 
+pub(crate) fn fake_assets(assets: &[(u8, u64)]) -> Assets {
+    Assets(
+        assets
+            .iter()
+            .map(|(name, qty)| (fake_asset_name(*name), BigNum(*qty)))
+            .collect(),
+    )
+}
+
+
+pub(crate) fn fake_multiasset(policies: &[(u8, &[(u8, u64)])]) -> MultiAsset {
+    MultiAsset(
+        policies
+            .iter()
+            .map(|(pid, assets)| (fake_policy_id(*pid), fake_assets(assets)))
+            .collect(),
+    )
+}
+
+pub(crate) fn fake_value_with_assets(coin: u64, policies: &[(u8, &[(u8, u64)])]) -> Value {
+    Value {
+        coin: BigNum(coin),
+        multiasset: Some(fake_multiasset(policies)),
+    }
+}
+
 pub(crate) fn fake_plutus_script_and_hash(x: u8) -> (PlutusScript, ScriptHash) {
     let s = PlutusScript::new(fake_bytes_32(x));
     (s.clone(), s.hash())

--- a/rust/src/tests/utils.rs
+++ b/rust/src/tests/utils.rs
@@ -1,3 +1,4 @@
+use super::fakes::{fake_multiasset, fake_value_with_assets};
 use crate::*;
 
 #[test]
@@ -791,6 +792,366 @@ fn value_empty_asset_equal() {
 
     assert_eq!(a, b);
     assert_eq!(a, c);
+}
+
+mod value_checked_arithmetic {
+    use super::*;
+    use num::{CheckedAdd, CheckedSub};
+
+    #[test]
+    fn checked_add_coin_only() {
+        let a = Value::from(BigNum(100));
+        let b = Value::from(BigNum(200));
+        let expected = Some(Value::from(BigNum(300)));
+        assert_eq!(CheckedAdd::checked_add(&a, &b), expected);
+    }
+
+    #[test]
+    fn checked_add_coin_overflow() {
+        let a = Value::from(BigNum(u64::MAX));
+        let b = Value::from(BigNum(1));
+        assert_eq!(CheckedAdd::checked_add(&a, &b), None);
+    }
+
+    #[test]
+    fn checked_add_both_have_multiasset() {
+        let a = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        let b = fake_value_with_assets(200, &[(0, &[(1, 5), (2, 20)])]);
+        let expected = fake_value_with_assets(300, &[(0, &[(1, 15), (2, 20)])]);
+        assert_eq!(CheckedAdd::checked_add(&a, &b), Some(expected));
+    }
+
+    #[test]
+    fn checked_add_one_side_none_multiasset() {
+        let a = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        let b = Value::from(BigNum(200));
+        let expected = fake_value_with_assets(300, &[(0, &[(1, 10)])]);
+        assert_eq!(CheckedAdd::checked_add(&a, &b), Some(expected.clone()));
+        assert_eq!(CheckedAdd::checked_add(&b, &a), Some(expected));
+    }
+
+    #[test]
+    fn checked_add_asset_overflow() {
+        let a = fake_value_with_assets(0, &[(0, &[(1, u64::MAX)])]);
+        let b = fake_value_with_assets(0, &[(0, &[(1, 1)])]);
+        assert_eq!(CheckedAdd::checked_add(&a, &b), None);
+    }
+
+    #[test]
+    fn checked_sub_coin_only() {
+        let a = Value::from(BigNum(300));
+        let b = Value::from(BigNum(100));
+        let expected = Some(Value::from(BigNum(200)));
+        assert_eq!(CheckedSub::checked_sub(&a, &b), expected);
+    }
+
+    #[test]
+    fn checked_sub_coin_underflow() {
+        let a = Value::from(BigNum(100));
+        let b = Value::from(BigNum(200));
+        assert_eq!(CheckedSub::checked_sub(&a, &b), None);
+    }
+
+    #[test]
+    fn checked_sub_both_have_multiasset() {
+        let a = fake_value_with_assets(300, &[(0, &[(1, 10), (2, 20)])]);
+        let b = fake_value_with_assets(100, &[(0, &[(1, 3)])]);
+        let expected = fake_value_with_assets(200, &[(0, &[(1, 7), (2, 20)])]);
+        assert_eq!(CheckedSub::checked_sub(&a, &b), Some(expected));
+    }
+
+    #[test]
+    fn checked_sub_asset_underflow() {
+        let a = fake_value_with_assets(300, &[(0, &[(1, 5)])]);
+        let b = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        assert_eq!(CheckedSub::checked_sub(&a, &b), None);
+    }
+
+    #[test]
+    fn checked_sub_lhs_none_rhs_nonzero_multiasset() {
+        let a = Value::from(BigNum(300));
+        let b = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        assert_eq!(CheckedSub::checked_sub(&a, &b), None);
+    }
+
+    #[test]
+    fn checked_sub_lhs_none_rhs_zero_multiasset() {
+        let a = Value::from(BigNum(300));
+        let b = Value {
+            coin: Coin::from(100u64),
+            multiasset: Some(MultiAsset::new()),
+        };
+        let expected = Some(Value::from(BigNum(200)));
+        assert_eq!(CheckedSub::checked_sub(&a, &b), expected);
+    }
+
+    #[test]
+    fn checked_sub_lhs_has_multiasset_rhs_none() {
+        let a = fake_value_with_assets(300, &[(0, &[(1, 10)])]);
+        let b = Value::from(BigNum(100));
+        let expected = Some(fake_value_with_assets(200, &[(0, &[(1, 10)])]));
+        assert_eq!(CheckedSub::checked_sub(&a, &b), expected);
+    }
+
+    #[test]
+    fn add_operator() {
+        let a = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        let b = fake_value_with_assets(200, &[(0, &[(1, 5)])]);
+        let expected = fake_value_with_assets(300, &[(0, &[(1, 15)])]);
+        assert_eq!(a + b, expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "Value overflow")]
+    fn add_operator_panics_on_overflow() {
+        let a = Value::from(BigNum(u64::MAX));
+        let b = Value::from(BigNum(1));
+        let _ = a + b;
+    }
+
+    #[test]
+    fn sub_operator() {
+        let a = Value::from(BigNum(300));
+        let b = Value::from(BigNum(100));
+        let expected = Value::from(BigNum(200));
+        assert_eq!(a - b, expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "Value underflow")]
+    fn sub_operator_panics_on_underflow() {
+        let a = Value::from(BigNum(100));
+        let b = Value::from(BigNum(200));
+        let _ = a - b;
+    }
+
+    #[test]
+    fn checked_add_disjoint_policies() {
+        let a = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        let b = fake_value_with_assets(200, &[(1, &[(1, 20)])]);
+        let expected = fake_value_with_assets(300, &[(0, &[(1, 10)]), (1, &[(1, 20)])]);
+        assert_eq!(CheckedAdd::checked_add(&a, &b), Some(expected));
+    }
+
+    #[test]
+    fn checked_sub_rhs_policy_not_in_lhs() {
+        let a = fake_value_with_assets(300, &[(0, &[(1, 10)])]);
+        let b = fake_value_with_assets(100, &[(1, &[(1, 5)])]);
+        assert_eq!(CheckedSub::checked_sub(&a, &b), None);
+    }
+
+    #[test]
+    fn checked_sub_rhs_asset_name_not_in_lhs() {
+        let a = fake_value_with_assets(300, &[(0, &[(1, 10)])]);
+        let b = fake_value_with_assets(100, &[(0, &[(2, 5)])]);
+        assert_eq!(CheckedSub::checked_sub(&a, &b), None);
+    }
+
+    #[test]
+    fn checked_sub_multiple_overlapping_policies() {
+        let a = fake_value_with_assets(300, &[(0, &[(1, 10)]), (1, &[(1, 20)])]);
+        let b = fake_value_with_assets(100, &[(0, &[(1, 3)]), (1, &[(1, 5)])]);
+        let expected = fake_value_with_assets(200, &[(0, &[(1, 7)]), (1, &[(1, 15)])]);
+        assert_eq!(CheckedSub::checked_sub(&a, &b), Some(expected));
+    }
+
+    #[test]
+    fn checked_sub_exact_assets_normalizes_to_none() {
+        let a = fake_value_with_assets(300, &[(0, &[(1, 10)])]);
+        let b = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        let expected = Some(Value::from(BigNum(200)));
+        assert_eq!(CheckedSub::checked_sub(&a, &b), expected);
+    }
+}
+
+mod value_saturating_arithmetic {
+    use super::*;
+    use num_traits::{SaturatingAdd, SaturatingSub};
+
+    #[test]
+    fn saturating_sub_coin_clamps_to_zero() {
+        let a = Value::from(BigNum(100));
+        let b = Value::from(BigNum(200));
+        let expected = Value::from(BigNum(0));
+        assert_eq!(a.saturating_sub(&b), expected);
+    }
+
+    #[test]
+    fn saturating_sub_coin_within_range() {
+        let a = Value::from(BigNum(300));
+        let b = Value::from(BigNum(100));
+        let expected = Value::from(BigNum(200));
+        assert_eq!(a.saturating_sub(&b), expected);
+    }
+
+    #[test]
+    fn saturating_sub_assets_clamp_to_zero_and_removed() {
+        let a = fake_value_with_assets(300, &[(0, &[(1, 5)])]);
+        let b = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        let expected = Value::from(BigNum(200));
+        assert_eq!(a.saturating_sub(&b), expected);
+    }
+
+    #[test]
+    fn saturating_sub_lhs_none_rhs_has_assets() {
+        let a = Value::from(BigNum(300));
+        let b = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        let expected = Value::from(BigNum(200));
+        assert_eq!(a.saturating_sub(&b), expected);
+    }
+
+    #[test]
+    fn saturating_sub_lhs_has_assets_rhs_none() {
+        let a = fake_value_with_assets(300, &[(0, &[(1, 10)])]);
+        let b = Value::from(BigNum(100));
+        let expected = fake_value_with_assets(200, &[(0, &[(1, 10)])]);
+        assert_eq!(a.saturating_sub(&b), expected);
+    }
+
+    #[test]
+    fn saturating_sub_partial_asset_clamp() {
+        let a = fake_value_with_assets(300, &[(0, &[(1, 5), (2, 20)])]);
+        let b = fake_value_with_assets(100, &[(0, &[(1, 10), (2, 3)])]);
+        let expected = fake_value_with_assets(200, &[(0, &[(2, 17)])]);
+        assert_eq!(a.saturating_sub(&b), expected);
+    }
+
+    #[test]
+    fn saturating_add_coin_clamps_at_max() {
+        let a = Value::from(BigNum(u64::MAX));
+        let b = Value::from(BigNum(100));
+        let expected = Value::from(BigNum(u64::MAX));
+        assert_eq!(a.saturating_add(&b), expected);
+    }
+
+    #[test]
+    fn saturating_add_asset_clamps_at_max() {
+        let a = fake_value_with_assets(100, &[(0, &[(1, u64::MAX)])]);
+        let b = fake_value_with_assets(200, &[(0, &[(1, 100), (2, 5)])]);
+        let expected = fake_value_with_assets(300, &[(0, &[(1, u64::MAX), (2, 5)])]);
+        assert_eq!(a.saturating_add(&b), expected);
+    }
+
+    #[test]
+    fn saturating_add_one_side_none_multiasset() {
+        let a = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        let b = Value::from(BigNum(200));
+        let expected = fake_value_with_assets(300, &[(0, &[(1, 10)])]);
+        assert_eq!(a.saturating_add(&b), expected.clone());
+        assert_eq!(b.saturating_add(&a), expected);
+    }
+
+    #[test]
+    fn saturating_add_both_none_multiasset() {
+        let a = Value::from(BigNum(100));
+        let b = Value::from(BigNum(200));
+        let expected = Value::from(BigNum(300));
+        assert_eq!(a.saturating_add(&b), expected);
+    }
+
+    #[test]
+    fn saturating_sub_disjoint_policies() {
+        let a = fake_value_with_assets(300, &[(0, &[(1, 10)])]);
+        let b = fake_value_with_assets(100, &[(1, &[(1, 5)])]);
+        let expected = fake_value_with_assets(200, &[(0, &[(1, 10)])]);
+        assert_eq!(a.saturating_sub(&b), expected);
+    }
+
+    #[test]
+    fn saturating_sub_rhs_asset_name_not_in_lhs() {
+        let a = fake_value_with_assets(300, &[(0, &[(1, 10)])]);
+        let b = fake_value_with_assets(100, &[(0, &[(2, 5)])]);
+        let expected = fake_value_with_assets(200, &[(0, &[(1, 10)])]);
+        assert_eq!(a.saturating_sub(&b), expected);
+    }
+
+    #[test]
+    fn saturating_add_overlapping_assets() {
+        let a = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        let b = fake_value_with_assets(200, &[(0, &[(1, 5)])]);
+        let expected = fake_value_with_assets(300, &[(0, &[(1, 15)])]);
+        assert_eq!(a.saturating_add(&b), expected);
+    }
+
+    #[test]
+    fn saturating_add_disjoint_policies() {
+        let a = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        let b = fake_value_with_assets(200, &[(1, &[(1, 20)])]);
+        let expected = fake_value_with_assets(300, &[(0, &[(1, 10)]), (1, &[(1, 20)])]);
+        assert_eq!(a.saturating_add(&b), expected);
+    }
+}
+
+mod value_sub_components {
+    use super::*;
+
+    #[test]
+    fn sub_coin_from_coin_only_value() {
+        let a = Value::from(BigNum(150));
+        let b = Coin::from(50u64);
+        let expected = Value::from(BigNum(100));
+        assert_eq!(a - b, expected);
+    }
+
+    #[test]
+    fn sub_coin_from_value_with_assets() {
+        let a = fake_value_with_assets(150, &[(0, &[(1, 10)])]);
+        let b = Coin::from(50u64);
+        let expected = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        assert_eq!(a - b, expected);
+    }
+
+    #[test]
+    fn sub_multiasset_from_value_with_assets() {
+        let a = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        let b = fake_multiasset(&[(0, &[(1, 4)])]);
+        let expected = fake_value_with_assets(100, &[(0, &[(1, 6)])]);
+        assert_eq!(a - b, expected);
+    }
+
+    #[test]
+    fn sub_multiasset_fully_removes_zeroed_asset() {
+        let a = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        let b = fake_multiasset(&[(0, &[(1, 10)])]);
+        let expected = Value::from(BigNum(100));
+        assert_eq!(a - b, expected);
+    }
+}
+
+mod value_add_components {
+    use super::*;
+
+    #[test]
+    fn add_coin_to_coin_only_value() {
+        let a = Value::from(BigNum(100));
+        let b = Coin::from(50u64);
+        let expected = Value::from(BigNum(150));
+        assert_eq!(a + b, expected);
+    }
+
+    #[test]
+    fn add_coin_to_value_with_assets() {
+        let a = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        let b = Coin::from(50u64);
+        let expected = fake_value_with_assets(150, &[(0, &[(1, 10)])]);
+        assert_eq!(a + b, expected);
+    }
+
+    #[test]
+    fn add_multiasset_to_coin_only_value() {
+        let a = Value::from(BigNum(100));
+        let b = fake_multiasset(&[(0, &[(1, 10)])]);
+        let expected = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        assert_eq!(a + b, expected);
+    }
+
+    #[test]
+    fn add_multiasset_to_value_with_assets() {
+        let a = fake_value_with_assets(100, &[(0, &[(1, 10)])]);
+        let b = fake_multiasset(&[(1, &[(2, 20)])]);
+        let expected = fake_value_with_assets(100, &[(0, &[(1, 10)]), (1, &[(2, 20)])]);
+        assert_eq!(a + b, expected);
+    }
 }
 
 #[test]

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -4,6 +4,7 @@ use cbor_event::{
     se::{Serialize, Serializer},
 };
 use hex::FromHex;
+use num::Zero;
 use serde_json;
 use std::fmt::Display;
 use std::{
@@ -338,6 +339,112 @@ impl PartialOrd for Value {
                 (_, _) => None,
             }
         })
+    }
+}
+
+impl std::ops::Add for Value {
+    type Output = Value;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        <Self as num_traits::CheckedAdd>::checked_add(&self, &rhs).expect("Value overflow")
+    }
+}
+
+impl std::ops::Add<Coin> for Value {
+    type Output = Value;
+
+    fn add(self, rhs: Coin) -> Self::Output {
+        let coin = num::CheckedAdd::checked_add(&self.coin, &rhs).expect("Value overflow");
+        Value { coin, ..self }
+    }
+}
+
+impl std::ops::Add<MultiAsset> for Value {
+    type Output = Value;
+
+    fn add(self, rhs: MultiAsset) -> Self::Output {
+        self + Value::from(rhs)
+    }
+}
+
+impl std::ops::Sub for Value {
+    type Output = Value;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        <Self as num_traits::CheckedSub>::checked_sub(&self, &rhs).expect("Value underflow")
+    }
+}
+
+impl std::ops::Sub<Coin> for Value {
+    type Output = Value;
+
+    fn sub(self, rhs: Coin) -> Self::Output {
+        let coin = num::CheckedSub::checked_sub(&self.coin, &rhs).expect("Value underflow");
+        Value { coin, ..self }
+    }
+}
+
+impl std::ops::Sub<MultiAsset> for Value {
+    type Output = Value;
+
+    fn sub(self, rhs: MultiAsset) -> Self::Output {
+        self - Value::from(rhs)
+    }
+}
+
+impl num_traits::CheckedAdd for Value {
+    fn checked_add(&self, other: &Self) -> Option<Self> {
+        let coin = num::CheckedAdd::checked_add(&self.coin, &other.coin)?;
+        let multiasset = match (&self.multiasset, &other.multiasset) {
+            (Some(first), Some(second)) => Some(num::CheckedAdd::checked_add(first, second)?),
+            (Some(first), None) => Some(first.clone()),
+            (None, Some(second)) => Some(second.clone()),
+            (None, None) => None,
+        }
+        .filter(|ma| !ma.is_zero());
+        Some(Self { coin, multiasset })
+    }
+}
+
+impl num_traits::CheckedSub for Value {
+    fn checked_sub(&self, other: &Self) -> Option<Self> {
+        let coin = num::CheckedSub::checked_sub(&self.coin, &other.coin)?;
+        let multiasset = match (&self.multiasset, &other.multiasset) {
+            (Some(first), Some(second)) => Some(num::CheckedSub::checked_sub(first, second)?),
+            (Some(first), None) => Some(first.clone()),
+            (None, Some(second)) if !second.is_zero() => return None,
+            (None, Some(_zero)) => None,
+            (None, None) => None,
+        }
+        .filter(|ma| !ma.is_zero());
+        Some(Self { coin, multiasset })
+    }
+}
+
+impl num_traits::SaturatingSub for Value {
+    fn saturating_sub(&self, v: &Self) -> Self {
+        let coin = self.coin.saturating_sub(&v.coin);
+        let multiasset = match (&self.multiasset, &v.multiasset) {
+            (Some(first), Some(second)) => Some(first.saturating_sub(second)),
+            (Some(first), None) => Some(first.clone()),
+            (None, _) => None,
+        }
+        .filter(|ma| !ma.is_zero());
+        Self { coin, multiasset }
+    }
+}
+
+impl num_traits::SaturatingAdd for Value {
+    fn saturating_add(&self, v: &Self) -> Self {
+        let coin = self.coin.saturating_add(&v.coin);
+        let multiasset = match (&self.multiasset, &v.multiasset) {
+            (Some(first), Some(second)) => Some(first.saturating_add(second)),
+            (Some(first), None) => Some(first.clone()),
+            (None, Some(second)) => Some(second.clone()),
+            (None, None) => None,
+        }
+        .filter(|ma| !ma.is_zero());
+        Self { coin, multiasset }
     }
 }
 

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -204,76 +204,17 @@ impl Value {
     }
 
     pub fn checked_add(&self, rhs: &Value) -> Result<Value, JsError> {
-        use std::collections::btree_map::Entry;
-        let coin = self.coin.checked_add(&rhs.coin)?;
-
-        let multiasset = match (&self.multiasset, &rhs.multiasset) {
-            (Some(lhs_multiasset), Some(rhs_multiasset)) => {
-                let mut multiasset = MultiAsset::new();
-
-                for ma in &[lhs_multiasset, rhs_multiasset] {
-                    for (policy, assets) in &ma.0 {
-                        for (asset_name, amount) in &assets.0 {
-                            match multiasset.0.entry(policy.clone()) {
-                                Entry::Occupied(mut assets) => {
-                                    match assets.get_mut().0.entry(asset_name.clone()) {
-                                        Entry::Occupied(mut assets) => {
-                                            let current = assets.get_mut();
-                                            *current = current.checked_add(&amount)?;
-                                        }
-                                        Entry::Vacant(vacant_entry) => {
-                                            vacant_entry.insert(amount.clone());
-                                        }
-                                    }
-                                }
-                                Entry::Vacant(entry) => {
-                                    let mut assets = Assets::new();
-                                    assets.0.insert(asset_name.clone(), amount.clone());
-                                    entry.insert(assets);
-                                }
-                            }
-                        }
-                    }
-                }
-
-                Some(multiasset)
-            }
-            (None, None) => None,
-            (Some(ma), None) => Some(ma.clone()),
-            (None, Some(ma)) => Some(ma.clone()),
-        };
-
-        Ok(Value { coin, multiasset })
+        <Self as num::CheckedAdd>::checked_add(self, rhs)
+            .ok_or_else(|| JsError::from_str("overflow"))
     }
 
     pub fn checked_sub(&self, rhs_value: &Value) -> Result<Value, JsError> {
-        let coin = self.coin.checked_sub(&rhs_value.coin)?;
-        let multiasset = match (&self.multiasset, &rhs_value.multiasset) {
-            (Some(lhs_ma), Some(rhs_ma)) => match lhs_ma.sub(rhs_ma).len() {
-                0 => None,
-                _ => Some(lhs_ma.sub(rhs_ma)),
-            },
-            (Some(lhs_ma), None) => Some(lhs_ma.clone()),
-            (None, Some(_rhs_ma)) => None,
-            (None, None) => None,
-        };
-
-        Ok(Value { coin, multiasset })
+        <Self as num::CheckedSub>::checked_sub(self, rhs_value)
+            .ok_or_else(|| JsError::from_str("underflow"))
     }
 
     pub fn clamped_sub(&self, rhs_value: &Value) -> Value {
-        let coin = self.coin.clamped_sub(&rhs_value.coin);
-        let multiasset = match (&self.multiasset, &rhs_value.multiasset) {
-            (Some(lhs_ma), Some(rhs_ma)) => match lhs_ma.sub(rhs_ma).len() {
-                0 => None,
-                _ => Some(lhs_ma.sub(rhs_ma)),
-            },
-            (Some(lhs_ma), None) => Some(lhs_ma.clone()),
-            (None, Some(_rhs_ma)) => None,
-            (None, None) => None,
-        };
-
-        Value { coin, multiasset }
+        <Self as num_traits::SaturatingSub>::saturating_sub(&self, rhs_value)
     }
 
     /// note: values are only partially comparable


### PR DESCRIPTION
1. Implements checked/saturating add/sub traits for `Value`. These are manual because `Value` has two fields and `multiasset` needs to be squashed to `None` when zero.
2. Implements Add/Sub for Value with right values of types MultiAsset and Coin. This is mainly a QoL improvement usable in tests. Unfortunately checked/saturating operators which could be used safely in production code don't allow heterogenous operands.
3. Replaces the manual logic of the inherent functions `Value::checked_add`, `checked_sub` and `clamped_sub` with calls to approprate traits from (1). This is the only change in this PR that alters existing behaviours. Namely:
    - `checked_sub` used to actually saturate the multiasset part, which was a bug. Now it correctly detects all underflows and normalizes zero to `None`. It also missed some edge cases around handling of zero multiassets (these can still be constructed even if the operators now normalize them).
    - `checked_add` and `clamped_sub` now normalize zero multiasset to `None` and avoid the same edge cases as `checked_sub`

Note on (3) - In general I don't think there would be any instances where the original buggy behaviour would produce correct/desired output and the new one wouldn't, but I put this change in a separate commit that can become a separate PR just in case.