### PR TITLE
fix: preserve Plutus language version through JSON serde

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -45,6 +45,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +79,7 @@ name = "cardano-serialization-lib"
 version = "16.0.0"
 dependencies = [
  "bech32",
+ "bincode",
  "cbor_event",
  "cfg-if",
  "clear_on_drop",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -70,6 +70,7 @@ getrandom = { version = "0.2.3", features = ["js"] }
 opt-level = "s"
 
 [dev-dependencies]
+bincode = "1.3.3"
 quickcheck = "0.9.2"
 quickcheck_macros = "0.9.1"
 rand_os = "0.1"

--- a/rust/src/protocol_types/plutus/plutus_script.rs
+++ b/rust/src/protocol_types/plutus/plutus_script.rs
@@ -127,8 +127,6 @@ enum PlutusScriptJson {
     },
 }
 
-const PLUTUS_SCRIPT_FIELDS: &'static [&'static str] = &["bytes", "language"];
-
 fn plutus_script_from_hex<E: serde::de::Error>(
     hex_str: &str,
     language: LanguageKind,
@@ -148,7 +146,7 @@ impl serde::Serialize for PlutusScript {
         where
             S: serde::Serializer,
     {
-        // Non-self-describing formats cannot decode the either-shape form below.
+        // Formats reporting is_human_readable() == false take a fixed pair instead.
         if !serializer.is_human_readable() {
             return (&self.bytes, Language(self.language)).serialize(serializer);
         }
@@ -204,11 +202,8 @@ impl<'de> serde::de::Visitor<'de> for PlutusScriptVisitor {
                     }
                     language = Some(map.next_value()?);
                 }
-                unknown => {
-                    return Err(serde::de::Error::unknown_field(
-                        unknown,
-                        PLUTUS_SCRIPT_FIELDS,
-                    ));
+                _ => {
+                    map.next_value::<serde::de::IgnoredAny>()?;
                 }
             }
         }

--- a/rust/src/protocol_types/plutus/plutus_script.rs
+++ b/rust/src/protocol_types/plutus/plutus_script.rs
@@ -115,12 +115,34 @@ impl PlutusScript {
     }
 }
 
+/// JSON representation of a [PlutusScript].
+///
+/// A bare hex string means Plutus V1, which is the only shape this type has ever
+/// emitted, so previously written JSON keeps deserializing unchanged. V2 and V3
+/// carry the language alongside the bytes, because the language selects the
+/// namespace byte in [PlutusScript::hash] and dropping it yields a script that
+/// hashes differently from the one that was serialized.
+#[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum PlutusScriptJson {
+    PlutusV1(String),
+    Versioned {
+        bytes: String,
+        language: LanguageKind,
+    },
+}
+
 impl serde::Serialize for PlutusScript {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer,
     {
-        serializer.serialize_str(&hex::encode(&self.bytes))
+        let bytes = hex::encode(&self.bytes);
+        match self.language {
+            LanguageKind::PlutusV1 => PlutusScriptJson::PlutusV1(bytes),
+            language => PlutusScriptJson::Versioned { bytes, language },
+        }
+        .serialize(serializer)
     }
 }
 
@@ -129,9 +151,12 @@ impl<'de> serde::de::Deserialize<'de> for PlutusScript {
         where
             D: serde::de::Deserializer<'de>,
     {
-        let s = <String as serde::de::Deserialize>::deserialize(deserializer)?;
+        let (s, language) = match PlutusScriptJson::deserialize(deserializer)? {
+            PlutusScriptJson::PlutusV1(s) => (s, LanguageKind::PlutusV1),
+            PlutusScriptJson::Versioned { bytes, language } => (bytes, language),
+        };
         hex::decode(&s)
-            .map(|bytes| PlutusScript::new(bytes))
+            .map(|bytes| PlutusScript { bytes, language })
             .map_err(|_err| {
                 serde::de::Error::invalid_value(
                     serde::de::Unexpected::Str(&s),
@@ -146,9 +171,9 @@ impl JsonSchema for PlutusScript {
         String::from("PlutusScript")
     }
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        String::json_schema(gen)
+        PlutusScriptJson::json_schema(gen)
     }
     fn is_referenceable() -> bool {
-        String::is_referenceable()
+        PlutusScriptJson::is_referenceable()
     }
 }

--- a/rust/src/protocol_types/plutus/plutus_script.rs
+++ b/rust/src/protocol_types/plutus/plutus_script.rs
@@ -115,21 +115,32 @@ impl PlutusScript {
     }
 }
 
-/// JSON representation of a [PlutusScript].
-///
-/// A bare hex string means Plutus V1, which is the only shape this type has ever
-/// emitted, so previously written JSON keeps deserializing unchanged. V2 and V3
-/// carry the language alongside the bytes, because the language selects the
-/// namespace byte in [PlutusScript::hash] and dropping it yields a script that
-/// hashes differently from the one that was serialized.
-#[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
+/// JSON form: a bare hex string means Plutus V1; V2 and V3 carry the language.
+#[derive(JsonSchema)]
 #[serde(untagged)]
+#[allow(dead_code)]
 enum PlutusScriptJson {
     PlutusV1(String),
     Versioned {
         bytes: String,
-        language: LanguageKind,
+        language: Language,
     },
+}
+
+const PLUTUS_SCRIPT_FIELDS: &'static [&'static str] = &["bytes", "language"];
+
+fn plutus_script_from_hex<E: serde::de::Error>(
+    hex_str: &str,
+    language: LanguageKind,
+) -> Result<PlutusScript, E> {
+    hex::decode(hex_str)
+        .map(|bytes| PlutusScript { bytes, language })
+        .map_err(|_err| {
+            serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(hex_str),
+                &"PlutusScript as hex string e.g. F8AB28C2 (without CBOR bytes tag)",
+            )
+        })
 }
 
 impl serde::Serialize for PlutusScript {
@@ -137,12 +148,73 @@ impl serde::Serialize for PlutusScript {
         where
             S: serde::Serializer,
     {
+        // Non-self-describing formats cannot decode the either-shape form below.
+        if !serializer.is_human_readable() {
+            return (&self.bytes, Language(self.language)).serialize(serializer);
+        }
         let bytes = hex::encode(&self.bytes);
         match self.language {
-            LanguageKind::PlutusV1 => PlutusScriptJson::PlutusV1(bytes),
-            language => PlutusScriptJson::Versioned { bytes, language },
+            LanguageKind::PlutusV1 => serializer.serialize_str(&bytes),
+            language => {
+                use serde::ser::SerializeStruct;
+                let mut state = serializer.serialize_struct("PlutusScript", 2)?;
+                state.serialize_field("bytes", &bytes)?;
+                state.serialize_field("language", &Language(language))?;
+                state.end()
+            }
         }
-        .serialize(serializer)
+    }
+}
+
+struct PlutusScriptVisitor;
+
+impl<'de> serde::de::Visitor<'de> for PlutusScriptVisitor {
+    type Value = PlutusScript;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str(
+            "a Plutus V1 script as a hex string, or an object with `bytes` and `language`",
+        )
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+    {
+        plutus_script_from_hex(value, LanguageKind::PlutusV1)
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+    {
+        let mut bytes: Option<String> = None;
+        let mut language: Option<Language> = None;
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "bytes" => {
+                    if bytes.is_some() {
+                        return Err(serde::de::Error::duplicate_field("bytes"));
+                    }
+                    bytes = Some(map.next_value()?);
+                }
+                "language" => {
+                    if language.is_some() {
+                        return Err(serde::de::Error::duplicate_field("language"));
+                    }
+                    language = Some(map.next_value()?);
+                }
+                unknown => {
+                    return Err(serde::de::Error::unknown_field(
+                        unknown,
+                        PLUTUS_SCRIPT_FIELDS,
+                    ));
+                }
+            }
+        }
+        let bytes = bytes.ok_or_else(|| serde::de::Error::missing_field("bytes"))?;
+        let language = language.ok_or_else(|| serde::de::Error::missing_field("language"))?;
+        plutus_script_from_hex(&bytes, language.kind())
     }
 }
 
@@ -151,18 +223,14 @@ impl<'de> serde::de::Deserialize<'de> for PlutusScript {
         where
             D: serde::de::Deserializer<'de>,
     {
-        let (s, language) = match PlutusScriptJson::deserialize(deserializer)? {
-            PlutusScriptJson::PlutusV1(s) => (s, LanguageKind::PlutusV1),
-            PlutusScriptJson::Versioned { bytes, language } => (bytes, language),
-        };
-        hex::decode(&s)
-            .map(|bytes| PlutusScript { bytes, language })
-            .map_err(|_err| {
-                serde::de::Error::invalid_value(
-                    serde::de::Unexpected::Str(&s),
-                    &"PlutusScript as hex string e.g. F8AB28C2 (without CBOR bytes tag)",
-                )
-            })
+        if !deserializer.is_human_readable() {
+            let (bytes, language) = <(Vec<u8>, Language)>::deserialize(deserializer)?;
+            return Ok(PlutusScript {
+                bytes,
+                language: language.kind(),
+            });
+        }
+        deserializer.deserialize_any(PlutusScriptVisitor)
     }
 }
 

--- a/rust/src/protocol_types/plutus/plutus_script.rs
+++ b/rust/src/protocol_types/plutus/plutus_script.rs
@@ -116,6 +116,7 @@ impl PlutusScript {
 }
 
 /// JSON form: a bare hex string means Plutus V1; V2 and V3 carry the language.
+/// The hex is the raw compiled script, not the cardano-cli "cborHex".
 #[derive(JsonSchema)]
 #[serde(untagged)]
 #[allow(dead_code)]

--- a/rust/src/tests/serialization/general.rs
+++ b/rust/src/tests/serialization/general.rs
@@ -306,6 +306,66 @@ fn tx_output_deser_post_alonzo_with_plutus_script_and_datum_json() {
 }
 
 #[test]
+fn plutus_script_json_round_trip_preserves_language() {
+    // The language selects the namespace byte in the script hash, so losing it
+    // yields a script that hashes differently from the one serialized.
+    for script in [
+        PlutusScript::new([61u8; 29].to_vec()),
+        PlutusScript::new_v2([61u8; 29].to_vec()),
+        PlutusScript::new_v3([61u8; 29].to_vec()),
+    ] {
+        let json = serde_json::to_string(&script).unwrap();
+        let deser: PlutusScript = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deser.language_version(), script.language_version(), "{json}");
+        assert_eq!(deser.bytes(), script.bytes(), "{json}");
+        assert_eq!(deser.hash(), script.hash(), "{json}");
+    }
+}
+
+#[test]
+fn plutus_script_json_v1_stays_a_bare_hex_string() {
+    // Previously written JSON has no language field, and everything this type
+    // ever emitted was Plutus V1. Both directions must keep working.
+    let script = PlutusScript::new([61u8; 29].to_vec());
+
+    assert_eq!(
+        serde_json::to_string(&script).unwrap(),
+        format!("\"{}\"", hex::encode([61u8; 29]))
+    );
+
+    let from_legacy: PlutusScript =
+        serde_json::from_str(&format!("\"{}\"", hex::encode([61u8; 29]))).unwrap();
+    assert_eq!(from_legacy.language_version(), Language::new_plutus_v1());
+    assert_eq!(from_legacy.bytes(), script.bytes());
+}
+
+#[test]
+fn tx_output_deser_post_alonzo_with_plutus_v2_script_and_datum_json() {
+    let mut txos = TransactionOutputs::new();
+    let addr = Address::from_bech32("addr1qyxwnq9kylzrtqprmyu35qt8gwylk3eemq53kqd38m9kyduv2q928esxmrz4y5e78cvp0nffhxklfxsqy3vdjn3nty9s8zygkm").unwrap();
+    let val = &Value::new(&BigNum::from_str("435464757").unwrap());
+    let mut txo = TransactionOutput {
+        address: addr.clone(),
+        amount: val.clone(),
+        plutus_data: None,
+        script_ref: None,
+        serialization_format: None,
+    };
+    txo.set_plutus_data(&PlutusData::new_bytes(fake_bytes_32(11)));
+    txo.set_script_ref(&ScriptRef::new_plutus_script(&PlutusScript::new_v2(
+        [61u8; 29].to_vec(),
+    )));
+    txos.add(&txo);
+
+    let json_txos = txos.to_json().unwrap();
+    let deser_txos = TransactionOutputs::from_json(json_txos.as_str()).unwrap();
+
+    assert_eq!(deser_txos.to_bytes(), txos.to_bytes());
+    assert_eq!(deser_txos.to_json().unwrap(), txos.to_json().unwrap());
+}
+
+#[test]
 fn tx_output_deser_post_alonzo_with_plutus_script_json() {
     let mut txos = TransactionOutputs::new();
     let addr = Address::from_bech32("addr1qyxwnq9kylzrtqprmyu35qt8gwylk3eemq53kqd38m9kyduv2q928esxmrz4y5e78cvp0nffhxklfxsqy3vdjn3nty9s8zygkm").unwrap();

--- a/rust/src/tests/serialization/general.rs
+++ b/rust/src/tests/serialization/general.rs
@@ -306,66 +306,6 @@ fn tx_output_deser_post_alonzo_with_plutus_script_and_datum_json() {
 }
 
 #[test]
-fn plutus_script_json_round_trip_preserves_language() {
-    // The language selects the namespace byte in the script hash, so losing it
-    // yields a script that hashes differently from the one serialized.
-    for script in [
-        PlutusScript::new([61u8; 29].to_vec()),
-        PlutusScript::new_v2([61u8; 29].to_vec()),
-        PlutusScript::new_v3([61u8; 29].to_vec()),
-    ] {
-        let json = serde_json::to_string(&script).unwrap();
-        let deser: PlutusScript = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(deser.language_version(), script.language_version(), "{json}");
-        assert_eq!(deser.bytes(), script.bytes(), "{json}");
-        assert_eq!(deser.hash(), script.hash(), "{json}");
-    }
-}
-
-#[test]
-fn plutus_script_json_v1_stays_a_bare_hex_string() {
-    // Previously written JSON has no language field, and everything this type
-    // ever emitted was Plutus V1. Both directions must keep working.
-    let script = PlutusScript::new([61u8; 29].to_vec());
-
-    assert_eq!(
-        serde_json::to_string(&script).unwrap(),
-        format!("\"{}\"", hex::encode([61u8; 29]))
-    );
-
-    let from_legacy: PlutusScript =
-        serde_json::from_str(&format!("\"{}\"", hex::encode([61u8; 29]))).unwrap();
-    assert_eq!(from_legacy.language_version(), Language::new_plutus_v1());
-    assert_eq!(from_legacy.bytes(), script.bytes());
-}
-
-#[test]
-fn tx_output_deser_post_alonzo_with_plutus_v2_script_and_datum_json() {
-    let mut txos = TransactionOutputs::new();
-    let addr = Address::from_bech32("addr1qyxwnq9kylzrtqprmyu35qt8gwylk3eemq53kqd38m9kyduv2q928esxmrz4y5e78cvp0nffhxklfxsqy3vdjn3nty9s8zygkm").unwrap();
-    let val = &Value::new(&BigNum::from_str("435464757").unwrap());
-    let mut txo = TransactionOutput {
-        address: addr.clone(),
-        amount: val.clone(),
-        plutus_data: None,
-        script_ref: None,
-        serialization_format: None,
-    };
-    txo.set_plutus_data(&PlutusData::new_bytes(fake_bytes_32(11)));
-    txo.set_script_ref(&ScriptRef::new_plutus_script(&PlutusScript::new_v2(
-        [61u8; 29].to_vec(),
-    )));
-    txos.add(&txo);
-
-    let json_txos = txos.to_json().unwrap();
-    let deser_txos = TransactionOutputs::from_json(json_txos.as_str()).unwrap();
-
-    assert_eq!(deser_txos.to_bytes(), txos.to_bytes());
-    assert_eq!(deser_txos.to_json().unwrap(), txos.to_json().unwrap());
-}
-
-#[test]
 fn tx_output_deser_post_alonzo_with_plutus_script_json() {
     let mut txos = TransactionOutputs::new();
     let addr = Address::from_bech32("addr1qyxwnq9kylzrtqprmyu35qt8gwylk3eemq53kqd38m9kyduv2q928esxmrz4y5e78cvp0nffhxklfxsqy3vdjn3nty9s8zygkm").unwrap();
@@ -392,6 +332,156 @@ fn tx_output_deser_post_alonzo_with_plutus_script_json() {
 
     assert_eq!(deser_txos.to_bytes(), txos.to_bytes());
     assert_eq!(deser_txos.to_json().unwrap(), txos.to_json().unwrap());
+}
+
+#[test]
+fn tx_output_deser_post_alonzo_with_plutus_v2_script_and_datum_json() {
+    let mut txos = TransactionOutputs::new();
+    let addr = Address::from_bech32("addr1qyxwnq9kylzrtqprmyu35qt8gwylk3eemq53kqd38m9kyduv2q928esxmrz4y5e78cvp0nffhxklfxsqy3vdjn3nty9s8zygkm").unwrap();
+    let val = &Value::new(&BigNum::from_str("435464757").unwrap());
+    let txo = TransactionOutput {
+        address: addr.clone(),
+        amount: val.clone(),
+        plutus_data: None,
+        script_ref: None,
+        serialization_format: None,
+    };
+    let mut txo_dh = txo.clone();
+    txo_dh.set_plutus_data(&PlutusData::new_bytes(fake_bytes_32(11)));
+    txo_dh.set_script_ref(&ScriptRef::new_plutus_script(&PlutusScript::new_v2(
+        [61u8; 29].to_vec(),
+    )));
+    txos.add(&txo);
+    txos.add(&txo_dh);
+    let json_txos = txos.to_json().unwrap();
+    let deser_txos = TransactionOutputs::from_json(json_txos.as_str()).unwrap();
+
+    assert_eq!(deser_txos.to_bytes(), txos.to_bytes());
+    assert_eq!(deser_txos.to_json().unwrap(), txos.to_json().unwrap());
+}
+
+/// A real compiled Plutus script; do not replace it with filler bytes.
+const COMPILED_PLUTUS_SCRIPT: &str = "4e4d01000033222220051200120011";
+
+fn compiled_plutus_script_bytes() -> Vec<u8> {
+    hex::decode(COMPILED_PLUTUS_SCRIPT).unwrap()
+}
+
+#[test]
+fn plutus_script_json_round_trip_preserves_language() {
+    // The language is the namespace byte in the script hash.
+    let bytes = compiled_plutus_script_bytes();
+    for script in [
+        PlutusScript::new(bytes.clone()),
+        PlutusScript::new_v2(bytes.clone()),
+        PlutusScript::new_v3(bytes.clone()),
+    ] {
+        let json = serde_json::to_string(&script).unwrap();
+        let deser: PlutusScript = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deser.language_version(), script.language_version(), "{json}");
+        assert_eq!(deser.bytes(), script.bytes(), "{json}");
+        assert_eq!(deser.hash(), script.hash(), "{json}");
+    }
+}
+
+#[test]
+fn plutus_script_json_v1_stays_a_bare_hex_string() {
+    // Previously written JSON has no language field and was always Plutus V1.
+    let script = PlutusScript::new(compiled_plutus_script_bytes());
+
+    assert_eq!(
+        serde_json::to_string(&script).unwrap(),
+        format!("\"{}\"", COMPILED_PLUTUS_SCRIPT)
+    );
+
+    let from_legacy: PlutusScript =
+        serde_json::from_str(&format!("\"{}\"", COMPILED_PLUTUS_SCRIPT)).unwrap();
+    assert_eq!(from_legacy.language_version(), Language::new_plutus_v1());
+    assert_eq!(from_legacy.bytes(), script.bytes());
+}
+
+#[test]
+fn plutus_script_json_accepts_an_explicit_v1_language() {
+    // Accepted but never emitted, so nothing else pins this branch.
+    let json = format!("{{\"bytes\":\"{COMPILED_PLUTUS_SCRIPT}\",\"language\":\"PlutusV1\"}}");
+
+    let script: PlutusScript = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(script.language_version(), Language::new_plutus_v1());
+    assert_eq!(script.bytes(), compiled_plutus_script_bytes());
+}
+
+#[test]
+fn plutus_script_json_rejects_malformed_input() {
+    for (json, expected) in [
+        ("null", "invalid type"),
+        ("12345", "invalid type"),
+        ("\"zz\"", "invalid value"),
+        ("{}", "missing field `bytes`"),
+        ("{\"bytes\":\"4e4d01\"}", "missing field `language`"),
+        (
+            "{\"bytes\":\"4e4d01\",\"language\":\"PlutusV2\",\"extra\":1}",
+            "unknown field `extra`",
+        ),
+        (
+            "{\"bytes\":\"zz\",\"language\":\"PlutusV2\"}",
+            "invalid value",
+        ),
+    ] {
+        let err = serde_json::from_str::<PlutusScript>(json).unwrap_err();
+        assert!(
+            err.to_string().contains(expected),
+            "{} gave {}, expected {}",
+            json,
+            err,
+            expected
+        );
+    }
+}
+
+#[test]
+fn plutus_script_binary_serde_round_trip_preserves_language() {
+    // Non-self-describing formats take a fixed pair, not the either-shape form.
+    for script in [
+        PlutusScript::new(compiled_plutus_script_bytes()),
+        PlutusScript::new_v2(compiled_plutus_script_bytes()),
+        PlutusScript::new_v3(compiled_plutus_script_bytes()),
+    ] {
+        let encoded = bincode::serialize(&script).unwrap();
+        let deser: PlutusScript = bincode::deserialize(&encoded).unwrap();
+
+        assert_eq!(deser, script);
+    }
+}
+
+#[test]
+fn witness_set_json_round_trip_keeps_each_script_language() {
+    // The language picks the witness-set CBOR key and the script_data_hash cost model.
+    let bytes = compiled_plutus_script_bytes();
+    let mut scripts = PlutusScripts::new();
+    scripts.add(&PlutusScript::new(bytes.clone()));
+    scripts.add(&PlutusScript::new_v2(bytes.clone()));
+    scripts.add(&PlutusScript::new_v3(bytes.clone()));
+    let mut ws = TransactionWitnessSet::new();
+    ws.set_plutus_scripts(&scripts);
+
+    let deser = TransactionWitnessSet::from_json(ws.to_json().unwrap().as_str()).unwrap();
+
+    let langs: Vec<Language> = deser
+        .plutus_scripts()
+        .unwrap()
+        .into_iter()
+        .map(|s| s.language_version())
+        .collect();
+    assert_eq!(
+        langs,
+        vec![
+            Language::new_plutus_v1(),
+            Language::new_plutus_v2(),
+            Language::new_plutus_v3()
+        ]
+    );
 }
 
 #[test]

--- a/rust/src/tests/serialization/general.rs
+++ b/rust/src/tests/serialization/general.rs
@@ -360,7 +360,6 @@ fn tx_output_deser_post_alonzo_with_plutus_v2_script_and_datum_json() {
     assert_eq!(deser_txos.to_json().unwrap(), txos.to_json().unwrap());
 }
 
-/// A real compiled Plutus script; do not replace it with filler bytes.
 const COMPILED_PLUTUS_SCRIPT: &str = "4e4d01000033222220051200120011";
 
 fn compiled_plutus_script_bytes() -> Vec<u8> {
@@ -369,7 +368,6 @@ fn compiled_plutus_script_bytes() -> Vec<u8> {
 
 #[test]
 fn plutus_script_json_round_trip_preserves_language() {
-    // The language is the namespace byte in the script hash.
     let bytes = compiled_plutus_script_bytes();
     for script in [
         PlutusScript::new(bytes.clone()),
@@ -387,7 +385,6 @@ fn plutus_script_json_round_trip_preserves_language() {
 
 #[test]
 fn plutus_script_json_v1_stays_a_bare_hex_string() {
-    // Previously written JSON has no language field and was always Plutus V1.
     let script = PlutusScript::new(compiled_plutus_script_bytes());
 
     assert_eq!(
@@ -403,7 +400,6 @@ fn plutus_script_json_v1_stays_a_bare_hex_string() {
 
 #[test]
 fn plutus_script_json_accepts_an_explicit_v1_language() {
-    // Accepted but never emitted, so nothing else pins this branch.
     let json = format!("{{\"bytes\":\"{COMPILED_PLUTUS_SCRIPT}\",\"language\":\"PlutusV1\"}}");
 
     let script: PlutusScript = serde_json::from_str(&json).unwrap();
@@ -413,20 +409,45 @@ fn plutus_script_json_accepts_an_explicit_v1_language() {
 }
 
 #[test]
+fn plutus_script_json_object_ignores_field_order_and_unknown_fields() {
+    let json =
+        format!("{{\"language\":\"PlutusV3\",\"extra\":1,\"bytes\":\"{COMPILED_PLUTUS_SCRIPT}\"}}");
+
+    let script: PlutusScript = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(script.language_version(), Language::new_plutus_v3());
+    assert_eq!(script.bytes(), compiled_plutus_script_bytes());
+}
+
+#[test]
+fn plutus_script_json_schema_describes_both_shapes() {
+    let schema = serde_json::to_value(schemars::schema_for!(PlutusScript)).unwrap();
+
+    let shapes = schema["anyOf"].as_array().unwrap();
+    assert_eq!(shapes[0]["type"], "string");
+    assert_eq!(shapes[1]["required"], serde_json::json!(["bytes", "language"]));
+}
+
+#[test]
 fn plutus_script_json_rejects_malformed_input() {
     for (json, expected) in [
         ("null", "invalid type"),
         ("12345", "invalid type"),
         ("\"zz\"", "invalid value"),
         ("{}", "missing field `bytes`"),
+        ("[]", "invalid type"),
         ("{\"bytes\":\"4e4d01\"}", "missing field `language`"),
-        (
-            "{\"bytes\":\"4e4d01\",\"language\":\"PlutusV2\",\"extra\":1}",
-            "unknown field `extra`",
-        ),
         (
             "{\"bytes\":\"zz\",\"language\":\"PlutusV2\"}",
             "invalid value",
+        ),
+        (
+            "{\"bytes\":\"4e4d01\",\"bytes\":\"4e4d01\",\"language\":\"PlutusV2\"}",
+            "duplicate field `bytes`",
+        ),
+        (
+            "{\"bytes\":\"4e4d01\",\"language\":\"PlutusV2\",\"language\":\"PlutusV3\"}",
+            "duplicate field `language`",
         ),
     ] {
         let err = serde_json::from_str::<PlutusScript>(json).unwrap_err();
@@ -442,7 +463,6 @@ fn plutus_script_json_rejects_malformed_input() {
 
 #[test]
 fn plutus_script_binary_serde_round_trip_preserves_language() {
-    // Non-self-describing formats take a fixed pair, not the either-shape form.
     for script in [
         PlutusScript::new(compiled_plutus_script_bytes()),
         PlutusScript::new_v2(compiled_plutus_script_bytes()),
@@ -457,7 +477,6 @@ fn plutus_script_binary_serde_round_trip_preserves_language() {
 
 #[test]
 fn witness_set_json_round_trip_keeps_each_script_language() {
-    // The language picks the witness-set CBOR key and the script_data_hash cost model.
     let bytes = compiled_plutus_script_bytes();
     let mut scripts = PlutusScripts::new();
     scripts.add(&PlutusScript::new(bytes.clone()));
@@ -468,6 +487,7 @@ fn witness_set_json_round_trip_keeps_each_script_language() {
 
     let deser = TransactionWitnessSet::from_json(ws.to_json().unwrap().as_str()).unwrap();
 
+    assert_eq!(deser.to_bytes(), ws.to_bytes());
     let langs: Vec<Language> = deser
         .plutus_scripts()
         .unwrap()

--- a/rust/src/tests/serialization/general.rs
+++ b/rust/src/tests/serialization/general.rs
@@ -1,4 +1,4 @@
-use crate::{Address, BigInt, BigNum, Block, BlockHash, CborContainerType, Coin, Credential, DataHash, ExUnits, HeaderBody, HeaderLeaderCertEnum, Int, KESVKey, MIRPot, MIRToStakeCredentials, MoveInstantaneousReward, NativeScript, OperationalCert, PlutusData, PlutusList, PlutusScript, PlutusScripts, ProtocolVersion, Redeemer, RedeemerTag, Redeemers, ScriptHash, ScriptRef, TimelockStart, TransactionBody, TransactionInputs, TransactionOutput, TransactionOutputs, TransactionWitnessSet, VRFCert, VRFVKey, Value, Vkeywitness, Vkeywitnesses, VersionedBlock, BlockEra, to_bytes, BootstrapWitnesses, Credentials, Ed25519KeyHashes, CborSetType, ScriptPubkey, NativeScripts, Language, PlutusDatumSchema, AddressKind};
+use crate::{Address, BigInt, BigNum, Block, BlockHash, CborContainerType, Coin, Credential, DataHash, ExUnits, HeaderBody, HeaderLeaderCertEnum, Int, KESVKey, MIRPot, MIRToStakeCredentials, MoveInstantaneousReward, NativeScript, OperationalCert, PlutusData, PlutusList, PlutusScript, PlutusScripts, ProtocolVersion, Redeemer, RedeemerTag, Redeemers, ScriptHash, ScriptRef, TimelockStart, TransactionBody, TransactionInputs, TransactionOutput, TransactionOutputs, TransactionUnspentOutput, TransactionWitnessSet, VRFCert, VRFVKey, Value, Vkeywitness, Vkeywitnesses, VersionedBlock, BlockEra, to_bytes, BootstrapWitnesses, Credentials, Ed25519KeyHashes, CborSetType, ScriptPubkey, NativeScripts, Language, PlutusDatumSchema, AddressKind};
 use crate::protocol_types::ScriptRefEnum;
 use crate::tests::fakes::{fake_base_address, fake_bootsrap_witness, fake_bytes_32, fake_data_hash, fake_key_hash, fake_signature, fake_tx_input, fake_tx_output, fake_value, fake_value2, fake_vkey, fake_vkey_witness};
 
@@ -360,10 +360,26 @@ fn tx_output_deser_post_alonzo_with_plutus_v2_script_and_datum_json() {
     assert_eq!(deser_txos.to_json().unwrap(), txos.to_json().unwrap());
 }
 
-const COMPILED_PLUTUS_SCRIPT: &str = "4e4d01000033222220051200120011";
+const COMPILED_PLUTUS_SCRIPT: &str = "4d01000033222220051200120011";
 
 fn compiled_plutus_script_bytes() -> Vec<u8> {
     hex::decode(COMPILED_PLUTUS_SCRIPT).unwrap()
+}
+
+#[test]
+fn utxo_json_round_trip_keeps_a_v3_reference_script() {
+    let addr = Address::from_bech32("addr1qyxwnq9kylzrtqprmyu35qt8gwylk3eemq53kqd38m9kyduv2q928esxmrz4y5e78cvp0nffhxklfxsqy3vdjn3nty9s8zygkm").unwrap();
+    let mut output = TransactionOutput::new(&addr, &Value::new(&BigNum::from_str("435464757").unwrap()));
+    let script = PlutusScript::new_v3(compiled_plutus_script_bytes());
+    output.set_script_ref(&ScriptRef::new_plutus_script(&script));
+    let utxo = TransactionUnspentOutput::new(&fake_tx_input(7), &output);
+
+    let deser = TransactionUnspentOutput::from_json(utxo.to_json().unwrap().as_str()).unwrap();
+
+    assert_eq!(deser.to_bytes(), utxo.to_bytes());
+    let deser_script = deser.output().script_ref().unwrap().plutus_script().unwrap();
+    assert_eq!(deser_script.language_version(), Language::new_plutus_v3());
+    assert_eq!(deser_script.hash(), script.hash());
 }
 
 #[test]


### PR DESCRIPTION
`PlutusScript` serializes to a bare hex string and always deserializes via `PlutusScript::new`, which is hardcoded to Plutus V1. A V2 or V3 script therefore round-trips as V1.

```rust
let s = PlutusScript::new_v2(vec![0x4e, 0x4d, 0x01]);
let r = ScriptRef::new_plutus_script(&s);
let back: ScriptRef = serde_json::from_str(&serde_json::to_string(&r).unwrap()).unwrap();
```

```
json={"PlutusScript":"4e4d01"}
before=PlutusV2  after=PlutusV1
hash_before=f5bd2659cbe2beda7e8ffc8e1e973108770d3f41dac38b13c5ede89a
hash_after =9884df433d130ee9a6cf8653787ba015638fcc5acf044fc13725fb64
```

The blast radius is wider than the script hash. The language is the namespace byte in `PlutusScript::hash`, it is the script-type discriminator inside the `script_ref` array (1, 2 or 3, per Conway `script = [0, native // 1, v1 // 2, v2 // 3, v3]`), it picks which witness-set key (3, 6 or 7) a script lands under, and it selects the cost model that feeds `script_data_hash`. `script_data_hash` sits inside the transaction body, so a witness set that has been through JSON yields a transaction with a different body hash, not merely a reference script with a different script hash. CBOR is unaffected throughout, since it encodes the language.

## Approach

Backwards compatible rather than changing the representation outright:

- V1 still serializes to a bare hex string, exactly as before.
- A bare hex string still deserializes to V1, so previously written JSON keeps working.
- V2 and V3 serialize as `{"bytes": "...", "language": "PlutusV2"}` and deserialize from it. An explicit `"language": "PlutusV1"` is accepted too, though never emitted.

Only V2/V3 JSON output changes shape, and that output is wrong today, so nothing can be depending on it correctly.

Deserialization is a hand-written `Visitor` rather than `#[serde(untagged)]`. Untagged buffers through `Content`, which needs `Deserializer::deserialize_any`, and formats that do not support that call would have broken for every language including V1, which had no bug. Untagged also collapses every failure into "data did not match any variant"; the visitor keeps the original invalid-value message and adds `missing field` and `duplicate field` where they apply. Unknown fields are ignored, matching the derived impls used by every other JSON type in the crate.

## Two wire changes worth calling out

**Binary serde output changes shape for all three languages, with no compat path.** Formats reporting `is_human_readable() == false` now take a fixed `(bytes, language)` pair; previously they got the hex string, same as JSON. No encoding can both carry the language and keep the old shape. For a standalone script an old archive fails cleanly, but for a script embedded mid-struct the new decoder can consume the hex ASCII as the byte payload and read the following field as the language discriminant, succeeding with corrupt data. The library has never documented a binary format, so this is a change to something previously unspecified rather than to a promise, but it should not go unmentioned. `serde-wasm-bindgen` reports `is_human_readable() == true` in both directions, so `to_js_value`/`from_js_value` stay on the same branch as `to_json`.

**The generated TypeScript typings break, so this cannot ship as a 16.0.x patch.** `PlutusScriptJSON` goes from

```ts
export type PlutusScriptJSON = string;
```

to

```ts
export type PlutusScriptJSON = string | { bytes: string; language: LanguageJSON };
```

Any downstream TS that treats a script as a string stops compiling. `is_referenceable()` also flips `false` to `true`, so `PlutusScript` moves from an inlined `{"type":"string"}` to a `$ref` in every enclosing schema. The Rust API is unchanged.

Happy to split the binary branch out or drop it if you would rather keep that surface untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes incorrect script hashes on JSON round-trip for Plutus V2/V3, which can invalidate transactions built from serialized UTXOs/witnesses; V1 JSON behavior is preserved.
> 
> **Overview**
> Fixes a bug where **`PlutusScript`** JSON round-trips dropped the Plutus language: scripts were always deserialized as **V1**, so **V2/V3** scripts got the wrong **script hash** (namespace byte in `hash()`). That broke JSON paths for **reference scripts** on outputs, witness sets, and UTXOs—CBOR was unaffected.
> 
> **JSON shape (backward compatible):** **V1** still serializes as a bare hex string and bare hex still means V1. **V2** and **V3** serialize as `{"bytes": "...", "language": "PlutusV2"|"PlutusV3"}` and deserialize from that object (explicit V1 object, unknown fields ignored). Non-human-readable serde (e.g. **bincode**) uses a `(bytes, language)` pair. **JsonSchema** documents both string and object forms.
> 
> Adds regression tests for JSON/bincode round-trip, witness sets, V2 outputs, and malformed input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02e1fec3a2a8ec459e42f9ad61a0e2a1df9a7644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
