### PR TITLE
fix: replace bare unwrap in from_bech32 with proper error handling

### DIFF
--- a/rust/src/protocol_types/crypto/impl_hash_type_macro.rs
+++ b/rust/src/protocol_types/crypto/impl_hash_type_macro.rs
@@ -42,7 +42,8 @@ macro_rules! impl_hash_type {
             pub fn from_bech32(bech_str: &str) -> Result<$name, JsError> {
                 let (_hrp, u5data) =
                     bech32::decode(bech_str).map_err(|e| JsError::from_str(&e.to_string()))?;
-                let data: Vec<u8> = bech32::FromBase32::from_base32(&u5data).unwrap();
+                let data: Vec<u8> = bech32::FromBase32::from_base32(&u5data)
+                    .map_err(|e| JsError::from_str(&format!("Base32 decode failed: {:?}", e)))?;
                 Ok(Self::from_bytes(data)?)
             }
 


### PR DESCRIPTION
## Summary

Replaces a bare `.unwrap()` in `from_bech32` with proper error handling via `map_err`.

## Vulnerability Details

**Finding 2.2 from #757**: Bech32 unwrap DoS

The `from_base32(&u5data).unwrap()` call in `impl_hash_type_macro.rs` would panic if given a malformed bech32 string that passes `bech32::decode` but fails base32 decoding. In WASM environments, this panics the entire thread/runtime.

## Fix

Changed from:
```rust
let data: Vec<u8> = bech32::FromBase32::from_base32(&u5data).unwrap();
```

To:
```rust
let data: Vec<u8> = bech32::FromBase32::from_base32(&u5data)
    .map_err(|e| JsError::from_str(&format!("Base32 decode failed: {:?}", e)))?;
```

## Impact

- Minimal change: only replaces `.unwrap()` with `.map_err()`
- No behavioral change for valid input
- Prevents DoS from malformed bech32 input
- Compiles successfully

## Related

Addresses Finding 2.2 from security audit #757.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line error-handling change in shared macro code; no auth or data-model changes, only safer failure mode for invalid input.
> 
> **Overview**
> **`from_bech32` in `impl_hash_type!` no longer panics** when `bech32::FromBase32::from_base32` fails after a successful `bech32::decode`. The bare `.unwrap()` is replaced with `.map_err(...)`, surfacing a `JsError` with a `"Base32 decode failed: ..."` message instead of aborting the WASM runtime.
> 
> Valid bech32 input behavior is unchanged; malformed payloads that previously could trigger a thread panic now fail through the existing `Result` path. The fix applies to every hash type generated by the macro (e.g. `ScriptHash`, `TransactionHash`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cc93b4f177fdb775e02978414048be1ce209906. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->