### PR TITLE
17.0.0: require an explicit language in PlutusScript JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "16.0.0",
+  "version": "17.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cardano-serialization-lib",
-      "version": "16.0.0",
+      "version": "17.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cardano-serialization-lib",
-  "version": "16.0.0",
+  "version": "17.0.0",
   "description": "(De)serialization functions for the Cardano blockchain along with related utility functions",
   "scripts": {
     "publish-all:prod": "node scripts/build-helper.js publish-all --env prod",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cardano-serialization-lib"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bech32",
  "bincode",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cardano-serialization-lib"
-version = "16.0.0"
+version = "17.0.0"
 edition = "2018"
 authors = ["EMURGO"]
 license = "MIT"

--- a/rust/json-gen/Cargo.lock
+++ b/rust/json-gen/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "cardano-serialization-lib"
-version = "16.0.0"
+version = "17.0.0"
 dependencies = [
  "bech32",
  "cbor_event",

--- a/rust/pkg/cardano_serialization_lib.js.flow
+++ b/rust/pkg/cardano_serialization_lib.js.flow
@@ -6,65 +6,44 @@
  */
 
 /**
+ * @param {TransactionMetadatum} metadata
+ * @returns {Uint8Array}
+ */
+declare export function decode_arbitrary_bytes_from_metadatum(
+  metadata: TransactionMetadatum
+): Uint8Array;
+
+/**
  * @param {string} json
  * @param {$Values<
                 typeof 
-                PlutusDatumSchema>} schema
- * @returns {PlutusData}
+                MetadataJsonSchema>} schema
+ * @returns {TransactionMetadatum}
  */
-declare export function encode_json_str_to_plutus_datum(
+declare export function encode_json_str_to_metadatum(
   json: string,
-  schema: $Values<typeof PlutusDatumSchema>
-): PlutusData;
+  schema: $Values<typeof MetadataJsonSchema>
+): TransactionMetadatum;
 
 /**
- * @param {PlutusData} datum
+ * @param {Uint8Array} bytes
+ * @returns {TransactionMetadatum}
+ */
+declare export function encode_arbitrary_bytes_as_metadatum(
+  bytes: Uint8Array
+): TransactionMetadatum;
+
+/**
+ * @param {TransactionMetadatum} metadatum
  * @param {$Values<
                 typeof 
-                PlutusDatumSchema>} schema
+                MetadataJsonSchema>} schema
  * @returns {string}
  */
-declare export function decode_plutus_datum_to_json_str(
-  datum: PlutusData,
-  schema: $Values<typeof PlutusDatumSchema>
+declare export function decode_metadatum_to_json_str(
+  metadatum: TransactionMetadatum,
+  schema: $Values<typeof MetadataJsonSchema>
 ): string;
-
-/**
- * @param {number} total_ref_scripts_size
- * @param {UnitInterval} ref_script_coins_per_byte
- * @returns {BigNum}
- */
-declare export function min_ref_script_fee(
-  total_ref_scripts_size: number,
-  ref_script_coins_per_byte: UnitInterval
-): BigNum;
-
-/**
- * @param {Transaction} tx
- * @param {LinearFee} linear_fee
- * @returns {BigNum}
- */
-declare export function min_fee(tx: Transaction, linear_fee: LinearFee): BigNum;
-
-/**
- * @param {Transaction} tx
- * @param {ExUnitPrices} ex_unit_prices
- * @returns {BigNum}
- */
-declare export function min_script_fee(
-  tx: Transaction,
-  ex_unit_prices: ExUnitPrices
-): BigNum;
-
-/**
- * @param {ExUnits} ex_units
- * @param {ExUnitPrices} ex_unit_prices
- * @returns {BigNum}
- */
-declare export function calculate_ex_units_ceil_cost(
-  ex_units: ExUnits,
-  ex_unit_prices: ExUnitPrices
-): BigNum;
 
 /**
  * @param {string} password
@@ -91,55 +70,146 @@ declare export function decrypt_with_password(
 ): string;
 
 /**
- * @param {string} json
+ * @param {PlutusData} datum
  * @param {$Values<
                 typeof 
-                MetadataJsonSchema>} schema
- * @returns {TransactionMetadatum}
- */
-declare export function encode_json_str_to_metadatum(
-  json: string,
-  schema: $Values<typeof MetadataJsonSchema>
-): TransactionMetadatum;
-
-/**
- * @param {TransactionMetadatum} metadatum
- * @param {$Values<
-                typeof 
-                MetadataJsonSchema>} schema
+                PlutusDatumSchema>} schema
  * @returns {string}
  */
-declare export function decode_metadatum_to_json_str(
-  metadatum: TransactionMetadatum,
-  schema: $Values<typeof MetadataJsonSchema>
+declare export function decode_plutus_datum_to_json_str(
+  datum: PlutusData,
+  schema: $Values<typeof PlutusDatumSchema>
 ): string;
 
 /**
- * @param {Uint8Array} bytes
- * @returns {TransactionMetadatum}
+ * @param {string} json
+ * @param {$Values<
+                typeof 
+                PlutusDatumSchema>} schema
+ * @returns {PlutusData}
  */
-declare export function encode_arbitrary_bytes_as_metadatum(
-  bytes: Uint8Array
-): TransactionMetadatum;
+declare export function encode_json_str_to_plutus_datum(
+  json: string,
+  schema: $Values<typeof PlutusDatumSchema>
+): PlutusData;
 
 /**
- * @param {TransactionMetadatum} metadata
- * @returns {Uint8Array}
+ * @param {number} total_ref_scripts_size
+ * @param {UnitInterval} ref_script_coins_per_byte
+ * @returns {BigNum}
  */
-declare export function decode_arbitrary_bytes_from_metadatum(
-  metadata: TransactionMetadatum
-): Uint8Array;
+declare export function min_ref_script_fee(
+  total_ref_scripts_size: number,
+  ref_script_coins_per_byte: UnitInterval
+): BigNum;
+
+/**
+ * @param {ExUnits} ex_units
+ * @param {ExUnitPrices} ex_unit_prices
+ * @returns {BigNum}
+ */
+declare export function calculate_ex_units_ceil_cost(
+  ex_units: ExUnits,
+  ex_unit_prices: ExUnitPrices
+): BigNum;
+
+/**
+ * @param {Transaction} tx
+ * @param {LinearFee} linear_fee
+ * @returns {BigNum}
+ */
+declare export function min_fee(tx: Transaction, linear_fee: LinearFee): BigNum;
+
+/**
+ * @param {Transaction} tx
+ * @param {ExUnitPrices} ex_unit_prices
+ * @returns {BigNum}
+ */
+declare export function min_script_fee(
+  tx: Transaction,
+  ex_unit_prices: ExUnitPrices
+): BigNum;
+
+/**
+ * Returns the state of the transaction sets.
+ * If all sets have a tag, it returns AllSetsHaveTag.
+ * If all sets have no tag, it returns AllSetsHaveNoTag.
+ * If there is a mix of tagged and untagged sets, it returns MixedSets.
+ * This function is useful for checking if a transaction might be signed by a hardware wallet.
+ * And for checking which parameter should be used in a hardware wallet api.
+ * WARNING this function will be deleted after all tags for set types will be mandatory. Approx after next hf
+ * @param {Uint8Array} tx_bytes
+ * @returns {$Values<
+                typeof 
+                TransactionSetsState>}
+ */
+declare export function has_transaction_set_tag(
+  tx_bytes: Uint8Array
+): $Values<typeof TransactionSetsState>;
 
 /**
  * @param {TransactionBody} txbody
  * @param {BigNum} pool_deposit
  * @param {BigNum} key_deposit
- * @returns {BigNum}
+ * @returns {Value}
  */
-declare export function get_deposit(
+declare export function get_implicit_input(
   txbody: TransactionBody,
   pool_deposit: BigNum,
   key_deposit: BigNum
+): Value;
+
+/**
+ * @param {TransactionHash} tx_body_hash
+ * @param {ByronAddress} addr
+ * @param {Bip32PrivateKey} key
+ * @returns {BootstrapWitness}
+ */
+declare export function make_icarus_bootstrap_witness(
+  tx_body_hash: TransactionHash,
+  addr: ByronAddress,
+  key: Bip32PrivateKey
+): BootstrapWitness;
+
+/**
+ * @param {PlutusData} plutus_data
+ * @returns {DataHash}
+ */
+declare export function hash_plutus_data(plutus_data: PlutusData): DataHash;
+
+/**
+ * @param {Redeemers} redeemers
+ * @param {Costmdls} cost_models
+ * @param {PlutusList | void} [datums]
+ * @returns {ScriptDataHash}
+ */
+declare export function hash_script_data(
+  redeemers: Redeemers,
+  cost_models: Costmdls,
+  datums?: PlutusList
+): ScriptDataHash;
+
+/**
+ * @param {TransactionHash} tx_body_hash
+ * @param {ByronAddress} addr
+ * @param {LegacyDaedalusPrivateKey} key
+ * @returns {BootstrapWitness}
+ */
+declare export function make_daedalus_bootstrap_witness(
+  tx_body_hash: TransactionHash,
+  addr: ByronAddress,
+  key: LegacyDaedalusPrivateKey
+): BootstrapWitness;
+
+/**
+ * returns minimal amount of ada for the output for case when the amount is included to the output
+ * @param {TransactionOutput} output
+ * @param {DataCost} data_cost
+ * @returns {BigNum}
+ */
+declare export function min_ada_for_output(
+  output: TransactionOutput,
+  data_cost: DataCost
 ): BigNum;
 
 /**
@@ -165,30 +235,6 @@ declare export function encode_json_str_to_native_script(
 ): NativeScript;
 
 /**
- * @param {TransactionBody} txbody
- * @param {BigNum} pool_deposit
- * @param {BigNum} key_deposit
- * @returns {Value}
- */
-declare export function get_implicit_input(
-  txbody: TransactionBody,
-  pool_deposit: BigNum,
-  key_deposit: BigNum
-): Value;
-
-/**
- * @param {TransactionHash} tx_body_hash
- * @param {ByronAddress} addr
- * @param {LegacyDaedalusPrivateKey} key
- * @returns {BootstrapWitness}
- */
-declare export function make_daedalus_bootstrap_witness(
-  tx_body_hash: TransactionHash,
-  addr: ByronAddress,
-  key: LegacyDaedalusPrivateKey
-): BootstrapWitness;
-
-/**
  * @param {TransactionHash} tx_body_hash
  * @param {PrivateKey} sk
  * @returns {Vkeywitness}
@@ -199,45 +245,16 @@ declare export function make_vkey_witness(
 ): Vkeywitness;
 
 /**
- * @param {PlutusData} plutus_data
- * @returns {DataHash}
- */
-declare export function hash_plutus_data(plutus_data: PlutusData): DataHash;
-
-/**
- * returns minimal amount of ada for the output for case when the amount is included to the output
- * @param {TransactionOutput} output
- * @param {DataCost} data_cost
+ * @param {TransactionBody} txbody
+ * @param {BigNum} pool_deposit
+ * @param {BigNum} key_deposit
  * @returns {BigNum}
  */
-declare export function min_ada_for_output(
-  output: TransactionOutput,
-  data_cost: DataCost
+declare export function get_deposit(
+  txbody: TransactionBody,
+  pool_deposit: BigNum,
+  key_deposit: BigNum
 ): BigNum;
-
-/**
- * @param {TransactionHash} tx_body_hash
- * @param {ByronAddress} addr
- * @param {Bip32PrivateKey} key
- * @returns {BootstrapWitness}
- */
-declare export function make_icarus_bootstrap_witness(
-  tx_body_hash: TransactionHash,
-  addr: ByronAddress,
-  key: Bip32PrivateKey
-): BootstrapWitness;
-
-/**
- * @param {Redeemers} redeemers
- * @param {Costmdls} cost_models
- * @param {PlutusList | void} [datums]
- * @returns {ScriptDataHash}
- */
-declare export function hash_script_data(
-  redeemers: Redeemers,
-  cost_models: Costmdls,
-  datums?: PlutusList
-): ScriptDataHash;
 
 /**
  * @param {AuxiliaryData} auxiliary_data
@@ -246,23 +263,6 @@ declare export function hash_script_data(
 declare export function hash_auxiliary_data(
   auxiliary_data: AuxiliaryData
 ): AuxiliaryDataHash;
-
-/**
- * Returns the state of the transaction sets.
- * If all sets have a tag, it returns AllSetsHaveTag.
- * If all sets have no tag, it returns AllSetsHaveNoTag.
- * If there is a mix of tagged and untagged sets, it returns MixedSets.
- * This function is useful for checking if a transaction might be signed by a hardware wallet.
- * And for checking which parameter should be used in a hardware wallet api.
- * WARNING this function will be deleted after all tags for set types will be mandatory. Approx after next hf
- * @param {Uint8Array} tx_bytes
- * @returns {$Values<
-                typeof 
-                TransactionSetsState>}
- */
-declare export function has_transaction_set_tag(
-  tx_bytes: Uint8Array
-): $Values<typeof TransactionSetsState>;
 
 /**
  * @param {Address} address
@@ -279,33 +279,52 @@ declare export function create_send_all(
 /**
  */
 
-declare export var VoteKind: {|
-  +No: 0, // 0
-  +Yes: 1, // 1
-  +Abstain: 2, // 2
+declare export var MetadataJsonSchema: {|
+  +NoConversions: 0, // 0
+  +BasicConversions: 1, // 1
+  +DetailedSchema: 2, // 2
 |};
 
 /**
  */
 
-declare export var RelayKind: {|
-  +SingleHostAddr: 0, // 0
-  +SingleHostName: 1, // 1
-  +MultiHostName: 2, // 2
+declare export var NetworkIdKind: {|
+  +Testnet: 0, // 0
+  +Mainnet: 1, // 1
 |};
 
 /**
- * Each new language uses a different namespace for hashing its script
- * This is because you could have a language where the same bytes have different semantics
- * So this avoids scripts in different languages mapping to the same hash
- * Note that the enum value here is different than the enum value for deciding the cost model of a script
  */
 
-declare export var ScriptHashNamespace: {|
-  +NativeScript: 0, // 0
-  +PlutusScript: 1, // 1
-  +PlutusScriptV2: 2, // 2
-  +PlutusScriptV3: 3, // 3
+declare export var CborContainerType: {|
+  +Array: 0, // 0
+  +Map: 1, // 1
+|};
+
+/**
+ */
+
+declare export var AddressKind: {|
+  +Base: 0, // 0
+  +Pointer: 1, // 1
+  +Enterprise: 2, // 2
+  +Reward: 3, // 3
+  +Byron: 4, // 4
+  +Malformed: 5, // 5
+|};
+
+/**
+ */
+
+declare export var BlockEra: {|
+  +Byron: 0, // 0
+  +Shelley: 1, // 1
+  +Allegra: 2, // 2
+  +Mary: 3, // 3
+  +Alonzo: 4, // 4
+  +Babbage: 5, // 5
+  +Conway: 6, // 6
+  +Unknown: 7, // 7
 |};
 
 /**
@@ -323,15 +342,79 @@ declare export var RedeemerTagKind: {|
 /**
  */
 
-declare export var BlockEra: {|
-  +Byron: 0, // 0
-  +Shelley: 1, // 1
-  +Allegra: 2, // 2
-  +Mary: 3, // 3
-  +Alonzo: 4, // 4
-  +Babbage: 5, // 5
-  +Conway: 6, // 6
-  +Unknown: 7, // 7
+declare export var MIRPot: {|
+  +Reserves: 0, // 0
+  +Treasury: 1, // 1
+|};
+
+/**
+ * JSON <-> PlutusData conversion schemas.
+ * Follows ScriptDataJsonSchema in cardano-cli defined at:
+ * https://github.com/input-output-hk/cardano-node/blob/master/cardano-api/src/Cardano/Api/ScriptData.hs#L254
+ *
+ * All methods here have the following restrictions due to limitations on dependencies:
+ * * JSON numbers above u64::MAX (positive) or below i64::MIN (negative) will throw errors
+ * * Hex strings for bytes don't accept odd-length (half-byte) strings.
+ *      cardano-cli seems to support these however but it seems to be different than just 0-padding
+ *      on either side when tested so proceed with caution
+ */
+
+declare export var PlutusDatumSchema: {|
+  +BasicConversions: 0, // 0
+  +DetailedSchema: 1, // 1
+|};
+
+/**
+ */
+
+declare export var ByronAddressType: {|
+  +ATPubKey: 0, // 0
+  +ATScript: 1, // 1
+  +ATRedeem: 2, // 2
+|};
+
+/**
+ */
+
+declare export var GovernanceActionKind: {|
+  +ParameterChangeAction: 0, // 0
+  +HardForkInitiationAction: 1, // 1
+  +TreasuryWithdrawalsAction: 2, // 2
+  +NoConfidenceAction: 3, // 3
+  +UpdateCommitteeAction: 4, // 4
+  +NewConstitutionAction: 5, // 5
+  +InfoAction: 6, // 6
+|};
+
+/**
+ */
+
+declare export var NativeScriptKind: {|
+  +ScriptPubkey: 0, // 0
+  +ScriptAll: 1, // 1
+  +ScriptAny: 2, // 2
+  +ScriptNOfK: 3, // 3
+  +TimelockStart: 4, // 4
+  +TimelockExpiry: 5, // 5
+|};
+
+/**
+ */
+
+declare export var CoinSelectionStrategyCIP2: {|
+  +LargestFirst: 0, // 0
+  +RandomImprove: 1, // 1
+  +LargestFirstMultiAsset: 2, // 2
+  +RandomImproveMultiAsset: 3, // 3
+|};
+
+/**
+ */
+
+declare export var RelayKind: {|
+  +SingleHostAddr: 0, // 0
+  +SingleHostName: 1, // 1
+  +MultiHostName: 2, // 2
 |};
 
 /**
@@ -368,54 +451,6 @@ declare export var CredKind: {|
 /**
  */
 
-declare export var GovernanceActionKind: {|
-  +ParameterChangeAction: 0, // 0
-  +HardForkInitiationAction: 1, // 1
-  +TreasuryWithdrawalsAction: 2, // 2
-  +NoConfidenceAction: 3, // 3
-  +UpdateCommitteeAction: 4, // 4
-  +NewConstitutionAction: 5, // 5
-  +InfoAction: 6, // 6
-|};
-
-/**
- */
-
-declare export var NetworkIdKind: {|
-  +Testnet: 0, // 0
-  +Mainnet: 1, // 1
-|};
-
-/**
- * JSON <-> PlutusData conversion schemas.
- * Follows ScriptDataJsonSchema in cardano-cli defined at:
- * https://github.com/input-output-hk/cardano-node/blob/master/cardano-api/src/Cardano/Api/ScriptData.hs#L254
- *
- * All methods here have the following restrictions due to limitations on dependencies:
- * * JSON numbers above u64::MAX (positive) or below i64::MIN (negative) will throw errors
- * * Hex strings for bytes don't accept odd-length (half-byte) strings.
- *      cardano-cli seems to support these however but it seems to be different than just 0-padding
- *      on either side when tested so proceed with caution
- */
-
-declare export var PlutusDatumSchema: {|
-  +BasicConversions: 0, // 0
-  +DetailedSchema: 1, // 1
-|};
-
-/**
- */
-
-declare export var CoinSelectionStrategyCIP2: {|
-  +LargestFirst: 0, // 0
-  +RandomImprove: 1, // 1
-  +LargestFirstMultiAsset: 2, // 2
-  +RandomImproveMultiAsset: 3, // 3
-|};
-
-/**
- */
-
 declare export var TransactionMetadatumKind: {|
   +MetadataMap: 0, // 0
   +MetadataList: 1, // 1
@@ -427,30 +462,10 @@ declare export var TransactionMetadatumKind: {|
 /**
  */
 
-declare export var CborSetType: {|
-  +Tagged: 0, // 0
-  +Untagged: 1, // 1
-|};
-
-/**
- */
-
-declare export var DRepKind: {|
-  +KeyHash: 0, // 0
-  +ScriptHash: 1, // 1
-  +AlwaysAbstain: 2, // 2
-  +AlwaysNoConfidence: 3, // 3
-|};
-
-/**
- */
-
-declare export var PlutusDataKind: {|
-  +ConstrPlutusData: 0, // 0
-  +Map: 1, // 1
-  +List: 2, // 2
-  +Integer: 3, // 3
-  +Bytes: 4, // 4
+declare export var VoteKind: {|
+  +No: 0, // 0
+  +Yes: 1, // 1
+  +Abstain: 2, // 2
 |};
 
 /**
@@ -465,6 +480,15 @@ declare export var LanguageKind: {|
 /**
  */
 
+declare export var TransactionSetsState: {|
+  +AllSetsHaveTag: 0, // 0
+  +AllSetsHaveNoTag: 1, // 1
+  +MixedSets: 2, // 2
+|};
+
+/**
+ */
+
 declare export var MIRKind: {|
   +ToOtherPot: 0, // 0
   +ToStakeCredentials: 1, // 1
@@ -473,52 +497,29 @@ declare export var MIRKind: {|
 /**
  */
 
-declare export var ByronAddressType: {|
-  +ATPubKey: 0, // 0
-  +ATScript: 1, // 1
-  +ATRedeem: 2, // 2
+declare export var CborSetType: {|
+  +Tagged: 0, // 0
+  +Untagged: 1, // 1
 |};
 
 /**
  */
 
-declare export var NativeScriptKind: {|
-  +ScriptPubkey: 0, // 0
-  +ScriptAll: 1, // 1
-  +ScriptAny: 2, // 2
-  +ScriptNOfK: 3, // 3
-  +TimelockStart: 4, // 4
-  +TimelockExpiry: 5, // 5
+declare export var PlutusDataKind: {|
+  +ConstrPlutusData: 0, // 0
+  +Map: 1, // 1
+  +List: 2, // 2
+  +Integer: 3, // 3
+  +Bytes: 4, // 4
 |};
 
 /**
+ * Used to choosed the schema for a script JSON string
  */
 
-declare export var MetadataJsonSchema: {|
-  +NoConversions: 0, // 0
-  +BasicConversions: 1, // 1
-  +DetailedSchema: 2, // 2
-|};
-
-/**
- */
-
-declare export var AddressKind: {|
-  +Base: 0, // 0
-  +Pointer: 1, // 1
-  +Enterprise: 2, // 2
-  +Reward: 3, // 3
-  +Byron: 4, // 4
-  +Malformed: 5, // 5
-|};
-
-/**
- */
-
-declare export var TransactionSetsState: {|
-  +AllSetsHaveTag: 0, // 0
-  +AllSetsHaveNoTag: 1, // 1
-  +MixedSets: 2, // 2
+declare export var ScriptSchema: {|
+  +Wallet: 0, // 0
+  +Node: 1, // 1
 |};
 
 /**
@@ -535,26 +536,25 @@ declare export var VoterKind: {|
 /**
  */
 
-declare export var CborContainerType: {|
-  +Array: 0, // 0
-  +Map: 1, // 1
+declare export var DRepKind: {|
+  +KeyHash: 0, // 0
+  +ScriptHash: 1, // 1
+  +AlwaysAbstain: 2, // 2
+  +AlwaysNoConfidence: 3, // 3
 |};
 
 /**
+ * Each new language uses a different namespace for hashing its script
+ * This is because you could have a language where the same bytes have different semantics
+ * So this avoids scripts in different languages mapping to the same hash
+ * Note that the enum value here is different than the enum value for deciding the cost model of a script
  */
 
-declare export var MIRPot: {|
-  +Reserves: 0, // 0
-  +Treasury: 1, // 1
-|};
-
-/**
- * Used to choosed the schema for a script JSON string
- */
-
-declare export var ScriptSchema: {|
-  +Wallet: 0, // 0
-  +Node: 1, // 1
+declare export var ScriptHashNamespace: {|
+  +NativeScript: 0, // 0
+  +PlutusScript: 1, // 1
+  +PlutusScriptV2: 2, // 2
+  +PlutusScriptV3: 3, // 3
 |};
 
 /**
@@ -14519,12 +14519,13 @@ export type NativeScriptJSON =
       TimelockExpiry: TimelockExpiryJSON,
       ...
     };
+export type LanguageJSON = "PlutusV1" | "PlutusV2" | "PlutusV3";
 export interface AuxiliaryDataJSON {
   metadata?: {
     [k: string]: string,
   } | null;
   native_scripts?: NativeScriptJSON[] | null;
-  plutus_scripts?: string[] | null;
+  plutus_scripts?: PlutusScriptJSON[] | null;
   prefer_alonzo_format: boolean;
 }
 export interface ScriptPubkeyJSON {
@@ -14545,6 +14546,13 @@ export interface TimelockStartJSON {
 }
 export interface TimelockExpiryJSON {
   slot: string;
+}
+/**
+ * JSON form: `{ "bytes": "<hex>", "language": "PlutusV1" }`, the same shape for every language version. The hex is the raw compiled script, without the CBOR bytes tag around it.
+ */
+export interface PlutusScriptJSON {
+  bytes: string;
+  language: LanguageJSON;
 }
 export type AuxiliaryDataHashJSON = string;
 export interface AuxiliaryDataSetJSON {
@@ -14722,7 +14730,7 @@ export type ScriptRefJSON =
       ...
     }
   | {
-      PlutusScript: string,
+      PlutusScript: PlutusScriptJSON,
       ...
     };
 export type MintJSON = [string, MintAssetsJSON][];
@@ -15161,7 +15169,7 @@ export interface TransactionWitnessSetJSON {
   bootstraps?: BootstrapWitnessJSON[] | null;
   native_scripts?: NativeScriptJSON[] | null;
   plutus_data?: PlutusListJSON | null;
-  plutus_scripts?: string[] | null;
+  plutus_scripts?: PlutusScriptJSON[] | null;
   redeemers?: RedeemerJSON[] | null;
   vkeys?: VkeywitnessJSON[] | null;
 }
@@ -15315,15 +15323,16 @@ export type IntJSON = string;
  * @maxItems 4
  */
 export type KESVKeyJSON = string;
-export type LanguageJSON = LanguageKindJSON;
 export type LanguageKindJSON = "PlutusV1" | "PlutusV2" | "PlutusV3";
 export type LanguagesJSON = LanguageJSON[];
 export type MIRToStakeCredentialsJSON = StakeToCoinJSON[];
 export type MintsAssetsJSON = MintAssetsJSON[];
 export type NativeScriptsJSON = NativeScriptJSON[];
 export type NetworkIdKindJSON = "Testnet" | "Mainnet";
-export type PlutusScriptJSON = string;
-export type PlutusScriptsJSON = string[];
+export type PlutusScriptsJSON = PlutusScriptJSON[];
+/**
+ * JSON form: `{ "bytes": "<hex>", "language": "PlutusV1" }`, the same shape for every language version. The hex is the raw compiled script, without the CBOR bytes tag around it.
+ */
 export type PoolMetadataHashJSON = string;
 export interface ProposedProtocolParameterUpdatesJSON {
   [k: string]: ProtocolParamUpdateJSON;
@@ -15365,7 +15374,7 @@ export type ScriptRefEnumJSON =
       ...
     }
   | {
-      PlutusScript: string,
+      PlutusScript: PlutusScriptJSON,
       ...
     };
 export interface TransactionJSON {

--- a/rust/src/protocol_types/plutus/plutus_script.rs
+++ b/rust/src/protocol_types/plutus/plutus_script.rs
@@ -115,31 +115,14 @@ impl PlutusScript {
     }
 }
 
-/// JSON form: a bare hex string means Plutus V1; V2 and V3 carry the language.
-/// The hex is the raw compiled script, not the cardano-cli "cborHex".
-#[derive(JsonSchema)]
-#[serde(untagged)]
-#[allow(dead_code)]
-enum PlutusScriptJson {
-    PlutusV1(String),
-    Versioned {
-        bytes: String,
-        language: Language,
-    },
-}
-
-fn plutus_script_from_hex<E: serde::de::Error>(
-    hex_str: &str,
-    language: LanguageKind,
-) -> Result<PlutusScript, E> {
-    hex::decode(hex_str)
-        .map(|bytes| PlutusScript { bytes, language })
-        .map_err(|_err| {
-            serde::de::Error::invalid_value(
-                serde::de::Unexpected::Str(hex_str),
-                &"PlutusScript as hex string e.g. F8AB28C2 (without CBOR bytes tag)",
-            )
-        })
+/// JSON form: `{ "bytes": "<hex>", "language": "PlutusV1" }`, the same shape for
+/// every language version. The hex is the raw compiled script, without the CBOR
+/// bytes tag around it.
+#[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
+#[serde(rename = "PlutusScript")]
+struct PlutusScriptJson {
+    bytes: String,
+    language: Language,
 }
 
 impl serde::Serialize for PlutusScript {
@@ -147,70 +130,11 @@ impl serde::Serialize for PlutusScript {
         where
             S: serde::Serializer,
     {
-        // Formats reporting is_human_readable() == false take a fixed pair instead.
-        if !serializer.is_human_readable() {
-            return (&self.bytes, Language(self.language)).serialize(serializer);
+        PlutusScriptJson {
+            bytes: hex::encode(&self.bytes),
+            language: Language(self.language),
         }
-        let bytes = hex::encode(&self.bytes);
-        match self.language {
-            LanguageKind::PlutusV1 => serializer.serialize_str(&bytes),
-            language => {
-                use serde::ser::SerializeStruct;
-                let mut state = serializer.serialize_struct("PlutusScript", 2)?;
-                state.serialize_field("bytes", &bytes)?;
-                state.serialize_field("language", &Language(language))?;
-                state.end()
-            }
-        }
-    }
-}
-
-struct PlutusScriptVisitor;
-
-impl<'de> serde::de::Visitor<'de> for PlutusScriptVisitor {
-    type Value = PlutusScript;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str(
-            "a Plutus V1 script as a hex string, or an object with `bytes` and `language`",
-        )
-    }
-
-    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-        where
-            E: serde::de::Error,
-    {
-        plutus_script_from_hex(value, LanguageKind::PlutusV1)
-    }
-
-    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-        where
-            A: serde::de::MapAccess<'de>,
-    {
-        let mut bytes: Option<String> = None;
-        let mut language: Option<Language> = None;
-        while let Some(key) = map.next_key::<String>()? {
-            match key.as_str() {
-                "bytes" => {
-                    if bytes.is_some() {
-                        return Err(serde::de::Error::duplicate_field("bytes"));
-                    }
-                    bytes = Some(map.next_value()?);
-                }
-                "language" => {
-                    if language.is_some() {
-                        return Err(serde::de::Error::duplicate_field("language"));
-                    }
-                    language = Some(map.next_value()?);
-                }
-                _ => {
-                    map.next_value::<serde::de::IgnoredAny>()?;
-                }
-            }
-        }
-        let bytes = bytes.ok_or_else(|| serde::de::Error::missing_field("bytes"))?;
-        let language = language.ok_or_else(|| serde::de::Error::missing_field("language"))?;
-        plutus_script_from_hex(&bytes, language.kind())
+        .serialize(serializer)
     }
 }
 
@@ -219,14 +143,18 @@ impl<'de> serde::de::Deserialize<'de> for PlutusScript {
         where
             D: serde::de::Deserializer<'de>,
     {
-        if !deserializer.is_human_readable() {
-            let (bytes, language) = <(Vec<u8>, Language)>::deserialize(deserializer)?;
-            return Ok(PlutusScript {
-                bytes,
+        let PlutusScriptJson { bytes, language } = PlutusScriptJson::deserialize(deserializer)?;
+        hex::decode(&bytes)
+            .map(|decoded| PlutusScript {
+                bytes: decoded,
                 language: language.kind(),
-            });
-        }
-        deserializer.deserialize_any(PlutusScriptVisitor)
+            })
+            .map_err(|_err| {
+                serde::de::Error::invalid_value(
+                    serde::de::Unexpected::Str(&bytes),
+                    &"PlutusScript as hex string e.g. F8AB28C2 (without CBOR bytes tag)",
+                )
+            })
     }
 }
 

--- a/rust/src/tests/serialization/general.rs
+++ b/rust/src/tests/serialization/general.rs
@@ -400,28 +400,30 @@ fn plutus_script_json_round_trip_preserves_language() {
 }
 
 #[test]
-fn plutus_script_json_v1_stays_a_bare_hex_string() {
+fn plutus_script_json_v1_carries_its_language() {
     let script = PlutusScript::new(compiled_plutus_script_bytes());
 
     assert_eq!(
         serde_json::to_string(&script).unwrap(),
-        format!("\"{}\"", COMPILED_PLUTUS_SCRIPT)
+        format!("{{\"bytes\":\"{COMPILED_PLUTUS_SCRIPT}\",\"language\":\"PlutusV1\"}}")
     );
 
-    let from_legacy: PlutusScript =
-        serde_json::from_str(&format!("\"{}\"", COMPILED_PLUTUS_SCRIPT)).unwrap();
-    assert_eq!(from_legacy.language_version(), Language::new_plutus_v1());
-    assert_eq!(from_legacy.bytes(), script.bytes());
+    let deser: PlutusScript = serde_json::from_str(
+        &format!("{{\"bytes\":\"{COMPILED_PLUTUS_SCRIPT}\",\"language\":\"PlutusV1\"}}"),
+    )
+    .unwrap();
+    assert_eq!(deser.language_version(), Language::new_plutus_v1());
+    assert_eq!(deser.bytes(), script.bytes());
 }
 
 #[test]
-fn plutus_script_json_accepts_an_explicit_v1_language() {
-    let json = format!("{{\"bytes\":\"{COMPILED_PLUTUS_SCRIPT}\",\"language\":\"PlutusV1\"}}");
+fn plutus_script_json_rejects_a_bare_hex_string() {
+    // 15.x wrote every script as a bare hex string, dropping the language. Reading
+    // one back as V1 would silently downgrade a V2/V3 script and change its hash.
+    let err = serde_json::from_str::<PlutusScript>(&format!("\"{COMPILED_PLUTUS_SCRIPT}\""))
+        .unwrap_err();
 
-    let script: PlutusScript = serde_json::from_str(&json).unwrap();
-
-    assert_eq!(script.language_version(), Language::new_plutus_v1());
-    assert_eq!(script.bytes(), compiled_plutus_script_bytes());
+    assert!(err.to_string().contains("invalid type"), "{}", err);
 }
 
 #[test]
@@ -436,12 +438,13 @@ fn plutus_script_json_object_ignores_field_order_and_unknown_fields() {
 }
 
 #[test]
-fn plutus_script_json_schema_describes_both_shapes() {
+fn plutus_script_json_schema_describes_one_shape() {
     let schema = serde_json::to_value(schemars::schema_for!(PlutusScript)).unwrap();
 
-    let shapes = schema["anyOf"].as_array().unwrap();
-    assert_eq!(shapes[0]["type"], "string");
-    assert_eq!(shapes[1]["required"], serde_json::json!(["bytes", "language"]));
+    assert!(schema.get("anyOf").is_none(), "{}", schema);
+    assert_eq!(schema["type"], "object");
+    assert_eq!(schema["required"], serde_json::json!(["bytes", "language"]));
+    assert_eq!(schema["properties"]["bytes"]["type"], "string");
 }
 
 #[test]
@@ -449,9 +452,9 @@ fn plutus_script_json_rejects_malformed_input() {
     for (json, expected) in [
         ("null", "invalid type"),
         ("12345", "invalid type"),
-        ("\"zz\"", "invalid value"),
+        ("\"zz\"", "invalid type"),
         ("{}", "missing field `bytes`"),
-        ("[]", "invalid type"),
+        ("[]", "invalid length"),
         ("{\"bytes\":\"4e4d01\"}", "missing field `language`"),
         (
             "{\"bytes\":\"zz\",\"language\":\"PlutusV2\"}",


### PR DESCRIPTION
Follow-up to #760, for the 17.0.0 major bump.

#760 stopped `PlutusScript` JSON from dropping the language, but kept a bare hex string as an accepted input meaning V1, so older JSON would still parse. This removes that fallback.

Note #760 was merged after 16.0.0 was cut (2026-08-07 vs a release published 2026-08-01), so it is unreleased — 17.0.0 is the first release to carry either change.

## Why remove the fallback

A bare hex string in stored JSON is not "a V1 script" — every CSL through 16.0.0 wrote *every* script that way, language discarded. Reading one back as V1 sets the wrong `script_namespace()` byte, so the `ScriptHash` and the script address come out wrong. That is exactly the failure #760 was about, and it stays silent. A parse error is the better outcome, and a major bump is where it belongs.

## What changes

JSON is one object shape for every language version:

```json
{ "bytes": "4d01000033222220051200120011", "language": "PlutusV1" }
```

Dropping the `untagged` variant removes the need for `deserialize_any`, so the hand-written `Visitor` and the `is_human_readable()` special case on both the serialize and deserialize sides collapse into a derive over one private struct — 118 lines out, 44 in.

The derive preserves what the visitor did by hand: unknown fields ignored, field order irrelevant, duplicate `bytes`/`language` rejected. Binary serde (bincode) still round-trips the language; `plutus_script_binary_serde_round_trip_preserves_language` passes unchanged.

`schemars::schema_for!(PlutusScript)` now emits a plain object with `required: ["bytes", "language"]` instead of an `anyOf` of `string` and `object`.

## Compatibility

Since no released version ever emitted the object form, 17.0.0 cannot parse JSON from 16.0.0 or earlier that contains a Plutus script — through `PlutusScripts`, `TransactionWitnessSet`, `AuxiliaryData`, `ScriptRef`, `TransactionOutput`, `TransactionUnspentOutput`, `TransactionBody`, `Transaction`, `Block`, `VersionedBlock` and their plural forms. CBOR is untouched, so re-encoding via CBOR is the migration path. Called out prominently in the release notes.

## Tests

- `plutus_script_json_v1_stays_a_bare_hex_string` → `plutus_script_json_v1_carries_its_language`
- new `plutus_script_json_rejects_a_bare_hex_string`, pinning the loud failure
- `plutus_script_json_accepts_an_explicit_v1_language` folded into the round-trip test
- `..._schema_describes_both_shapes` → `..._describes_one_shape`
- in `..._rejects_malformed_input`: a string is now `invalid type` (was `invalid value`), an array `invalid length` (was `invalid type`)

`cargo test --lib`: 754 passed, 0 failed.

## Release

`ea489e8` bumps `Cargo.toml`, `package.json`, the lockfiles and the regenerated `.js.flow` to 17.0.0. Tag `17.0.0` points at that commit — merge with a merge commit (as #756 was) so the tag stays reachable from master.
