### PR TITLE
feat: improve Plutus data type constructor ergonomics

### DIFF
--- a/rust/src/protocol_types/plutus/plutus_data.rs
+++ b/rust/src/protocol_types/plutus/plutus_data.rs
@@ -21,6 +21,16 @@ pub struct ConstrPlutusData {
 
 to_from_bytes!(ConstrPlutusData);
 
+#[macro_export]
+macro_rules! plutus_constr {
+    ($variant:expr $(, $field:expr)* $(,)?) => {
+        $crate::ConstrPlutusData::new(
+            &$crate::BigNum::from($variant),
+            &$crate::plutus_list![$($field),*]
+        )
+    };
+}
+
 #[wasm_bindgen]
 impl ConstrPlutusData {
     pub fn alternative(&self) -> BigNum {

--- a/rust/src/protocol_types/plutus/plutus_data.rs
+++ b/rust/src/protocol_types/plutus/plutus_data.rs
@@ -590,17 +590,11 @@ impl PlutusData {
     }
 
     fn from_pointer(pointer: &Pointer) -> Result<PlutusData, JsError> {
-        let mut data_list = PlutusList::new();
-        data_list.add(&PlutusData::new_integer(&pointer.slot_bignum().into()));
-        data_list.add(&PlutusData::new_integer(&pointer.tx_index_bignum().into()));
-        data_list.add(&PlutusData::new_integer(
-            &pointer.cert_index_bignum().into(),
-        ));
-
-        Ok(PlutusData::new_constr_plutus_data(&ConstrPlutusData::new(
-            &BigNum::from(1u32),
-            &data_list,
-        )))
+        Ok(ConstrPlutusData::new(&1u64.into(), &plutus_list![
+            pointer.slot_bignum(),
+            pointer.tx_index_bignum(),
+            pointer.cert_index_bignum()
+        ]).into())
     }
 
     fn as_pointer(&self) -> Result<Pointer, JsError> {
@@ -702,6 +696,19 @@ pub struct PlutusList {
 to_from_bytes!(PlutusList);
 impl_vec_wrapper!(PlutusList, PlutusData, elems);
 
+#[macro_export]
+macro_rules! plutus_list {
+    ($($item:expr),* $(,)?) => {
+        $crate::PlutusList::from(vec![$($crate::PlutusData::from($item)),*])
+    };
+    ($elem:expr; $n:expr) => {
+        {
+            let elem = $crate::PlutusData::from($elem);
+            $crate::PlutusList::from(vec![ elem ; $n ])
+        }
+    };
+}
+
 #[wasm_bindgen]
 impl PlutusList {
     pub fn new() -> Self {
@@ -721,8 +728,7 @@ impl PlutusList {
     }
 
     pub fn add(&mut self, elem: &PlutusData) {
-        self.elems.push(elem.clone());
-        self.definite_encoding = None;
+        self.push(elem.clone());
     }
 
     #[allow(dead_code)]
@@ -773,6 +779,13 @@ impl PlutusList {
 
     pub(crate) fn get_set_type(&self) -> Option<CborSetType> {
         self.cbor_set_type.clone()
+    }
+}
+
+impl PlutusList {
+    pub fn push(&mut self, data: PlutusData) {
+        self.elems.push(data);
+        self.definite_encoding = None;
     }
 }
 

--- a/rust/src/protocol_types/plutus/plutus_data.rs
+++ b/rust/src/protocol_types/plutus/plutus_data.rs
@@ -274,6 +274,16 @@ impl From<&[u8]> for PlutusDataEnum {
     }
 }
 
+#[macro_export]
+macro_rules! plutus_bytes {
+    ($($byte:expr),* $(,)?) => {
+        $crate::PlutusData::from(vec![$($byte),*])
+    };
+    ($elem:expr; $n:expr) => {
+        $crate::PlutusData::from(vec![$elem ; $n])
+    };
+}
+
 #[wasm_bindgen]
 #[derive(Clone, Debug, Ord, PartialOrd)]
 pub struct PlutusData {

--- a/rust/src/protocol_types/plutus/plutus_data.rs
+++ b/rust/src/protocol_types/plutus/plutus_data.rs
@@ -85,6 +85,12 @@ impl From<Vec<PlutusData>> for PlutusMapValues {
     }
 }
 
+impl From<PlutusData> for PlutusMapValues {
+    fn from(data: PlutusData) -> Self {
+        Self { elems: vec![data] }
+    }
+}
+
 #[wasm_bindgen]
 impl PlutusMapValues {
     pub fn new() -> Self {
@@ -184,6 +190,66 @@ pub enum PlutusDataEnum {
     Bytes(Vec<u8>),
 }
 
+impl From<ConstrPlutusData> for PlutusDataEnum {
+    fn from(value: ConstrPlutusData) -> Self {
+        Self::ConstrPlutusData(value)
+    }
+}
+
+impl From<PlutusMap> for PlutusDataEnum {
+    fn from(value: PlutusMap) -> Self {
+        Self::Map(value)
+    }
+}
+
+impl From<PlutusList> for PlutusDataEnum {
+    fn from(value: PlutusList) -> Self {
+        Self::List(value)
+    }
+}
+
+impl From<BigInt> for PlutusDataEnum {
+    fn from(value: BigInt) -> Self {
+        Self::Integer(value)
+    }
+}
+
+impl From<BigNum> for PlutusDataEnum {
+    fn from(value: BigNum) -> Self {
+        Self::Integer(value.into())
+    }
+}
+
+impl From<u64> for PlutusDataEnum {
+    fn from(value: u64) -> Self {
+        Self::Integer(BigNum::from(value).into())
+    }
+}
+
+impl From<i32> for PlutusDataEnum {
+    fn from(value: i32) -> Self {
+        Self::Integer(BigInt::from(value))
+    }
+}
+
+impl From<i64> for PlutusDataEnum {
+    fn from(value: i64) -> Self {
+        Self::Integer(BigInt::from(value))
+    }
+}
+
+impl From<Vec<u8>> for PlutusDataEnum {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self::Bytes(bytes)
+    }
+}
+
+impl From<&[u8]> for PlutusDataEnum {
+    fn from(bytes: &[u8]) -> Self {
+        Self::Bytes(bytes.to_vec())
+    }
+}
+
 #[wasm_bindgen]
 #[derive(Clone, Debug, Ord, PartialOrd)]
 pub struct PlutusData {
@@ -191,6 +257,15 @@ pub struct PlutusData {
     // We should always preserve the original datums when deserialized as this is NOT canonicized
     // before computing datum hashes. So this field stores the original bytes to re-use.
     pub(crate) original_bytes: Option<Vec<u8>>,
+}
+
+impl<T> From<T> for PlutusData where PlutusDataEnum: From<T> {
+    fn from(value: T) -> Self {
+        Self {
+            datum: value.into(),
+            original_bytes: None
+        }
+    }
 }
 
 impl std::cmp::PartialEq<Self> for PlutusData {

--- a/rust/src/protocol_types/plutus/plutus_data.rs
+++ b/rust/src/protocol_types/plutus/plutus_data.rs
@@ -121,6 +121,30 @@ pub struct PlutusMap(pub(crate) LinkedHashMap<PlutusData, PlutusMapValues>);
 
 to_from_bytes!(PlutusMap);
 
+#[macro_export]
+macro_rules! plutus_map_values {
+    ($($item:expr),* $(,)?) => {
+        {
+            #[allow(unused_mut)]
+            let mut values = $crate::PlutusMapValues::new();
+            $(values.add(&$crate::PlutusData::from($item));)*
+            values
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! plutus_map {
+    ($($key:expr => $value:expr),* $(,)?) => {
+        {
+            #[allow(unused_mut)]
+            let mut plutus_map = $crate::PlutusMap::new();
+            $(plutus_map.insert(&$key.into(), &$value.into());)*
+            plutus_map
+        }
+    };
+}
+
 #[wasm_bindgen]
 impl PlutusMap {
     pub fn new() -> Self {

--- a/rust/src/tests/plutus.rs
+++ b/rust/src/tests/plutus.rs
@@ -889,4 +889,69 @@ mod constructor_macros {
             assert_eq!(data, PlutusData::new_bytes(vec![0xab, 0xab, 0xab, 0xab]));
         }
     }
+
+    mod plutus_constr {
+        use super::*;
+
+        #[test]
+        fn no_fields() {
+            assert_eq!(
+                plutus_constr!(0u32),
+                ConstrPlutusData::new(&BigNum::from(0u32), &PlutusList::new())
+            );
+        }
+
+        #[test]
+        fn single_field() {
+            assert_eq!(
+                plutus_constr!(0u32, 42u64),
+                ConstrPlutusData::new(&BigNum::from(0u32), &plutus_list![42u64])
+            );
+        }
+
+        #[test]
+        fn multiple_fields() {
+            assert_eq!(
+                plutus_constr!(1u32, 10u64, 20u64, 30u64),
+                ConstrPlutusData::new(&BigNum::from(1u32), &plutus_list![10u64, 20u64, 30u64])
+            );
+        }
+
+        #[test]
+        fn trailing_comma() {
+            assert_eq!(
+                plutus_constr!(0u32, 1u64, 2u64,),
+                ConstrPlutusData::new(&BigNum::from(0u32), &plutus_list![1u64, 2u64])
+            );
+        }
+
+        #[test]
+        fn non_zero_alternative() {
+            let constr = plutus_constr!(5u32);
+            assert_eq!(constr.alternative(), BigNum::from(5u32));
+            assert_eq!(constr.data(), PlutusList::new());
+        }
+
+        #[test]
+        fn mixed_field_types() {
+            let bytes_data = PlutusData::new_bytes(vec![0xde, 0xad]);
+            let constr = plutus_constr!(0u32, 42u64, bytes_data);
+            assert_eq!(constr.data().len(), 2);
+            assert_eq!(
+                constr.data().get(0),
+                PlutusData::new_integer(&BigInt::from(42i32))
+            );
+            assert_eq!(
+                constr.data().get(1),
+                PlutusData::new_bytes(vec![0xde, 0xad])
+            );
+        }
+
+        #[test]
+        fn bignum_alternative() {
+            let constr = plutus_constr!(BigNum::from(200u32), 1u64);
+            assert_eq!(constr.alternative(), BigNum::from(200u32));
+            assert_eq!(constr.data().len(), 1);
+        }
+    }
 }

--- a/rust/src/tests/plutus.rs
+++ b/rust/src/tests/plutus.rs
@@ -681,3 +681,212 @@ fn plutus_data_malformed_address_error() {
     let plutus_data = PlutusData::from_address(&malformed_address);
     assert!(plutus_data.is_err());
 }
+
+mod constructor_macros {
+    use super::*;
+
+    mod plutus_list {
+        use super::*;
+
+        #[test]
+        fn empty() {
+            assert_eq!(plutus_list![], PlutusList::new());
+        }
+
+        #[test]
+        fn single_item() {
+            let list = plutus_list![BigNum::from(42u32)];
+            assert_eq!(list.len(), 1);
+            assert_eq!(list.get(0), PlutusData::new_integer(&BigInt::from(42i32)));
+        }
+
+        #[test]
+        fn multiple_items() {
+            let list = plutus_list![BigNum::from(1u32), BigNum::from(2u32), BigNum::from(3u32)];
+            assert_eq!(list.len(), 3);
+            assert_eq!(list.get(0), PlutusData::new_integer(&BigInt::from(1i32)));
+            assert_eq!(list.get(1), PlutusData::new_integer(&BigInt::from(2i32)));
+            assert_eq!(list.get(2), PlutusData::new_integer(&BigInt::from(3i32)));
+        }
+
+        #[test]
+        fn trailing_comma() {
+            let list = plutus_list![BigNum::from(1u32), BigNum::from(2u32),];
+            assert_eq!(list.len(), 2);
+            assert_eq!(list.get(0), PlutusData::new_integer(&BigInt::from(1i32)));
+            assert_eq!(list.get(1), PlutusData::new_integer(&BigInt::from(2i32)));
+        }
+
+        #[test]
+        fn u64_values() {
+            let list = plutus_list![1u64, 2u64, 3u64];
+            assert_eq!(list.len(), 3);
+            assert_eq!(list.get(0), PlutusData::new_integer(&BigInt::from(1i32)));
+            assert_eq!(list.get(1), PlutusData::new_integer(&BigInt::from(2i32)));
+            assert_eq!(list.get(2), PlutusData::new_integer(&BigInt::from(3i32)));
+        }
+
+        #[test]
+        fn mixed_element_types() {
+            let constr = ConstrPlutusData::new(&BigNum::from(0u32), &PlutusList::new());
+            let list = plutus_list![constr, 2];
+            assert_eq!(list.len(), 2);
+            assert_eq!(
+                list.get(0),
+                PlutusData::new_constr_plutus_data(&ConstrPlutusData::new(
+                    &BigNum::from(0u32),
+                    &PlutusList::new()
+                ))
+            );
+            assert_eq!(list.get(1), PlutusData::new_integer(&BigInt::from(2i32)));
+        }
+
+        #[test]
+        fn array_syntax() {
+            let list = plutus_list![1; 3];
+
+            assert_eq!(list, PlutusList::from(vec![
+                PlutusData::new_integer(&1.into()),
+                PlutusData::new_integer(&1.into()),
+                PlutusData::new_integer(&1.into()),
+            ]));
+        }
+    }
+
+    mod plutus_map {
+        use super::*;
+
+        #[test]
+        fn empty() {
+            assert_eq!(plutus_map!{}, PlutusMap::new());
+        }
+
+        #[test]
+        fn single_entry() {
+            let map = plutus_map! {
+                BigNum::from(1u32) => PlutusData::new_integer(&BigInt::from(10i32))
+            };
+            assert_eq!(map.len(), 1);
+            assert_eq!(map.get(&PlutusData::from(1u64)), Some(PlutusMapValues::from(PlutusData::from(10u64))));
+        }
+
+        #[test]
+        fn multiple_entries() {
+            let map = plutus_map! {
+                BigNum::from(1u32) => PlutusData::new_integer(&BigInt::from(10i32)),
+                BigNum::from(2u32) => PlutusData::new_integer(&BigInt::from(20i32)),
+            };
+            assert_eq!(map.len(), 2);
+            assert_eq!(map.get(&PlutusData::from(1u64)), Some(PlutusMapValues::from(PlutusData::from(10u64))));
+            assert_eq!(map.get(&PlutusData::from(2u64)), Some(PlutusMapValues::from(PlutusData::from(20u64))));
+        }
+
+        #[test]
+        fn u64_keys() {
+            let map = plutus_map! {
+                1u64 => PlutusData::new_integer(&BigInt::from(100i32)),
+                2u64 => PlutusData::new_integer(&BigInt::from(200i32)),
+            };
+            assert_eq!(map.len(), 2);
+            assert_eq!(map.get(&PlutusData::from(1u64)), Some(PlutusMapValues::from(PlutusData::from(100u64))));
+            assert_eq!(map.get(&PlutusData::from(2u64)), Some(PlutusMapValues::from(PlutusData::from(200u64))));
+        }
+
+        #[test]
+        fn list_datum_value() {
+            let list_datum = PlutusData::new_list(&plutus_list![1u64, 2u64, 3u64]);
+            let map = plutus_map! { 1u64 => list_datum.clone() };
+            assert_eq!(map.len(), 1);
+            assert_eq!(
+                map.get(&PlutusData::from(1u64)),
+                Some(PlutusMapValues::from(list_datum))
+            );
+        }
+
+        #[test]
+        fn duplicate_entry_uses_last() {
+            let map = plutus_map! {
+                BigNum::from(1u32) => PlutusData::new_integer(&BigInt::from(10i32)),
+                BigNum::from(1u32) => PlutusData::new_integer(&BigInt::from(20i32)),
+            };
+            assert_eq!(map.len(), 1);
+            assert_eq!(map.get(&PlutusData::from(1u64)), Some(PlutusMapValues::from(PlutusData::from(20u64))));
+        }
+    }
+
+    mod plutus_map_values {
+        use super::*;
+
+        #[test]
+        fn empty() {
+            assert_eq!(plutus_map_values![], PlutusMapValues::new());
+        }
+
+        #[test]
+        fn single_value() {
+            let values = plutus_map_values![1u64];
+            assert_eq!(values.len(), 1);
+            assert_eq!(values.get(0), Some(PlutusData::from(1u64)));
+        }
+
+        #[test]
+        fn multiple_values() {
+            let values = plutus_map_values![1u64, 2u64, 3u64];
+            assert_eq!(values.len(), 3);
+            assert_eq!(values.get(0), Some(PlutusData::from(1u64)));
+            assert_eq!(values.get(1), Some(PlutusData::from(2u64)));
+            assert_eq!(values.get(2), Some(PlutusData::from(3u64)));
+        }
+
+        #[test]
+        fn trailing_comma() {
+            let values = plutus_map_values![1u64, 2u64,];
+            assert_eq!(values.len(), 2);
+        }
+
+        #[test]
+        fn mixed_types() {
+            let values = plutus_map_values![
+                1u64,
+                PlutusData::new_bytes(vec![0xab]),
+            ];
+            assert_eq!(values.len(), 2);
+            assert_eq!(values.get(0), Some(PlutusData::from(1u64)));
+            assert_eq!(values.get(1), Some(PlutusData::new_bytes(vec![0xab])));
+        }
+
+        #[test]
+        fn in_plutus_map() {
+            let map = plutus_map! {
+                1u64 => plutus_map_values![10u64, 20u64, 30u64]
+            };
+            assert_eq!(map.len(), 1);
+            let values = map.get(&PlutusData::from(1u64)).unwrap();
+            assert_eq!(values.len(), 3);
+            assert_eq!(values.get(0), Some(PlutusData::from(10u64)));
+            assert_eq!(values.get(2), Some(PlutusData::from(30u64)));
+        }
+    }
+
+    mod plutus_bytes {
+        use super::*;
+
+        #[test]
+        fn empty() {
+            let data = plutus_bytes![];
+            assert_eq!(data, PlutusData::new_bytes(vec![]));
+        }
+
+        #[test]
+        fn literal_bytes() {
+            let data = plutus_bytes![1, 2, 3];
+            assert_eq!(data, PlutusData::new_bytes(vec![1, 2, 3]));
+        }
+
+        #[test]
+        fn array_syntax() {
+            let data = plutus_bytes![0xab; 4];
+            assert_eq!(data, PlutusData::new_bytes(vec![0xab, 0xab, 0xab, 0xab]));
+        }
+    }
+}


### PR DESCRIPTION
A bunch of changes that improve ergonomic of creating and transforming the Plutus data and related types

- Adds `From` instances to `PlutusData` from subtypes like`PlutusList` etc.
- Adds macros to construct values:
      -  `plutus_list`
      - `plutus_map`
      - `plutus_map_values`
      - `plutus_bytes`
      - `plutus_constr`

The macros implicitly use `From` internally, so where it's unambiguous, even primitive types can be used. Plutus data construction can now look like the following:

```rust
let my_bytes = plutus_bytes![1, 2, 3];
let my_list = plutus_list![1, 2, my_bytes];
let my_map = plutus_map! {
    1 => my_list,
    2 => plutus_map_values![my_bytes, 42],
};
// 3-field constructor with variant 0
let my_constr = plutus_constr!(0,
    my_bytes,
    my_list,
    my_map);
```

I propose `=>` as the separator for maps, because it's much more readable than a `:` or just `=`, and it fits convention from some other crates.